### PR TITLE
fix sidecar build for x86_64 release target

### DIFF
--- a/scripts/build_mongosh_sidecar.sh
+++ b/scripts/build_mongosh_sidecar.sh
@@ -9,20 +9,46 @@ if ! command -v bun >/dev/null 2>&1; then
   exit 1
 fi
 
-# Determine architecture-specific output directory
-ARCH="$(uname -m)"
-OS="$(uname -s)"
-if [[ "$OS" == "Darwin" ]]; then
-  if [[ "$ARCH" == "arm64" ]]; then
-    ARCH_DIR="macos-arm64"
-  else
-    ARCH_DIR="macos-x86_64"
-  fi
-elif [[ "$OS" == "Linux" ]]; then
-  ARCH_DIR="linux-x86_64"
+# Accept optional Rust target triple (e.g., aarch64-apple-darwin, x86_64-apple-darwin)
+TARGET="${1:-}"
+BUN_TARGET=""
+
+if [[ -n "$TARGET" ]]; then
+  # Cross-compilation: derive arch dir and Bun target from Rust target triple
+  case "$TARGET" in
+    aarch64-apple-darwin)
+      ARCH_DIR="macos-arm64"
+      BUN_TARGET="bun-darwin-arm64"
+      ;;
+    x86_64-apple-darwin)
+      ARCH_DIR="macos-x86_64"
+      BUN_TARGET="bun-darwin-x64"
+      ;;
+    x86_64-unknown-linux-gnu)
+      ARCH_DIR="linux-x86_64"
+      BUN_TARGET="bun-linux-x64"
+      ;;
+    *)
+      echo "Unsupported target: $TARGET" >&2
+      exit 1
+      ;;
+  esac
 else
-  echo "Unsupported OS: $OS" >&2
-  exit 1
+  # Auto-detect from host
+  ARCH="$(uname -m)"
+  OS="$(uname -s)"
+  if [[ "$OS" == "Darwin" ]]; then
+    if [[ "$ARCH" == "arm64" ]]; then
+      ARCH_DIR="macos-arm64"
+    else
+      ARCH_DIR="macos-x86_64"
+    fi
+  elif [[ "$OS" == "Linux" ]]; then
+    ARCH_DIR="linux-x86_64"
+  else
+    echo "Unsupported OS: $OS" >&2
+    exit 1
+  fi
 fi
 
 OUT_DIR="$ROOT_DIR/resources/bin/$ARCH_DIR"
@@ -34,7 +60,13 @@ if [ ! -d node_modules ]; then
   bun install
 fi
 
+BUN_TARGET_FLAG=()
+if [[ -n "$BUN_TARGET" ]]; then
+  BUN_TARGET_FLAG=(--target "$BUN_TARGET")
+fi
+
 bun build ./src/bun-entry.ts --compile \
+  "${BUN_TARGET_FLAG[@]}" \
   --outfile "$OUT_DIR/mongosh-sidecar" \
   --external electron \
   --external os-dns-native \


### PR DESCRIPTION
build_mongosh_sidecar.sh was always building for the host architecture
(arm64 on macos-latest runners), so the x86_64 release job couldn't
find mongosh-sidecar in resources/bin/macos-x86_64/.

Accept an optional Rust target triple argument to derive both the
output directory and Bun's --target flag for cross-compilation.

NOTE: .github/workflows/release.yml also needs updating to pass
matrix.target to the sidecar build step (requires workflows permission):
  run: ./scripts/build_mongosh_sidecar.sh ${{ matrix.target }}

https://claude.ai/code/session_01E5KBeFTtWCFg2pE3M2dgpA