### PR TITLE
Complete saved queries and connection environment identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Saved-query descriptions, tags, global scope, and bounded versioned JSON import/export with atomic persistence and credential screening
+- Explicit Development, Staging, and Production connection identity across the workspace, with optional fail-closed confirmation for Production writes and Forge execution
 - Complete keyboard and command-palette coverage for Schema, Transfer and its query editor, Forge, document/index/aggregation workflows, tabs, and focus navigation, with a visible palette button
 - Customizable keyboard shortcuts with search, context-aware conflict validation, recording, disable/reset controls, persisted overrides, and restart-safe application
 - Query Library for Documents, Aggregation, and Forge with successful-run history, saved queries, full-text search, restore/run/copy/update/delete actions, keyboard access, atomic local persistence, and credential-aware exclusion

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+MongoDB power users, application developers, and small engineering teams doing day-to-day database work on macOS. They need to inspect, query, edit, analyze, and move data quickly while retaining clear context about the active connection and the consequences of each operation.
+
+## Product Purpose
+
+OpenMango is a fast, native, keyboard-friendly MongoDB workbench. It brings document browsing, aggregation, schema analysis, explain plans, Forge, and guarded data transfer into one coherent desktop workflow without Electron or web views. Success means experienced users can work quickly while the product makes connection identity, persistence, privacy, and destructive effects explicit.
+
+## Brand Personality
+
+Fast, calm, trustworthy. Interaction patterns should feel familiar to users of DataGrip and VS Code: dense when useful, predictable under the keyboard, and restrained rather than decorative.
+
+## Anti-references
+
+Avoid decorative SaaS-dashboard styling, modal-heavy workflows, surprising custom controls, ornamental motion, excessive cards, and visual noise that competes with data. Do not trade safety or clarity for novelty, and do not hide important scope or destructive effects behind color alone.
+
+## Design Principles
+
+1. Prefer earned familiarity over invention: standard desktop-tool patterns should disappear into the task.
+2. Put context at the point of action: connection, environment, namespace, and write impact must be visible where decisions are made.
+3. Make safety explicit and recoverable: validate before writes, confirm destructive work, preserve user input, and report failures clearly.
+4. Maintain keyboard and pointer parity: every core workflow must be discoverable, focusable, and operable without a mouse.
+5. Keep private work local: never persist credentials or resolved secrets, and make portable data formats inspectable and versioned.
+
+## Accessibility & Inclusion
+
+Target WCAG AA contrast and complete keyboard operation. Provide visible labels, tooltips, focus indicators, predictable focus order, and focus restoration after overlays. Never encode meaning through color alone. Respect reduced-motion preferences and avoid decorative motion. Where GPUI cannot yet expose complete native accessibility semantics, preserve clear visible text and keyboard behavior and adopt semantic APIs as the framework makes them available.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # OpenMango Features & Roadmap
 
-Snapshot date: 2026-02-21
+Snapshot date: 2026-07-22
 Audience: power users and small engineering teams
 
 ## Priority Legend
@@ -29,8 +29,8 @@ Audience: power users and small engineering teams
 
 - [x] P0: Explain plan UI (winning plan, scanned docs, stage costs)
 - [ ] P0: Index hinting and "why query is slow" diagnostics
-- [ ] P1: Query history (per tab/session) with restore
-- [ ] P1: Saved query snippets/templates
+- [x] P1: Query history across Documents, Aggregation, and Forge with restore
+- [x] P1: Saved query snippets with metadata, tags, global scope, and portable import/export
 
 ### Schema & Data Quality
 
@@ -50,6 +50,7 @@ Audience: power users and small engineering teams
 - [x] P0: Connection import/export (redacted + encrypted options)
 - [x] P1: SSH tunneling and proxy-aware connection flow
 - [x] P1: Secrets integration (versioned Keychain-backed credential bundles)
+- [x] P1: Explicit connection environments with optional Production write confirmation
 - [ ] P2: Field-level masking workflows for export/share
 
 ### Transfer format notes
@@ -69,4 +70,4 @@ Audience: power users and small engineering teams
 
 - [ ] P1: Split view (side-by-side tabs/collections)
 - [ ] P1: Tab pinning/grouping and better large-workspace ergonomics
-- [ ] P2: Keymap customization and command palette expansion
+- [x] P2: Keymap customization and command palette expansion

--- a/src/ai/blocks.rs
+++ b/src/ai/blocks.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 use uuid::Uuid;
 
 use crate::ai::safety::{ConfirmationSender, OperationPreview, SafetyTier};
+use crate::models::ConnectionWriteIdentity;
 
 // ---------------------------------------------------------------------------
 // Content blocks — structured rendering primitives
@@ -377,6 +378,7 @@ pub enum ToolActivityStatus {
         description: String,
         tier: SafetyTier,
         preview: OperationPreview,
+        write_identity: ConnectionWriteIdentity,
         response_tx: ConfirmationSender,
     },
     Completed,
@@ -637,6 +639,7 @@ impl AiChatState {
         description: String,
         tier: SafetyTier,
         preview: OperationPreview,
+        write_identity: ConnectionWriteIdentity,
         response_tx: ConfirmationSender,
     ) {
         for entry in self.entries.iter_mut().rev() {
@@ -648,6 +651,7 @@ impl AiChatState {
                     description,
                     tier,
                     preview,
+                    write_identity,
                     response_tx,
                 };
                 return;

--- a/src/ai/tools/mod.rs
+++ b/src/ai/tools/mod.rs
@@ -17,6 +17,7 @@ use mongodb::bson;
 use rig::tool::ToolDyn;
 
 use crate::ai::safety::{ConfirmationSender, OperationPreview, SafetyTier, classify_tool_call};
+use crate::models::ConnectionWriteIdentity;
 
 /// Shared context passed to all tools at construction time.
 #[derive(Clone)]
@@ -24,6 +25,7 @@ pub struct MongoContext {
     pub client: mongodb::Client,
     pub database: String,
     pub collection: Option<String>,
+    pub write_identity: ConnectionWriteIdentity,
     pub read_only: bool,
     pub event_tx: Option<tokio::sync::mpsc::UnboundedSender<StreamEvent>>,
 }
@@ -60,6 +62,7 @@ pub enum StreamEvent {
         description: String,
         tier: SafetyTier,
         preview: OperationPreview,
+        write_identity: ConnectionWriteIdentity,
         response_tx: ConfirmationSender,
     },
 }
@@ -128,6 +131,7 @@ pub async fn require_confirmation(
                     description: classification.description,
                     tier: classification.tier,
                     preview,
+                    write_identity: ctx.write_identity.clone(),
                     response_tx: ConfirmationSender::new(resp_tx),
                 });
                 match resp_rx.await {

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -3,9 +3,22 @@ use gpui_component::WindowExt as _;
 use gpui_component::dialog::Dialog;
 use gpui_component::input::InputState;
 
-use crate::components::{FormField, cancel_button, primary_button};
+use crate::components::{
+    ConnectionIdentity, FormField, cancel_button, connection_identity_badge, primary_button,
+    request_connection_write,
+};
 use crate::state::{AppCommands, AppState};
 use crate::theme::spacing;
+
+fn selected_connection_identity(state: &Entity<AppState>, cx: &App) -> AnyElement {
+    state
+        .read(cx)
+        .selected_connection_id()
+        .and_then(|id| state.read(cx).connection_by_id(id))
+        .map(ConnectionIdentity::from)
+        .map(|identity| connection_identity_badge(&identity, true, cx))
+        .unwrap_or_else(|| div().into_any_element())
+}
 
 pub(crate) fn open_create_database_dialog(
     state: Entity<AppState>,
@@ -30,6 +43,7 @@ pub(crate) fn open_create_database_dialog(
                     .flex_col()
                     .gap(spacing::md())
                     .p(spacing::md())
+                    .child(selected_connection_identity(&state, cx))
                     .child(FormField::new("Database name", &db_state).render(cx))
                     .child(FormField::new("Initial collection", &col_state).render(cx)),
             )
@@ -49,13 +63,28 @@ pub(crate) fn open_create_database_dialog(
                             if db.trim().is_empty() || col.trim().is_empty() {
                                 return;
                             }
-                            AppCommands::create_database(
+                            let Some(connection_id) = state.read(cx).selected_connection_id()
+                            else {
+                                return;
+                            };
+                            let db = db.trim().to_string();
+                            let col = col.trim().to_string();
+                            let state_for_write = state.clone();
+                            request_connection_write(
                                 state.clone(),
-                                db.trim().to_string(),
-                                col.trim().to_string(),
+                                crate::components::WriteRequest::new(
+                                    connection_id,
+                                    format!("{db}.{col}"),
+                                    "Create a database and its initial collection",
+                                    None,
+                                ),
+                                window,
                                 cx,
+                                move |window, cx| {
+                                    window.close_dialog(cx);
+                                    AppCommands::create_database(state_for_write, db, col, cx);
+                                },
                             );
-                            window.close_dialog(cx);
                         }),
                     ]
                 }
@@ -82,6 +111,7 @@ pub(crate) fn open_create_collection_dialog(
                     .flex_col()
                     .gap(spacing::md())
                     .p(spacing::md())
+                    .child(selected_connection_identity(&state, cx))
                     .child(FormField::new("Collection name", &col_state).render(cx)),
             )
             .footer({
@@ -99,13 +129,34 @@ pub(crate) fn open_create_collection_dialog(
                             if col.trim().is_empty() {
                                 return;
                             }
-                            AppCommands::create_collection(
+                            let Some(connection_id) = state.read(cx).selected_connection_id()
+                            else {
+                                return;
+                            };
+                            let collection = col.trim().to_string();
+                            let state_for_write = state.clone();
+                            let database_for_write = database.clone();
+                            let target = format!("{database}.{collection}");
+                            request_connection_write(
                                 state.clone(),
-                                database.clone(),
-                                col.trim().to_string(),
+                                crate::components::WriteRequest::new(
+                                    connection_id,
+                                    target,
+                                    "Create a collection",
+                                    None,
+                                ),
+                                window,
                                 cx,
+                                move |window, cx| {
+                                    window.close_dialog(cx);
+                                    AppCommands::create_collection(
+                                        state_for_write,
+                                        database_for_write,
+                                        collection,
+                                        cx,
+                                    );
+                                },
                             );
-                            window.close_dialog(cx);
                         }),
                     ]
                 }
@@ -134,6 +185,7 @@ pub(crate) fn open_rename_collection_dialog(
                     .flex_col()
                     .gap(spacing::md())
                     .p(spacing::md())
+                    .child(selected_connection_identity(&state, cx))
                     .child(FormField::new("New collection name", &name_state).render(cx)),
             )
             .footer({
@@ -154,14 +206,36 @@ pub(crate) fn open_rename_collection_dialog(
                             if new_name.is_empty() || new_name == collection.as_str() {
                                 return;
                             }
-                            AppCommands::rename_collection(
+                            let Some(connection_id) = state.read(cx).selected_connection_id()
+                            else {
+                                return;
+                            };
+                            let new_name = new_name.to_string();
+                            let state_for_write = state.clone();
+                            let database_for_write = database.clone();
+                            let collection_for_write = collection.clone();
+                            let target = format!("{database}.{collection} → {database}.{new_name}");
+                            request_connection_write(
                                 state.clone(),
-                                database.clone(),
-                                collection.clone(),
-                                new_name.to_string(),
+                                crate::components::WriteRequest::new(
+                                    connection_id,
+                                    target,
+                                    "Rename a collection",
+                                    None,
+                                ),
+                                window,
                                 cx,
+                                move |window, cx| {
+                                    window.close_dialog(cx);
+                                    AppCommands::rename_collection(
+                                        state_for_write,
+                                        database_for_write,
+                                        collection_for_write,
+                                        new_name,
+                                        cx,
+                                    );
+                                },
                             );
-                            window.close_dialog(cx);
                         }),
                     ]
                 }

--- a/src/app/menus.rs
+++ b/src/app/menus.rs
@@ -6,8 +6,8 @@ use gpui_component::{Icon, IconName};
 use uuid::Uuid;
 
 use crate::components::{
-    ConnectionManager, open_confirm_dialog, request_disconnect_connection,
-    request_remove_connection,
+    ConnectionManager, WriteConfirmation, open_confirm_dialog, request_connection_write,
+    request_disconnect_connection, request_remove_connection,
 };
 use crate::keyboard::{
     CopyConnectionUri, CopySelectionName, CopyTreeItem, CreateCollection, DeleteSelection,
@@ -328,18 +328,32 @@ pub(crate) fn build_database_menu(
                     move |_, window, cx| {
                         let message =
                             format!("Drop database \"{database}\"? This cannot be undone.");
-                        open_confirm_dialog(window, cx, "Drop database", message, "Drop", true, {
-                            let state = state.clone();
-                            let database = database.clone();
+                        let state_for_write = state.clone();
+                        let database_for_write = database.clone();
+                        request_connection_write(
+                            state.clone(),
+                            crate::components::WriteRequest::new(
+                                connection_id,
+                                database.clone(),
+                                "Drop a database",
+                                Some(WriteConfirmation {
+                                    title: "Drop database".into(),
+                                    message,
+                                    confirm_label: "Drop".into(),
+                                    destructive: true,
+                                }),
+                            ),
+                            window,
+                            cx,
                             move |_window, cx| {
                                 AppCommands::drop_database(
-                                    state.clone(),
+                                    state_for_write,
                                     connection_id,
-                                    database.clone(),
+                                    database_for_write,
                                     cx,
                                 );
-                            }
-                        });
+                            },
+                        );
                     }
                 }),
         )
@@ -519,26 +533,32 @@ pub(crate) fn build_collection_menu(
                         let message = format!(
                             "Drop collection \"{database}.{collection}\"? This cannot be undone."
                         );
-                        open_confirm_dialog(
+                        let state_for_write = state.clone();
+                        let database_for_write = database.clone();
+                        let collection_for_write = collection.clone();
+                        request_connection_write(
+                            state.clone(),
+                            crate::components::WriteRequest::new(
+                                connection_id,
+                                format!("{database}.{collection}"),
+                                "Drop a collection",
+                                Some(WriteConfirmation {
+                                    title: "Drop collection".into(),
+                                    message,
+                                    confirm_label: "Drop".into(),
+                                    destructive: true,
+                                }),
+                            ),
                             window,
                             cx,
-                            "Drop collection",
-                            message,
-                            "Drop",
-                            true,
-                            {
-                                let state = state.clone();
-                                let database = database.clone();
-                                let collection = collection.clone();
-                                move |_window, cx| {
-                                    AppCommands::drop_collection(
-                                        state.clone(),
-                                        connection_id,
-                                        database.clone(),
-                                        collection.clone(),
-                                        cx,
-                                    );
-                                }
+                            move |_window, cx| {
+                                AppCommands::drop_collection(
+                                    state_for_write,
+                                    connection_id,
+                                    database_for_write,
+                                    collection_for_write,
+                                    cx,
+                                );
                             },
                         );
                     }

--- a/src/app/root.rs
+++ b/src/app/root.rs
@@ -7,8 +7,9 @@ use uuid::Uuid;
 use super::sidebar::Sidebar;
 use crate::components::action_bar::ActionBar;
 use crate::components::{
-    ConnectionManager, ContentArea, QueryLibraryDialog, StatusBar, open_confirm_dialog,
-    request_app_quit, request_disconnect_connection, request_remove_connection,
+    ConnectionManager, ContentArea, QueryLibraryDialog, StatusBar, WriteConfirmation,
+    open_confirm_dialog, request_app_quit, request_connection_write, request_disconnect_connection,
+    request_remove_connection,
 };
 use crate::helpers::keystore::KeyStore;
 use crate::helpers::validate::UriSecrets;
@@ -601,19 +602,29 @@ impl Render for AppRoot {
                 };
                 let message =
                     format!("Drop database \"{}\"? This cannot be undone.", database_key.database);
-                open_confirm_dialog(window, cx, "Drop database", message, "Drop", true, {
-                    let state = this.state.clone();
-                    let database = database_key.database.clone();
-                    let connection_id = database_key.connection_id;
+                let state = this.state.clone();
+                let state_for_write = state.clone();
+                let database = database_key.database;
+                let connection_id = database_key.connection_id;
+                request_connection_write(
+                    state,
+                    crate::components::WriteRequest::new(
+                        connection_id,
+                        database.clone(),
+                        "Drop a database",
+                        Some(WriteConfirmation {
+                            title: "Drop database".into(),
+                            message,
+                            confirm_label: "Drop".into(),
+                            destructive: true,
+                        }),
+                    ),
+                    window,
+                    cx,
                     move |_window, cx| {
-                        AppCommands::drop_database(
-                            state.clone(),
-                            connection_id,
-                            database.clone(),
-                            cx,
-                        );
-                    }
-                });
+                        AppCommands::drop_database(state_for_write, connection_id, database, cx);
+                    },
+                );
             }))
             .on_action(cx.listener(|this, _: &DeleteConnection, window, cx| {
                 if let Some(connection_id) = this.state.read(cx).selected_connection_id() {

--- a/src/app/sidebar/mod.rs
+++ b/src/app/sidebar/mod.rs
@@ -8,8 +8,9 @@ use gpui_component::input::InputState;
 use uuid::Uuid;
 
 use crate::components::{
-    ConnectionManager, open_confirm_dialog, request_disconnect_connection,
-    request_preview_collection, request_remove_connection, request_unsaved_action,
+    ConnectionManager, WriteConfirmation, open_confirm_dialog, request_connection_write,
+    request_disconnect_connection, request_preview_collection, request_remove_connection,
+    request_unsaved_action,
 };
 use crate::keyboard::FocusContent;
 use crate::models::{ActiveConnection, SavedConnection, TreeNodeId};
@@ -837,31 +838,58 @@ impl Sidebar {
             }
             TreeNodeId::Database { connection, database } => {
                 let message = format!("Drop database \"{database}\"? This cannot be undone.");
-                open_confirm_dialog(window, cx, "Drop database", message, "Drop", true, {
-                    let state = self.state.clone();
-                    let database = database.clone();
+                let state = self.state.clone();
+                let state_for_write = state.clone();
+                request_connection_write(
+                    state,
+                    crate::components::WriteRequest::new(
+                        connection,
+                        database.clone(),
+                        "Drop a database",
+                        Some(WriteConfirmation {
+                            title: "Drop database".into(),
+                            message,
+                            confirm_label: "Drop".into(),
+                            destructive: true,
+                        }),
+                    ),
+                    window,
+                    cx,
                     move |_window, cx| {
-                        AppCommands::drop_database(state.clone(), connection, database.clone(), cx);
-                    }
-                });
+                        AppCommands::drop_database(state_for_write, connection, database, cx);
+                    },
+                );
             }
             TreeNodeId::Collection { connection, database, collection } => {
                 let message =
                     format!("Drop collection \"{database}.{collection}\"? This cannot be undone.");
-                open_confirm_dialog(window, cx, "Drop collection", message, "Drop", true, {
-                    let state = self.state.clone();
-                    let database = database.clone();
-                    let collection = collection.clone();
+                let state = self.state.clone();
+                let state_for_write = state.clone();
+                request_connection_write(
+                    state,
+                    crate::components::WriteRequest::new(
+                        connection,
+                        format!("{database}.{collection}"),
+                        "Drop a collection",
+                        Some(WriteConfirmation {
+                            title: "Drop collection".into(),
+                            message,
+                            confirm_label: "Drop".into(),
+                            destructive: true,
+                        }),
+                    ),
+                    window,
+                    cx,
                     move |_window, cx| {
                         AppCommands::drop_collection(
-                            state.clone(),
+                            state_for_write,
                             connection,
-                            database.clone(),
-                            collection.clone(),
+                            database,
+                            collection,
                             cx,
                         );
-                    }
-                });
+                    },
+                );
             }
         }
     }

--- a/src/app/sidebar/view.rs
+++ b/src/app/sidebar/view.rs
@@ -12,7 +12,7 @@ use gpui_component::spinner::Spinner;
 use gpui_component::tooltip::Tooltip;
 use gpui_component::{Icon, IconName, Sizable as _};
 
-use crate::components::ConnectionManager;
+use crate::components::{ConnectionIdentity, ConnectionManager, connection_identity_badge};
 use crate::keyboard::{
     CloseSidebarSearch, CopyConnectionUri, CopySelectionName, CopyTreeItem, DeleteSelection,
     DisconnectConnection, EditConnection, FindInSidebar, OpenActionBar, OpenSelection,
@@ -56,6 +56,13 @@ impl Render for Sidebar {
                 .collect::<HashMap<_, _>>(),
         );
 
+        let connection_identities = Rc::new(
+            self.cached_connections
+                .iter()
+                .map(|connection| (connection.id, ConnectionIdentity::from(connection)))
+                .collect::<HashMap<_, _>>(),
+        );
+
         let disconnected_connections: Vec<_> = self
             .cached_connections
             .iter()
@@ -79,7 +86,16 @@ impl Render for Sidebar {
             let is_connecting = connecting_id == Some(connection_id);
             let accent =
                 connection_accents.get(&connection_id).copied().unwrap_or(cx.theme().foreground);
-            Some((idx, entry.label.clone(), connection_id, is_connected, is_connecting, accent))
+            let identity = connection_identities.get(&connection_id).cloned();
+            Some((
+                idx,
+                entry.label.clone(),
+                connection_id,
+                is_connected,
+                is_connecting,
+                accent,
+                identity,
+            ))
         });
 
         let search_query = self.search_state.read(cx).value().to_string();
@@ -492,11 +508,12 @@ impl Render for Sidebar {
                             let state_clone = state_for_tree.clone();
                             let sidebar_entity = sidebar_entity.clone();
                             let connection_accents = connection_accents.clone();
+                            let connection_identities = connection_identities.clone();
                             cx.processor(
                                 move |sidebar,
                                       visible_range: std::ops::Range<usize>,
                                       _window,
-                                      _cx| {
+                                      cx| {
                                     let visible_start = visible_range.start;
                                     let mut items = Vec::with_capacity(visible_range.len());
                                     let connecting_id = connecting_id;
@@ -520,6 +537,8 @@ impl Render for Sidebar {
                                         let connection_accent = connection_accents
                                             .get(&connection_id)
                                             .copied();
+                                        let connection_identity =
+                                            connection_identities.get(&connection_id);
                                         let row_accent = if is_connection {
                                             connection_accent.unwrap_or(theme_primary)
                                         } else {
@@ -723,6 +742,14 @@ impl Render for Sidebar {
                                                     .truncate()
                                                     .child(label.clone()),
                                             )
+                                            .when_some(
+                                                is_connection.then_some(connection_identity).flatten(),
+                                                |this, identity| {
+                                                    this.child(connection_identity_badge(
+                                                        identity, false, cx,
+                                                    ))
+                                                },
+                                            )
                                             .when(is_connecting || is_loading_db, |this| {
                                                 this.child(Spinner::new().xsmall())
                                             });
@@ -813,7 +840,7 @@ impl Render for Sidebar {
                     }),
                     )
                     // Sticky connection header overlay
-                    .when_some(sticky_info, |this, (idx, label, _connection_id, _is_connected, _is_connecting, accent)| {
+                    .when_some(sticky_info, |this, (idx, label, _connection_id, _is_connected, _is_connecting, accent, identity)| {
                         let scroll_handle = self.scroll_handle.clone();
                         let sidebar_entity = sidebar_entity.clone();
                         let sticky_bg = opaque_color(cx.theme().sidebar);
@@ -863,7 +890,10 @@ impl Render for Sidebar {
                                         .text_color(cx.theme().foreground)
                                         .truncate()
                                         .child(label),
-                                ),
+                                )
+                                .when_some(identity, |header, identity| {
+                                    header.child(connection_identity_badge(&identity, false, cx))
+                                }),
                         )
                     })
                     // Typeahead query indicator

--- a/src/components/confirm.rs
+++ b/src/components/confirm.rs
@@ -1,13 +1,190 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::ActiveTheme as _;
 use gpui_component::WindowExt as _;
 use gpui_component::dialog::Dialog;
+use uuid::Uuid;
 
-use crate::components::Button;
+use crate::components::{Button, ConnectionIdentity, connection_identity_badge};
+use crate::models::ConnectionWriteIdentity;
+use crate::state::{AppState, StatusMessage};
 use crate::theme::spacing;
+
+#[derive(Debug, Clone)]
+pub struct WriteConfirmation {
+    pub title: String,
+    pub message: String,
+    pub confirm_label: String,
+    pub destructive: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct WriteRequest {
+    pub connection_id: Uuid,
+    pub target: String,
+    pub operation: String,
+    pub confirmation: Option<WriteConfirmation>,
+    authorization_uses: usize,
+}
+
+impl WriteRequest {
+    pub fn new(
+        connection_id: Uuid,
+        target: impl Into<String>,
+        operation: impl Into<String>,
+        confirmation: Option<WriteConfirmation>,
+    ) -> Self {
+        Self {
+            connection_id,
+            target: target.into(),
+            operation: operation.into(),
+            confirmation,
+            authorization_uses: 1,
+        }
+    }
+
+    pub fn for_writes(mut self, uses: usize) -> Self {
+        self.authorization_uses = uses.max(1);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteRequestDecision {
+    BlockReadOnly,
+    Confirm,
+    Proceed,
+}
+
+pub fn write_request_decision(
+    read_only: bool,
+    ordinary_confirmation: bool,
+    protected_production: bool,
+) -> WriteRequestDecision {
+    if read_only {
+        WriteRequestDecision::BlockReadOnly
+    } else if ordinary_confirmation || protected_production {
+        WriteRequestDecision::Confirm
+    } else {
+        WriteRequestDecision::Proceed
+    }
+}
+
+pub fn request_connection_write(
+    state: Entity<AppState>,
+    request: WriteRequest,
+    window: &mut Window,
+    cx: &mut App,
+    on_confirm: impl FnOnce(&mut Window, &mut App) + 'static,
+) {
+    let WriteRequest { connection_id, target, operation, confirmation, authorization_uses } =
+        request;
+    let Some(connection) = state.read(cx).connection_by_id(connection_id).cloned() else {
+        state.update(cx, |state, cx| {
+            state.set_status_message(Some(StatusMessage::error(
+                "Write blocked because the connection no longer exists.",
+            )));
+            cx.notify();
+        });
+        return;
+    };
+    let identity = ConnectionIdentity::from(&connection);
+    let snapshot = ConnectionWriteIdentity::from(&connection);
+    let protected = connection.requires_production_write_confirmation();
+    match write_request_decision(
+        state.read(cx).connection_read_only(connection_id),
+        confirmation.is_some(),
+        protected,
+    ) {
+        WriteRequestDecision::BlockReadOnly => {
+            state.update(cx, |state, cx| {
+                state.set_status_message(Some(StatusMessage::error(
+                    "Read-only connection: writes are disabled.",
+                )));
+                cx.notify();
+            });
+        }
+        WriteRequestDecision::Proceed => on_confirm(window, cx),
+        WriteRequestDecision::Confirm => {
+            let confirmation = confirmation.unwrap_or_else(|| WriteConfirmation {
+                title: "Confirm Production write".into(),
+                message: format!("{operation}."),
+                confirm_label: "Continue".into(),
+                destructive: true,
+            });
+            let confirmation = WriteConfirmation {
+                message: format!(
+                    "{}\n\nConnection: {}\nEnvironment: {}\nTarget: {target}",
+                    confirmation.message,
+                    identity.name,
+                    identity.environment_label().unwrap_or("Not set")
+                ),
+                ..confirmation
+            };
+            let state_for_confirm = state.clone();
+            open_confirm_dialog_boxed(
+                window,
+                cx,
+                confirmation,
+                Some(identity.clone()),
+                Box::new(move |window, cx| {
+                    let allowed = state_for_confirm
+                        .read(cx)
+                        .connection_by_id(connection_id)
+                        .is_some_and(|connection| {
+                            snapshot.matches(connection)
+                                && !state_for_confirm.read(cx).connection_read_only(connection_id)
+                        });
+                    if !allowed {
+                        state_for_confirm.update(cx, |state, cx| {
+                            state.set_status_message(Some(StatusMessage::error(
+                                "Write blocked because the connection identity changed. Review it again.",
+                            )));
+                            cx.notify();
+                        });
+                        return;
+                    }
+                    if protected {
+                        state_for_confirm.update(cx, |state, _cx| {
+                            state.authorize_production_writes(connection_id, authorization_uses);
+                        });
+                    }
+                    on_confirm(window, cx);
+                    if protected {
+                        state_for_confirm.update(cx, |state, _cx| {
+                            state.revoke_production_write_authorizations(
+                                connection_id,
+                                authorization_uses,
+                            );
+                        });
+                    }
+                }),
+            );
+        }
+    }
+}
+
+pub(crate) fn with_scoped_production_authorizations(
+    state: &Entity<AppState>,
+    grants: &[(Uuid, usize)],
+    cx: &mut App,
+    action: impl FnOnce(&mut App),
+) {
+    state.update(cx, |state, _cx| {
+        for (connection_id, uses) in grants {
+            state.authorize_production_writes(*connection_id, *uses);
+        }
+    });
+    action(cx);
+    state.update(cx, |state, _cx| {
+        for (connection_id, uses) in grants {
+            state.revoke_production_write_authorizations(*connection_id, *uses);
+        }
+    });
+}
 
 #[derive(Default)]
 struct ConfirmDialogState {
@@ -25,18 +202,39 @@ fn close_dialog_and_restore_focus(
     }
 }
 
+type ConfirmCallback = Box<dyn FnOnce(&mut Window, &mut App)>;
+
 pub fn open_confirm_dialog(
     window: &mut Window,
     cx: &mut App,
-    title: impl Into<SharedString>,
-    message: impl Into<SharedString>,
-    confirm_label: impl Into<SharedString>,
+    title: impl Into<String>,
+    message: impl Into<String>,
+    confirm_label: impl Into<String>,
     destructive: bool,
     on_confirm: impl FnOnce(&mut Window, &mut App) + 'static,
 ) {
-    let title: SharedString = title.into();
-    let message: SharedString = message.into();
-    let confirm_label: SharedString = confirm_label.into();
+    open_confirm_dialog_boxed(
+        window,
+        cx,
+        WriteConfirmation {
+            title: title.into(),
+            message: message.into(),
+            confirm_label: confirm_label.into(),
+            destructive,
+        },
+        None,
+        Box::new(on_confirm),
+    );
+}
+
+fn open_confirm_dialog_boxed(
+    window: &mut Window,
+    cx: &mut App,
+    confirmation: WriteConfirmation,
+    identity: Option<ConnectionIdentity>,
+    on_confirm: ConfirmCallback,
+) {
+    let WriteConfirmation { title, message, confirm_label, destructive } = confirmation;
     let on_confirm = Rc::new(RefCell::new(Some(on_confirm)));
     let previous_focus = window.focused(cx);
     let cancel_focus = cx.focus_handle().tab_index(0).tab_stop(true);
@@ -120,6 +318,9 @@ pub fn open_confirm_dialog(
                 .gap(spacing::md())
                 .p(spacing::md())
                 .on_key_down(key_handler)
+                .when_some(identity.clone(), |content, identity| {
+                    content.child(connection_identity_badge(&identity, true, cx))
+                })
                 .child(
                     div()
                         .text_sm()

--- a/src/components/connection_dialog.rs
+++ b/src/components/connection_dialog.rs
@@ -1,3 +1,4 @@
+use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::ActiveTheme as _;
 use gpui_component::Sizable as _;
@@ -11,7 +12,7 @@ use crate::helpers::{
     UriSecrets, extract_host_from_uri, extract_uri_secrets, inject_uri_secrets, strip_uri_secrets,
     validate_mongodb_uri,
 };
-use crate::models::SavedConnection;
+use crate::models::{ConnectionEnvironment, SavedConnection};
 use crate::state::{AppState, UnsavedScope};
 use crate::theme::spacing;
 
@@ -30,6 +31,8 @@ pub struct ConnectionDialog {
     password_state: Entity<InputState>,
     uri_secrets: UriSecrets,
     sanitizing_uri: bool,
+    environment: Option<ConnectionEnvironment>,
+    confirm_production_writes: bool,
     read_only: bool,
     status: TestStatus,
     last_tested_uri: Option<String>,
@@ -116,6 +119,8 @@ impl ConnectionDialog {
             password_state,
             uri_secrets: UriSecrets::default(),
             sanitizing_uri: false,
+            environment: None,
+            confirm_production_writes: false,
             read_only: false,
             status: TestStatus::Idle,
             last_tested_uri: None,
@@ -179,6 +184,8 @@ impl ConnectionDialog {
             password_state,
             uri_secrets,
             sanitizing_uri: false,
+            environment: existing.environment,
+            confirm_production_writes: existing.confirm_production_writes,
             read_only: existing.read_only,
             status: TestStatus::Success,
             last_tested_uri: Some(redacted_default),
@@ -272,6 +279,46 @@ impl Render for ConnectionDialog {
         let is_edit = self.existing.is_some();
         let is_connected =
             self.existing.as_ref().is_some_and(|e| self.state.read(cx).is_connected(e.id));
+        let selected_environment = self.environment;
+        let view = cx.entity();
+        let mut no_environment = Button::new("simple-environment-none")
+            .compact()
+            .label(if selected_environment.is_none() { "✓ Not set" } else { "Not set" })
+            .on_click({
+                let view = view.clone();
+                move |_, _window, cx| {
+                    view.update(cx, |this, cx| {
+                        this.environment = None;
+                        cx.notify();
+                    });
+                }
+            });
+        if selected_environment.is_none() {
+            no_environment = no_environment.primary();
+        }
+        let environments = ConnectionEnvironment::ALL
+            .into_iter()
+            .map(|environment| {
+                let view = view.clone();
+                let mut button = Button::new(("simple-environment", environment as usize))
+                    .compact()
+                    .label(if selected_environment == Some(environment) {
+                        format!("✓ {}", environment.label())
+                    } else {
+                        environment.label().to_string()
+                    })
+                    .on_click(move |_, _window, cx| {
+                        view.update(cx, |this, cx| {
+                            this.environment = Some(environment);
+                            cx.notify();
+                        });
+                    });
+                if selected_environment == Some(environment) {
+                    button = button.primary();
+                }
+                button.into_any_element()
+            })
+            .collect::<Vec<_>>();
         let save_label = if is_edit {
             if is_connected { "Update & Reconnect" } else { "Update & Connect" }
         } else {
@@ -319,6 +366,50 @@ impl Render for ConnectionDialog {
                     .child(div().text_sm().text_color(cx.theme().foreground).child("Password"))
                     .child(Input::new(&self.password_state).mask_toggle()),
             )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(spacing::xs())
+                    .child(div().text_sm().text_color(cx.theme().foreground).child("Environment"))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_wrap()
+                            .gap(spacing::xs())
+                            .child(no_environment)
+                            .children(environments),
+                    )
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(cx.theme().muted_foreground)
+                            .child("Explicit identity; never inferred from the URI."),
+                    ),
+            )
+            .when(self.environment == Some(ConnectionEnvironment::Production), |content| {
+                content.child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(spacing::sm())
+                        .child(
+                            Switch::new("simple-confirm-production-writes")
+                                .checked(self.confirm_production_writes)
+                                .small()
+                                .on_click({
+                                    let view = view.clone();
+                                    move |checked, _window, cx| {
+                                        view.update(cx, |this, cx| {
+                                            this.confirm_production_writes = *checked;
+                                            cx.notify();
+                                        });
+                                    }
+                                }),
+                        )
+                        .child("Confirm Production writes and Forge"),
+                )
+            })
             .child(
                 div()
                     .flex()
@@ -386,6 +477,8 @@ impl Render for ConnectionDialog {
                                 let uri_state = self.uri_state.clone();
                                 let password_state = self.password_state.clone();
                                 let uri_secrets = self.uri_secrets.clone();
+                                let environment = self.environment;
+                                let confirm_production_writes = self.confirm_production_writes;
                                 let read_only = self.read_only;
                                 let existing = self.existing.clone();
                                 move |_, window, cx| {
@@ -425,6 +518,8 @@ impl Render for ConnectionDialog {
                                                     id: existing.id,
                                                     name,
                                                     color: existing.color,
+                                                    environment,
+                                                    confirm_production_writes,
                                                     uri,
                                                     last_connected: existing.last_connected,
                                                     read_only,
@@ -436,6 +531,9 @@ impl Render for ConnectionDialog {
                                             } else {
                                                 let mut connection =
                                                     SavedConnection::new(name, uri);
+                                                connection.environment = environment;
+                                                connection.confirm_production_writes =
+                                                    confirm_production_writes;
                                                 connection.read_only = read_only;
                                                 connection_id = Some(connection.id);
                                                 state.add_connection(connection, cx);

--- a/src/components/connection_identity.rs
+++ b/src/components/connection_identity.rs
@@ -1,0 +1,144 @@
+use gpui::*;
+use gpui_component::ActiveTheme as _;
+use uuid::Uuid;
+
+use crate::models::{
+    ConnectionColor, ConnectionEnvironment, ConnectionWriteIdentity, SavedConnection,
+};
+use crate::state::AppState;
+use crate::theme::{borders, colors, spacing};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionIdentity {
+    pub id: Uuid,
+    pub name: String,
+    pub color: Option<ConnectionColor>,
+    pub environment: Option<ConnectionEnvironment>,
+    pub read_only: bool,
+    pub confirm_production_writes: bool,
+}
+
+impl From<&ConnectionWriteIdentity> for ConnectionIdentity {
+    fn from(connection: &ConnectionWriteIdentity) -> Self {
+        Self {
+            id: connection.id,
+            name: connection.name.clone(),
+            color: connection.color,
+            environment: connection.environment,
+            read_only: connection.read_only,
+            confirm_production_writes: connection.confirm_production_writes,
+        }
+    }
+}
+
+impl From<&SavedConnection> for ConnectionIdentity {
+    fn from(connection: &SavedConnection) -> Self {
+        Self {
+            id: connection.id,
+            name: connection.name.clone(),
+            color: connection.color,
+            environment: connection.environment,
+            read_only: connection.read_only,
+            confirm_production_writes: connection.confirm_production_writes,
+        }
+    }
+}
+
+impl ConnectionIdentity {
+    pub fn requires_production_write_confirmation(&self) -> bool {
+        self.environment == Some(ConnectionEnvironment::Production)
+            && self.confirm_production_writes
+    }
+
+    pub fn environment_label(&self) -> Option<&'static str> {
+        self.environment.map(ConnectionEnvironment::label)
+    }
+
+    pub fn display_name(&self) -> String {
+        match (self.environment_label(), self.read_only) {
+            (Some(environment), true) => format!("{} · {environment} · Read-only", self.name),
+            (Some(environment), false) => format!("{} · {environment}", self.name),
+            (None, true) => format!("{} · Read-only", self.name),
+            (None, false) => self.name.clone(),
+        }
+    }
+}
+
+pub fn connection_identity_for(
+    state: &Entity<AppState>,
+    connection_id: Uuid,
+    include_name: bool,
+    cx: &App,
+) -> AnyElement {
+    state
+        .read(cx)
+        .connection_by_id(connection_id)
+        .map(ConnectionIdentity::from)
+        .map(|identity| connection_identity_badge(&identity, include_name, cx))
+        .unwrap_or_else(|| div().into_any_element())
+}
+
+pub fn connection_identity_badge(
+    identity: &ConnectionIdentity,
+    include_name: bool,
+    cx: &App,
+) -> AnyElement {
+    let environment = identity.environment_label();
+    let mut row = div().flex().items_center().gap(spacing::xs()).min_w(px(0.0));
+    if let Some(color) = identity.color {
+        row = row.child(
+            div()
+                .size(px(8.0))
+                .flex_shrink_0()
+                .rounded_full()
+                .bg(colors::connection_accent(color, cx)),
+        );
+    }
+    if include_name {
+        row = row.child(
+            div()
+                .min_w(px(0.0))
+                .overflow_hidden()
+                .text_ellipsis()
+                .whitespace_nowrap()
+                .text_sm()
+                .text_color(cx.theme().foreground)
+                .child(identity.name.clone()),
+        );
+    }
+    if let Some(environment) = environment {
+        row = row.child(
+            div()
+                .px(spacing::xs())
+                .py(px(1.0))
+                .rounded(borders::radius_sm())
+                .flex_shrink_0()
+                .bg(if identity.environment == Some(ConnectionEnvironment::Production) {
+                    cx.theme().danger.opacity(0.14)
+                } else {
+                    cx.theme().secondary
+                })
+                .text_xs()
+                .text_color(if identity.environment == Some(ConnectionEnvironment::Production) {
+                    cx.theme().danger
+                } else {
+                    cx.theme().secondary_foreground
+                })
+                .child(environment),
+        );
+    }
+    if identity.read_only {
+        row = row.child(
+            div()
+                .px(spacing::xs())
+                .py(px(1.0))
+                .rounded(borders::radius_sm())
+                .flex_shrink_0()
+                .bg(cx.theme().warning.opacity(0.16))
+                .text_xs()
+                .text_color(cx.theme().warning)
+                .child("RO"),
+        );
+    }
+    row.into_any_element()
+}

--- a/src/components/connection_manager/actions.rs
+++ b/src/components/connection_manager/actions.rs
@@ -92,6 +92,8 @@ impl ConnectionManager {
                 .name_state
                 .update(cx, |state, cx| state.set_value(connection.name.clone(), window, cx));
             self.draft.color = connection.color;
+            self.draft.environment = connection.environment;
+            self.draft.confirm_production_writes = connection.confirm_production_writes;
             self.draft.read_only = connection.read_only;
             self.load_transport_settings(&connection, window, cx);
             self.import_uri(connection.uri.clone(), window, cx);
@@ -632,6 +634,8 @@ impl ConnectionManager {
         };
 
         let color = self.draft.color;
+        let environment = self.draft.environment;
+        let confirm_production_writes = self.draft.confirm_production_writes;
         let read_only = self.draft.read_only;
         let (ssh, proxy) = match self.build_transport_settings(cx) {
             Ok(settings) => settings,
@@ -651,6 +655,8 @@ impl ConnectionManager {
                         id: existing_id,
                         name: name.clone(),
                         color,
+                        environment,
+                        confirm_production_writes,
                         uri: uri.clone(),
                         last_connected: existing.last_connected,
                         read_only,
@@ -664,6 +670,8 @@ impl ConnectionManager {
             } else {
                 let mut connection = SavedConnection::new(name.clone(), uri.clone());
                 connection.color = color;
+                connection.environment = environment;
+                connection.confirm_production_writes = confirm_production_writes;
                 connection.read_only = read_only;
                 connection.ssh = ssh.clone();
                 connection.proxy = proxy.clone();

--- a/src/components/connection_manager/connection_list.rs
+++ b/src/components/connection_manager/connection_list.rs
@@ -9,10 +9,10 @@ use gpui_component::scroll::ScrollableElement;
 use gpui_component::{Icon, IconName, Sizable as _};
 use uuid::Uuid;
 
-use crate::components::Button;
+use crate::components::{Button, ConnectionIdentity, connection_identity_badge};
 use crate::helpers::extract_host_from_uri;
 use crate::models::SavedConnection;
-use crate::theme::{borders, colors, sizing, spacing};
+use crate::theme::{borders, sizing, spacing};
 
 use super::export_dialog::open_export_dialog;
 use super::import::open_import_flow;
@@ -166,8 +166,7 @@ impl ConnectionManager {
             .last_connected
             .map(|dt| dt.format("%Y-%m-%d").to_string())
             .unwrap_or_else(|| "Never".to_string());
-        let read_only = conn.read_only;
-        let accent = conn.color.map(|color| colors::connection_accent(color, cx));
+        let identity = ConnectionIdentity::from(&conn);
 
         div()
             .flex()
@@ -186,33 +185,7 @@ impl ConnectionManager {
                     .flex()
                     .items_center()
                     .justify_between()
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap(spacing::xs())
-                            .when_some(accent, |this, color| {
-                                this.child(div().size(px(8.0)).rounded_full().bg(color))
-                            })
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(cx.theme().foreground)
-                                    .child(conn.name.clone()),
-                            ),
-                    )
-                    .when(read_only, |s| {
-                        s.child(
-                            div()
-                                .px(spacing::xs())
-                                .py(px(1.0))
-                                .rounded(borders::radius_sm())
-                                .bg(cx.theme().warning)
-                                .text_xs()
-                                .text_color(cx.theme().tab_bar)
-                                .child("RO"),
-                        )
-                    }),
+                    .child(connection_identity_badge(&identity, true, cx)),
             )
             .child(div().text_xs().text_color(cx.theme().secondary_foreground).child(host))
             .child(

--- a/src/components/connection_manager/mod.rs
+++ b/src/components/connection_manager/mod.rs
@@ -66,6 +66,8 @@ struct ConnectionDraft {
     uri_secrets: crate::helpers::UriSecrets,
     internal_uri_value: Option<String>,
     color: Option<crate::models::ConnectionColor>,
+    environment: Option<crate::models::ConnectionEnvironment>,
+    confirm_production_writes: bool,
     read_only: bool,
     direct_connection: bool,
     tls: bool,

--- a/src/components/connection_manager/state.rs
+++ b/src/components/connection_manager/state.rs
@@ -82,6 +82,8 @@ impl ConnectionDraft {
             uri_secrets: crate::helpers::UriSecrets::default(),
             internal_uri_value: None,
             color: None,
+            environment: None,
+            confirm_production_writes: false,
             read_only: false,
             direct_connection: false,
             tls: false,
@@ -147,6 +149,8 @@ impl ConnectionDraft {
         self.uri_secrets = crate::helpers::UriSecrets::default();
         self.internal_uri_value = None;
         self.color = None;
+        self.environment = None;
+        self.confirm_production_writes = false;
         self.read_only = false;
         self.direct_connection = false;
         self.tls = false;

--- a/src/components/connection_manager/tabs.rs
+++ b/src/components/connection_manager/tabs.rs
@@ -11,7 +11,7 @@ use gpui_component::input::Input;
 use gpui_component::switch::Switch;
 
 use crate::components::Button;
-use crate::models::ConnectionColor;
+use crate::models::{ConnectionColor, ConnectionEnvironment};
 use crate::theme::{colors, spacing};
 
 use super::ConnectionManager;
@@ -60,6 +60,45 @@ impl ConnectionManager {
                 button.into_any_element()
             })
             .collect::<Vec<_>>();
+        let selected_environment = self.draft.environment;
+        let mut no_environment_button = Button::new("connection-environment-none")
+            .compact()
+            .label(if selected_environment.is_none() { "✓ Not set" } else { "Not set" })
+            .on_click({
+                let view = view.clone();
+                move |_, _window, cx| {
+                    view.update(cx, |this, cx| {
+                        this.draft.environment = None;
+                        cx.notify();
+                    });
+                }
+            });
+        if selected_environment.is_none() {
+            no_environment_button = no_environment_button.primary();
+        }
+        let environment_buttons = ConnectionEnvironment::ALL
+            .into_iter()
+            .map(|environment| {
+                let view = view.clone();
+                let mut button = Button::new(("connection-environment", environment as usize))
+                    .compact()
+                    .label(if selected_environment == Some(environment) {
+                        format!("✓ {}", environment.label())
+                    } else {
+                        environment.label().to_string()
+                    })
+                    .on_click(move |_, _window, cx| {
+                        view.update(cx, |this, cx| {
+                            this.draft.environment = Some(environment);
+                            cx.notify();
+                        });
+                    });
+                if selected_environment == Some(environment) {
+                    button = button.primary();
+                }
+                button.into_any_element()
+            })
+            .collect::<Vec<_>>();
 
         div()
             .flex()
@@ -99,6 +138,69 @@ impl ConnectionManager {
                             .child("Accents this connection in the sidebar and tabs."),
                     ),
             )
+            // Environment identity
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(spacing::xs())
+                    .child(div().text_sm().text_color(cx.theme().foreground).child("Environment"))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_wrap()
+                            .items_center()
+                            .gap(spacing::xs())
+                            .child(no_environment_button)
+                            .children(environment_buttons),
+                    )
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(cx.theme().muted_foreground)
+                            .child("Selected explicitly; OpenMango never infers Production from a hostname."),
+                    ),
+            )
+            .when(self.draft.environment == Some(ConnectionEnvironment::Production), |content| {
+                content.child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(spacing::sm())
+                        .child(
+                            Switch::new("confirm-production-writes")
+                                .checked(self.draft.confirm_production_writes)
+                                .small()
+                                .on_click({
+                                    let view = view.clone();
+                                    move |checked, _window, cx| {
+                                        view.update(cx, |this, cx| {
+                                            this.draft.confirm_production_writes = *checked;
+                                            cx.notify();
+                                        });
+                                    }
+                                }),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .flex_col()
+                                .gap(px(2.0))
+                                .child(
+                                    div()
+                                        .text_sm()
+                                        .text_color(cx.theme().foreground)
+                                        .child("Confirm Production writes and Forge"),
+                                )
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(cx.theme().secondary_foreground)
+                                        .child("Require an additional review before writes and Forge execution."),
+                                ),
+                        ),
+                )
+            })
             // URI
             .child(
                 div()

--- a/src/components/content/tabs.rs
+++ b/src/components/content/tabs.rs
@@ -6,7 +6,7 @@ use gpui_component::scroll::ScrollbarHandle as _;
 use gpui_component::tab::{Tab, TabBar};
 use gpui_component::{ActiveTheme as _, Icon, IconName, Sizable as _};
 
-use crate::components::request_unsaved_action;
+use crate::components::{ConnectionIdentity, connection_identity_badge, request_unsaved_action};
 use crate::keyboard::FocusContent;
 use crate::state::{
     ActiveTab, AppState, AppearanceSettings, IslandsTabStyle, SessionKey, TabKey, UnsavedScope,
@@ -150,7 +150,7 @@ impl Render for OpenTabsBar {
             preview_tab,
             dirty_tabs,
             current_view,
-            connection_colors,
+            connection_identities,
         ) = {
             let state_ref = self.state.read(cx);
             (
@@ -163,7 +163,7 @@ impl Render for OpenTabsBar {
                 state_ref
                     .connections_snapshot()
                     .into_iter()
-                    .filter_map(|connection| connection.color.map(|color| (connection.id, color)))
+                    .map(|connection| (connection.id, ConnectionIdentity::from(&connection)))
                     .collect::<HashMap<_, _>>(),
             )
         };
@@ -268,8 +268,10 @@ impl Render for OpenTabsBar {
                             TabKey::Forge(tab) => Some(tab.connection_id),
                             TabKey::Settings | TabKey::Changelog => None,
                         };
+                        let connection_identity =
+                            connection_id.and_then(|id| connection_identities.get(&id));
                         let connection_color =
-                            connection_id.and_then(|id| connection_colors.get(&id)).copied();
+                            connection_identity.and_then(|identity| identity.color);
                         let is_selected = selected_index == index;
                         let state = self.state.clone();
                         let tab_to_close = tab.clone();
@@ -372,7 +374,15 @@ impl Render for OpenTabsBar {
                         let tab_view = Tab::new()
                             .max_w(px(OPEN_TAB_MAX_WIDTH))
                             .child(
-                                div().max_w(px(OPEN_TAB_LABEL_MAX_WIDTH)).truncate().child(label),
+                                div()
+                                    .flex()
+                                    .items_center()
+                                    .gap(px(4.0))
+                                    .max_w(px(OPEN_TAB_LABEL_MAX_WIDTH))
+                                    .child(div().min_w(px(0.0)).truncate().child(label))
+                                    .when_some(connection_identity, |content, identity| {
+                                        content.child(connection_identity_badge(identity, true, cx))
+                                    }),
                             )
                             .prefix(prefix);
 
@@ -549,9 +559,9 @@ impl Render for OpenTabsBar {
                             dirty_dot = dirty_dot.mr(px(2.0));
                         }
 
-                        let icon_color = connection_colors
-                            .get(&tab.connection_id)
-                            .copied()
+                        let preview_identity = connection_identities.get(&tab.connection_id);
+                        let icon_color = preview_identity
+                            .and_then(|identity| identity.color)
                             .map(|color| colors::connection_accent(color, cx))
                             .unwrap_or_else(|| {
                                 if is_preview_selected {
@@ -584,11 +594,21 @@ impl Render for OpenTabsBar {
                             .max_w(px(OPEN_TAB_MAX_WIDTH))
                             .child(
                                 div()
+                                    .flex()
+                                    .items_center()
+                                    .gap(px(4.0))
                                     .max_w(px(OPEN_TAB_LABEL_MAX_WIDTH))
-                                    .truncate()
-                                    .italic()
-                                    .text_color(cx.theme().muted_foreground)
-                                    .child(label),
+                                    .child(
+                                        div()
+                                            .min_w(px(0.0))
+                                            .truncate()
+                                            .italic()
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child(label),
+                                    )
+                                    .when_some(preview_identity, |content, identity| {
+                                        content.child(connection_identity_badge(identity, true, cx))
+                                    }),
                             )
                             .prefix(prefix)
                             .suffix(close_button)

--- a/src/components/file_picker.rs
+++ b/src/components/file_picker.rs
@@ -61,6 +61,11 @@ impl FileFilter {
         Self::new("OpenMango Connections", vec!["json"])
     }
 
+    /// OpenMango Query Library (.json)
+    pub fn query_library_json() -> Self {
+        Self::new("OpenMango Query Library", vec!["json"])
+    }
+
     /// All files
     pub fn all() -> Self {
         Self::new("All Files", vec!["*"])

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -5,6 +5,7 @@ pub mod ai_blocks;
 pub mod button;
 pub mod confirm;
 pub mod connection_dialog;
+pub mod connection_identity;
 pub mod connection_manager;
 mod content;
 pub mod dialog_helpers;
@@ -15,8 +16,12 @@ pub mod query_library;
 mod status_bar;
 mod unsaved_guard;
 pub use button::Button;
-pub use confirm::open_confirm_dialog;
+pub(crate) use confirm::with_scoped_production_authorizations;
+pub use confirm::{WriteConfirmation, WriteRequest, open_confirm_dialog, request_connection_write};
 pub use connection_dialog::ConnectionDialog;
+pub use connection_identity::{
+    ConnectionIdentity, connection_identity_badge, connection_identity_for,
+};
 pub use connection_manager::ConnectionManager;
 pub use content::ContentArea;
 pub use dialog_helpers::{cancel_button, primary_button};

--- a/src/components/query_library.rs
+++ b/src/components/query_library.rs
@@ -11,11 +11,14 @@ use gpui_component::input::{Input, InputEvent, InputState};
 use gpui_component::scroll::ScrollableElement;
 use uuid::Uuid;
 
-use crate::components::Button;
+use crate::components::file_picker::{FileFilter, FilePickerMode, open_file_dialog_async};
+use crate::components::{Button, ConnectionIdentity, connection_identity_badge};
+use crate::helpers::query_library_io;
 use crate::keyboard::RunForgeAll;
 use crate::state::{
     AppCommands, AppState, CollectionSubview, DocumentQuery, ForgeTabKey, QueryContent,
-    QueryDefinition, QueryKind, QueryLibraryPersistenceError, SessionKey, StatusMessage, View,
+    QueryDefinition, QueryKind, QueryLibraryPersistenceError, SavedQueryInput, SavedQueryScope,
+    SessionKey, StatusMessage, View,
 };
 use crate::theme::spacing;
 use crate::views::documents::compile_filter_input;
@@ -40,6 +43,13 @@ impl QueryLibraryTarget {
             }
             View::Forge => state.active_forge_tab_key().cloned().map(Self::Forge),
             _ => None,
+        }
+    }
+
+    fn connection_id(&self) -> Uuid {
+        match self {
+            Self::Documents(key) | Self::Aggregation(key) => key.connection_id,
+            Self::Forge(key) => key.connection_id,
         }
     }
 
@@ -68,6 +78,16 @@ impl QueryLibraryTarget {
             Self::Forge(key) => {
                 definition.matches_scope(QueryKind::Forge, key.connection_id, &key.database, None)
             }
+        }
+    }
+
+    fn identity_label(&self, state: &AppState) -> String {
+        let connection = connection_label(state, self.connection_id());
+        match self {
+            Self::Documents(key) | Self::Aggregation(key) => {
+                format!("{connection} / {}.{}", key.database, key.collection)
+            }
+            Self::Forge(key) => format!("{connection} / {}", key.database),
         }
     }
 
@@ -124,7 +144,7 @@ enum LibraryMode {
 #[derive(Clone)]
 enum EditIntent {
     Save(QueryDefinition),
-    RenameSaved(Uuid),
+    EditSaved(Uuid),
 }
 
 #[derive(Clone)]
@@ -132,9 +152,27 @@ struct LibraryItem {
     id: Uuid,
     saved: bool,
     name: Option<String>,
+    description: String,
+    tags: Vec<String>,
+    scope: SavedQueryScope,
     timestamp: DateTime<Utc>,
     connection_name: String,
     definition: QueryDefinition,
+}
+
+struct EditValues {
+    name: String,
+    description: String,
+    tags: Vec<String>,
+    scope: SavedQueryScope,
+}
+
+#[derive(Clone)]
+struct PendingImport {
+    inputs: Vec<SavedQueryInput>,
+    global: usize,
+    connection: usize,
+    renamed: usize,
 }
 
 pub struct QueryLibraryDialog {
@@ -142,9 +180,15 @@ pub struct QueryLibraryDialog {
     target: QueryLibraryTarget,
     search_state: Entity<InputState>,
     name_state: Entity<InputState>,
+    description_state: Entity<InputState>,
+    tags_state: Entity<InputState>,
+    import_focus: FocusHandle,
+    edit_scope: SavedQueryScope,
     mode: LibraryMode,
     show_all: bool,
     editing: Option<EditIntent>,
+    pending_import: Option<PendingImport>,
+    file_busy: bool,
     confirm_clear: bool,
     confirm_delete: Option<Uuid>,
     error: Option<String>,
@@ -196,11 +240,17 @@ impl QueryLibraryDialog {
     ) -> Self {
         let search_state = cx.new(|cx| {
             InputState::new(window, cx)
-                .placeholder("Search query text, name, or namespace")
+                .placeholder("Search name, description, tags, query, or namespace")
                 .clean_on_escape()
         });
         let name_state =
             cx.new(|cx| InputState::new(window, cx).placeholder("Query name").clean_on_escape());
+        let description_state = cx.new(|cx| {
+            InputState::new(window, cx).placeholder("Description (optional)").clean_on_escape()
+        });
+        let tags_state = cx.new(|cx| {
+            InputState::new(window, cx).placeholder("Tags, separated by commas").clean_on_escape()
+        });
 
         let mut subscriptions = Vec::new();
         subscriptions.push(cx.subscribe_in(&search_state, window, |view, _, event, window, cx| {
@@ -215,11 +265,24 @@ impl QueryLibraryDialog {
                 _ => {}
             }
         }));
-        subscriptions.push(cx.subscribe_in(&name_state, window, |view, _, event, _window, cx| {
-            if matches!(event, InputEvent::PressEnter { .. }) {
-                view.commit_edit(cx);
+        subscriptions.push(cx.subscribe_in(&name_state, window, |view, _, event, window, cx| {
+            match event {
+                InputEvent::Change => {
+                    view.error = None;
+                    cx.notify();
+                }
+                InputEvent::PressEnter { .. } => view.commit_edit(window, cx),
+                _ => {}
             }
         }));
+        for input in [&description_state, &tags_state] {
+            subscriptions.push(cx.subscribe_in(input, window, |view, _, event, _window, cx| {
+                if matches!(event, InputEvent::Change) {
+                    view.error = None;
+                    cx.notify();
+                }
+            }));
+        }
         subscriptions.push(cx.observe(&state, |_, _, cx| cx.notify()));
 
         Self {
@@ -227,9 +290,15 @@ impl QueryLibraryDialog {
             target,
             search_state,
             name_state,
+            description_state,
+            tags_state,
+            import_focus: cx.focus_handle(),
+            edit_scope: SavedQueryScope::Connection,
             mode: LibraryMode::History,
             show_all: false,
             editing: None,
+            pending_import: None,
+            file_busy: false,
             confirm_clear: false,
             confirm_delete: None,
             error: None,
@@ -248,6 +317,9 @@ impl QueryLibraryDialog {
                     id: entry.id,
                     saved: false,
                     name: None,
+                    description: String::new(),
+                    tags: Vec::new(),
+                    scope: SavedQueryScope::Connection,
                     timestamp: entry.executed_at,
                     connection_name: connection_label(state, entry.definition.connection_id),
                     definition: entry.definition.clone(),
@@ -260,6 +332,9 @@ impl QueryLibraryDialog {
                     id: entry.id,
                     saved: true,
                     name: Some(entry.name.clone()),
+                    description: entry.description.clone(),
+                    tags: entry.tags.clone(),
+                    scope: entry.scope,
                     timestamp: entry.updated_at,
                     connection_name: connection_label(state, entry.definition.connection_id),
                     definition: entry.definition.clone(),
@@ -267,14 +342,20 @@ impl QueryLibraryDialog {
                 .collect::<Vec<_>>(),
         };
         items.retain(|item| {
-            (self.show_all || self.target.matches_scope(&item.definition))
+            let in_scope = if item.saved && item.scope == SavedQueryScope::Global {
+                item.definition.kind() == self.target.kind()
+            } else {
+                self.target.matches_scope(&item.definition)
+            };
+            let matches_saved = item.saved
+                && state
+                    .saved_queries()
+                    .iter()
+                    .find(|saved| saved.id == item.id)
+                    .is_some_and(|saved| saved.matches_search(&query));
+            (self.show_all || in_scope)
                 && (query.is_empty()
-                    || item
-                        .name
-                        .as_deref()
-                        .unwrap_or_default()
-                        .to_ascii_lowercase()
-                        .contains(&query)
+                    || matches_saved
                     || item.connection_name.to_ascii_lowercase().contains(&query)
                     || item.definition.namespace().to_ascii_lowercase().contains(&query)
                     || item.definition.content.copy_text().to_ascii_lowercase().contains(&query))
@@ -282,10 +363,12 @@ impl QueryLibraryDialog {
         items
     }
 
+    fn item_applicable(&self, item: &LibraryItem) -> bool {
+        query_applicable(&self.target, item.saved, item.scope, &item.definition)
+    }
+
     fn activate_first(&mut self, run: bool, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(item) =
-            self.items(cx).into_iter().find(|item| item.definition.kind() == self.target.kind())
-        else {
+        let Some(item) = self.items(cx).into_iter().find(|item| self.item_applicable(item)) else {
             self.error =
                 Some(format!("No {} queries match this search.", self.target.kind().label()));
             cx.notify();
@@ -301,14 +384,31 @@ impl QueryLibraryDialog {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if item.definition.kind() != self.target.kind() {
-            self.error =
-                Some(format!("Open {} to restore this query.", item.definition.kind().label()));
+        if !self.item_applicable(&item) {
+            self.error = Some(if item.definition.kind() != self.target.kind() {
+                format!("Open {} to restore this query.", item.definition.kind().label())
+            } else {
+                "This connection-specific query can only be restored in its saved namespace."
+                    .to_string()
+            });
             cx.notify();
             return;
         }
 
         let target = self.target.clone();
+        let is_global = item.saved && item.scope == SavedQueryScope::Global;
+        let target_identity = target.identity_label(self.state.read(cx));
+        let status = if is_global {
+            if run {
+                format!("Global query restored to {target_identity} and started")
+            } else {
+                format!("Global query restored to {target_identity}")
+            }
+        } else if run {
+            "Query restored and started".to_string()
+        } else {
+            "Query restored".to_string()
+        };
         let definition = item.definition.clone();
         let result = self.state.update(cx, |state, cx| {
             let result = match &target {
@@ -321,11 +421,7 @@ impl QueryLibraryDialog {
                 QueryLibraryTarget::Forge(key) => state.restore_forge_query(key, &definition),
             };
             if result.is_ok() {
-                state.set_status_message(Some(StatusMessage::info(if run {
-                    "Query restored and started"
-                } else {
-                    "Query restored"
-                })));
+                state.set_status_message(Some(StatusMessage::info(status)));
                 cx.notify();
             }
             result
@@ -357,28 +453,55 @@ impl QueryLibraryDialog {
     fn start_edit(
         &mut self,
         intent: EditIntent,
-        value: String,
+        values: EditValues,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.editing = Some(intent);
+        self.edit_scope = values.scope;
         self.error = None;
         self.name_state.update(cx, |input, cx| {
-            input.set_value(value, window, cx);
+            input.set_value(values.name, window, cx);
             input.focus(window, cx);
+        });
+        self.description_state.update(cx, |input, cx| {
+            input.set_value(values.description, window, cx);
+        });
+        self.tags_state.update(cx, |input, cx| {
+            input.set_value(values.tags.join(", "), window, cx);
         });
         cx.notify();
     }
 
-    fn commit_edit(&mut self, cx: &mut Context<Self>) {
+    fn focus_search(&self, window: &mut Window, cx: &mut Context<Self>) {
+        self.search_state.update(cx, |input, cx| input.focus(window, cx));
+    }
+
+    fn commit_edit(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(intent) = self.editing.clone() else {
             return;
         };
         let name = self.name_state.read(cx).value().to_string();
+        let description = self.description_state.read(cx).value().to_string();
+        let tags =
+            self.tags_state.read(cx).value().split(',').map(str::to_string).collect::<Vec<_>>();
+        let scope = self.edit_scope;
         let result = self.state.update(cx, |state, cx| {
-            let result = match intent {
-                EditIntent::Save(definition) => state.save_query(definition, &name).map(|_| ()),
-                EditIntent::RenameSaved(id) => state.rename_saved_query(id, &name),
+            let (id, definition) = match intent {
+                EditIntent::Save(definition) => (None, definition),
+                EditIntent::EditSaved(id) => {
+                    let Some(saved) = state.saved_queries().iter().find(|saved| saved.id == id)
+                    else {
+                        return Err(anyhow::anyhow!("That saved query no longer exists."));
+                    };
+                    (Some(id), saved.definition.clone())
+                }
+            };
+            let input = SavedQueryInput { name, description, tags, scope, definition };
+            let result = if let Some(id) = id {
+                state.edit_saved_query(id, input)
+            } else {
+                state.save_query_input(input).map(|_| ())
             };
             if result.is_ok() {
                 cx.notify();
@@ -389,15 +512,167 @@ impl QueryLibraryDialog {
             Ok(()) => {
                 self.editing = None;
                 self.error = None;
+                self.focus_search(window, cx);
             }
             Err(error) => {
                 if error.downcast_ref::<QueryLibraryPersistenceError>().is_some() {
                     self.editing = None;
+                    self.focus_search(window, cx);
                 }
                 self.error = Some(error.to_string());
             }
         }
         cx.notify();
+    }
+
+    fn start_import(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.file_busy {
+            return;
+        }
+        let window_handle = window.window_handle();
+        let connection_id = self.target.connection_id();
+        self.file_busy = true;
+        self.pending_import = None;
+        self.error = None;
+        cx.notify();
+        cx.spawn(async move |view: WeakEntity<Self>, cx: &mut AsyncApp| {
+            let path = open_file_dialog_async(
+                FilePickerMode::Open,
+                vec![FileFilter::query_library_json(), FileFilter::all()],
+                None,
+            )
+            .await;
+            let result = path.map(|path| query_library_io::read_import(&path));
+            let _ = cx.update_window(window_handle, |_root, window, cx| {
+                let _ = view.update(cx, |this, cx| {
+                    this.file_busy = false;
+                    match result {
+                        None => this.focus_search(window, cx),
+                        Some(Err(error)) => {
+                            this.error =
+                                Some(format!("Saved queries could not be imported: {error}"));
+                            this.focus_search(window, cx);
+                        }
+                        Some(Ok(file)) => {
+                            let inputs = file
+                                .queries
+                                .into_iter()
+                                .map(|query| query.into_input(connection_id))
+                                .collect::<anyhow::Result<Vec<_>>>();
+                            match inputs.and_then(|inputs| {
+                                let report =
+                                    this.state.read(cx).preview_saved_query_import(&inputs)?;
+                                Ok((inputs, report))
+                            }) {
+                                Ok((inputs, report)) => {
+                                    this.pending_import = Some(PendingImport {
+                                        inputs,
+                                        global: report.global,
+                                        connection: report.connection,
+                                        renamed: report.renamed,
+                                    });
+                                    let focus = this.import_focus.clone();
+                                    window.defer(cx, move |window, _cx| window.focus(&focus));
+                                }
+                                Err(error) => {
+                                    this.error = Some(format!(
+                                        "Saved queries could not be imported: {error}"
+                                    ));
+                                    this.focus_search(window, cx);
+                                }
+                            }
+                        }
+                    }
+                    cx.notify();
+                });
+            });
+        })
+        .detach();
+    }
+
+    fn confirm_import(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(pending) = self.pending_import.clone() else {
+            return;
+        };
+        let result =
+            self.state.update(cx, |state, cx| match state.import_saved_queries(pending.inputs) {
+                Ok(report) => {
+                    state.set_status_message(Some(StatusMessage::info(format!(
+                        "Imported {} saved queries ({} renamed)",
+                        report.imported, report.renamed
+                    ))));
+                    cx.notify();
+                    Ok(report)
+                }
+                Err(error) => Err(error),
+            });
+        match result {
+            Ok(_) => {
+                self.pending_import = None;
+                self.mode = LibraryMode::Saved;
+                self.show_all = true;
+                self.error = None;
+                self.focus_search(window, cx);
+            }
+            Err(error) => {
+                self.error = Some(error.to_string());
+                window.focus(&self.import_focus);
+            }
+        }
+        cx.notify();
+    }
+
+    fn start_export(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.file_busy {
+            return;
+        }
+        let file = match query_library_io::build_export(self.state.read(cx).saved_queries()) {
+            Ok(file) => file,
+            Err(error) => {
+                self.error = Some(format!("Saved queries could not be exported: {error}"));
+                self.focus_search(window, cx);
+                cx.notify();
+                return;
+            }
+        };
+        let count = file.queries.len();
+        let state = self.state.clone();
+        let window_handle = window.window_handle();
+        self.file_busy = true;
+        self.error = None;
+        cx.notify();
+        cx.spawn(async move |view: WeakEntity<Self>, cx: &mut AsyncApp| {
+            let path = open_file_dialog_async(
+                FilePickerMode::Save,
+                vec![FileFilter::query_library_json(), FileFilter::all()],
+                Some("openmango-query-library.json".to_string()),
+            )
+            .await;
+            let result = path.map(|path| query_library_io::write_export(&path, &file));
+            let _ = cx.update_window(window_handle, |_root, window, cx| {
+                let _ = view.update(cx, |this, cx| {
+                    this.file_busy = false;
+                    match result {
+                        None => {}
+                        Some(Ok(())) => {
+                            state.update(cx, |state, cx| {
+                                state.set_status_message(Some(StatusMessage::info(format!(
+                                    "Exported {count} saved queries"
+                                ))));
+                                cx.notify();
+                            });
+                        }
+                        Some(Err(error)) => {
+                            this.error =
+                                Some(format!("Saved queries could not be exported: {error}"));
+                        }
+                    }
+                    this.focus_search(window, cx);
+                    cx.notify();
+                });
+            });
+        })
+        .detach();
     }
 
     fn mutate_library(
@@ -422,8 +697,24 @@ impl QueryLibraryDialog {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let compatible = item.definition.kind() == self.target.kind();
+        let applicable = self.item_applicable(&item);
+        let target_identity = self.target.identity_label(self.state.read(cx));
         let namespace = item.definition.namespace();
         let connection_name = item.connection_name.clone();
+        let identity = if item.saved && item.scope == SavedQueryScope::Global {
+            div()
+                .px(px(5.0))
+                .py(px(1.0))
+                .rounded(px(3.0))
+                .bg(cx.theme().secondary)
+                .text_color(cx.theme().secondary_foreground)
+                .child("Global")
+                .into_any_element()
+        } else {
+            div().child(connection_name.clone()).into_any_element()
+        };
+        let description = item.description.clone();
+        let tags = item.tags.clone();
         let preview = item.definition.content.preview();
         let kind = item.definition.kind().label();
         let timestamp = format_timestamp(item.timestamp);
@@ -491,6 +782,19 @@ impl QueryLibraryDialog {
                                 .child(name),
                         )
                     })
+                    .when(!description.is_empty(), |this| {
+                        this.child(
+                            div()
+                                .text_xs()
+                                .text_color(cx.theme().secondary_foreground)
+                                .child(description),
+                        )
+                    })
+                    .when(!tags.is_empty(), |this| {
+                        this.child(div().text_xs().text_color(cx.theme().muted_foreground).child(
+                            tags.iter().map(|tag| format!("#{tag}")).collect::<Vec<_>>().join("  "),
+                        ))
+                    })
                     .child(
                         div()
                             .text_sm()
@@ -512,7 +816,7 @@ impl QueryLibraryDialog {
                             .text_color(cx.theme().muted_foreground)
                             .child(kind)
                             .child("·")
-                            .child(connection_name)
+                            .child(identity)
                             .child("·")
                             .child(namespace)
                             .child("·")
@@ -530,11 +834,18 @@ impl QueryLibraryDialog {
                         Button::new(("query-restore", index))
                             .compact()
                             .label("Restore")
-                            .disabled(!compatible)
-                            .tooltip(if compatible {
-                                "Restore without running"
+                            .disabled(!applicable)
+                            .tooltip(if applicable {
+                                if item.saved && item.scope == SavedQueryScope::Global {
+                                    format!("Restore into {target_identity}")
+                                } else {
+                                    "Restore without running".to_string()
+                                }
+                            } else if compatible {
+                                "Open this query's saved connection and namespace to restore"
+                                    .to_string()
                             } else {
-                                "Open the matching editor to restore"
+                                "Open the matching editor to restore".to_string()
                             })
                             .on_click({
                                 let item = item.clone();
@@ -551,8 +862,15 @@ impl QueryLibraryDialog {
                             .compact()
                             .primary()
                             .label("Run")
-                            .disabled(!compatible)
-                            .tooltip("Restore and run")
+                            .disabled(!applicable)
+                            .tooltip(if applicable {
+                                format!("Restore and run in {target_identity}")
+                            } else if compatible {
+                                "Open this query's saved connection and namespace to run"
+                                    .to_string()
+                            } else {
+                                "Open the matching editor to run".to_string()
+                            })
                             .on_click({
                                 let item = item.clone();
                                 let view = view.clone();
@@ -571,7 +889,12 @@ impl QueryLibraryDialog {
                                     view.update(cx, |this, cx| {
                                         this.start_edit(
                                             EditIntent::Save(save_definition.clone()),
-                                            String::new(),
+                                            EditValues {
+                                                name: String::new(),
+                                                description: String::new(),
+                                                tags: Vec::new(),
+                                                scope: SavedQueryScope::Connection,
+                                            },
                                             window,
                                             cx,
                                         );
@@ -582,29 +905,34 @@ impl QueryLibraryDialog {
                     })
                     .when(item.saved, |this| {
                         let name = item.name.clone().unwrap_or_default();
+                        let description = item.description.clone();
+                        let tags = item.tags.clone();
+                        let scope = item.scope;
                         this.child(
-                            Button::new(("query-rename", index))
-                                .compact()
-                                .label("Rename")
-                                .on_click({
-                                    let view = view.clone();
-                                    move |_, window, cx| {
-                                        view.update(cx, |this, cx| {
-                                            this.start_edit(
-                                                EditIntent::RenameSaved(item.id),
-                                                name.clone(),
-                                                window,
-                                                cx,
-                                            );
-                                        });
-                                    }
-                                }),
+                            Button::new(("query-edit", index)).compact().label("Edit").on_click({
+                                let view = view.clone();
+                                move |_, window, cx| {
+                                    view.update(cx, |this, cx| {
+                                        this.start_edit(
+                                            EditIntent::EditSaved(item.id),
+                                            EditValues {
+                                                name: name.clone(),
+                                                description: description.clone(),
+                                                tags: tags.clone(),
+                                                scope,
+                                            },
+                                            window,
+                                            cx,
+                                        );
+                                    });
+                                }
+                            }),
                         )
                         .child(
                             Button::new(("query-update", index))
                                 .compact()
                                 .label("Update")
-                                .disabled(!compatible || !can_update)
+                                .disabled(!applicable || !can_update)
                                 .tooltip("Replace this saved query with the current editor content")
                                 .on_click({
                                     let view = view.clone();
@@ -663,6 +991,11 @@ impl Render for QueryLibraryDialog {
         let current_definition = self.target.definition(self.state.read(cx));
         let can_save_current =
             current_definition.as_ref().is_some_and(|definition| !definition.content.is_empty());
+        let identity = self
+            .state
+            .read(cx)
+            .connection_by_id(self.target.connection_id())
+            .map(ConnectionIdentity::from);
         let view = cx.entity();
 
         let mut history_button = Button::new("query-library-history")
@@ -674,6 +1007,7 @@ impl Render for QueryLibraryDialog {
                     view.update(cx, |this, cx| {
                         this.mode = LibraryMode::History;
                         this.editing = None;
+                        this.pending_import = None;
                         this.confirm_clear = false;
                         this.confirm_delete = None;
                         cx.notify();
@@ -703,7 +1037,7 @@ impl Render for QueryLibraryDialog {
         }
 
         let mut current_button =
-            Button::new("query-library-current").compact().label("Current namespace").on_click({
+            Button::new("query-library-current").compact().label("Applicable here").on_click({
                 let view = view.clone();
                 move |_, _window, cx| {
                     view.update(cx, |this, cx| {
@@ -733,52 +1067,229 @@ impl Render for QueryLibraryDialog {
         let edit_panel = self.editing.as_ref().map(|intent| {
             let label = match intent {
                 EditIntent::Save(_) => "Save query",
-                EditIntent::RenameSaved(_) => "Rename query",
+                EditIntent::EditSaved(_) => "Edit saved query",
             };
+            let connection_selected = self.edit_scope == SavedQueryScope::Connection;
+            let global_selected = self.edit_scope == SavedQueryScope::Global;
+            let mut connection_scope = Button::new("query-scope-connection")
+                .compact()
+                .label(if connection_selected { "✓ This connection" } else { "This connection" })
+                .on_click({
+                    let view = view.clone();
+                    move |_, _window, cx| {
+                        view.update(cx, |this, cx| {
+                            this.edit_scope = SavedQueryScope::Connection;
+                            cx.notify();
+                        });
+                    }
+                });
+            let mut global_scope = Button::new("query-scope-global")
+                .compact()
+                .label(if global_selected { "✓ Global" } else { "Global" })
+                .tooltip("Available in any compatible editor")
+                .on_click({
+                    let view = view.clone();
+                    move |_, _window, cx| {
+                        view.update(cx, |this, cx| {
+                            this.edit_scope = SavedQueryScope::Global;
+                            cx.notify();
+                        });
+                    }
+                });
+            if self.edit_scope == SavedQueryScope::Connection {
+                connection_scope = connection_scope.primary();
+            } else {
+                global_scope = global_scope.primary();
+            }
             div()
                 .flex()
-                .items_end()
+                .flex_col()
                 .gap(spacing::sm())
                 .px(spacing::md())
                 .py(spacing::sm())
                 .bg(cx.theme().secondary.opacity(0.25))
                 .border_b_1()
                 .border_color(cx.theme().border)
+                .child(div().text_sm().font_weight(FontWeight::MEDIUM).child(label))
+                .child(
+                    div()
+                        .flex()
+                        .gap(spacing::sm())
+                        .child(
+                            div()
+                                .flex_1()
+                                .flex()
+                                .flex_col()
+                                .gap(px(3.0))
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .child("Name"),
+                                )
+                                .child(Input::new(&self.name_state).w_full()),
+                        )
+                        .child(
+                            div()
+                                .flex_1()
+                                .flex()
+                                .flex_col()
+                                .gap(px(3.0))
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .child("Description"),
+                                )
+                                .child(Input::new(&self.description_state).w_full()),
+                        ),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .items_end()
+                        .gap(spacing::sm())
+                        .child(
+                            div()
+                                .flex_1()
+                                .flex()
+                                .flex_col()
+                                .gap(px(3.0))
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .child("Tags"),
+                                )
+                                .child(Input::new(&self.tags_state).w_full()),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .flex_col()
+                                .gap(px(3.0))
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .child("Scope"),
+                                )
+                                .child(
+                                    div()
+                                        .flex()
+                                        .items_center()
+                                        .gap(spacing::xs())
+                                        .child(connection_scope)
+                                        .child(global_scope),
+                                ),
+                        )
+                        .child(
+                            Button::new("query-name-save")
+                                .compact()
+                                .primary()
+                                .label("Save")
+                                .on_click({
+                                    let view = view.clone();
+                                    move |_, window, cx| {
+                                        view.update(cx, |this, cx| this.commit_edit(window, cx));
+                                    }
+                                }),
+                        )
+                        .child(
+                            Button::new("query-name-cancel").compact().label("Cancel").on_click({
+                                let view = view.clone();
+                                move |_, window, cx| {
+                                    view.update(cx, |this, cx| {
+                                        this.editing = None;
+                                        this.error = None;
+                                        this.focus_search(window, cx);
+                                        cx.notify();
+                                    });
+                                }
+                            }),
+                        ),
+                )
+        });
+
+        let import_panel = self.pending_import.as_ref().map(|pending| {
+            let total = pending.inputs.len();
+            let connection_name =
+                connection_label(self.state.read(cx), self.target.connection_id());
+            div()
+                .track_focus(&self.import_focus)
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap(spacing::md())
+                .px(spacing::md())
+                .py(spacing::sm())
+                .bg(cx.theme().warning.opacity(0.08))
+                .border_b_1()
+                .border_color(cx.theme().warning.opacity(0.35))
                 .child(
                     div()
                         .flex()
                         .flex_col()
-                        .flex_1()
-                        .gap(spacing::xs())
-                        .child(div().text_sm().text_color(cx.theme().foreground).child(label))
-                        .child(Input::new(&self.name_state).w_full()),
+                        .gap(px(2.0))
+                        .child(
+                            div()
+                                .text_sm()
+                                .font_weight(FontWeight::MEDIUM)
+                                .child(format!("Import {total} saved queries?")),
+                        )
+                        .child(div().text_xs().text_color(cx.theme().secondary_foreground).child(
+                            format!(
+                                "{} global · {} bound to {} · {} name collisions renamed",
+                                pending.global,
+                                pending.connection,
+                                connection_name,
+                                pending.renamed
+                            ),
+                        )),
                 )
                 .child(
-                    Button::new("query-name-save")
-                        .compact()
-                        .primary()
-                        .label("Save query")
-                        .on_click({
-                            let view = view.clone();
-                            move |_, _window, cx| {
-                                view.update(cx, |this, cx| this.commit_edit(cx));
-                            }
-                        }),
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(spacing::xs())
+                        .child(
+                            Button::new("query-import-confirm")
+                                .compact()
+                                .primary()
+                                .label("Import")
+                                .on_click({
+                                    let view = view.clone();
+                                    move |_, window, cx| {
+                                        view.update(cx, |this, cx| {
+                                            this.confirm_import(window, cx);
+                                        });
+                                    }
+                                }),
+                        )
+                        .child(
+                            Button::new("query-import-cancel").compact().label("Cancel").on_click(
+                                {
+                                    let view = view.clone();
+                                    move |_, window, cx| {
+                                        view.update(cx, |this, cx| {
+                                            this.pending_import = None;
+                                            this.focus_search(window, cx);
+                                            cx.notify();
+                                        });
+                                    }
+                                },
+                            ),
+                        ),
                 )
-                .child(Button::new("query-name-cancel").compact().label("Cancel").on_click({
-                    let view = view.clone();
-                    move |_, _window, cx| {
-                        view.update(cx, |this, cx| {
-                            this.editing = None;
-                            this.error = None;
-                            cx.notify();
-                        });
-                    }
-                }))
         });
 
         let body = if items.is_empty() {
-            let message = if self.search_state.read(cx).value().trim().is_empty() {
+            let total = match self.mode {
+                LibraryMode::History => history_count,
+                LibraryMode::Saved => saved_count,
+            };
+            let searching = !self.search_state.read(cx).value().trim().is_empty();
+            let message = if total == 0 {
                 match self.mode {
                     LibraryMode::History => {
                         "No query history yet. Run a document query, aggregation, or Forge statement."
@@ -787,9 +1298,14 @@ impl Render for QueryLibraryDialog {
                         "No saved queries yet. Save the current editor or a useful History entry."
                     }
                 }
-            } else {
+            } else if searching {
                 "No queries match this search."
+            } else if self.show_all {
+                "No queries are compatible with this editor."
+            } else {
+                "No queries are applicable here."
             };
+            let show_all_offer = total > 0 && !self.show_all;
             div()
                 .flex()
                 .flex_col()
@@ -812,6 +1328,17 @@ impl Render for QueryLibraryDialog {
                         .text_color(cx.theme().muted_foreground)
                         .child("Query text stays local and entries that may contain credentials are not recorded."),
                 )
+                .when(show_all_offer, |empty| {
+                    empty.child(Button::new("query-empty-show-all").compact().label("Show all").on_click({
+                        let view = view.clone();
+                        move |_, _window, cx| {
+                            view.update(cx, |this, cx| {
+                                this.show_all = true;
+                                cx.notify();
+                            });
+                        }
+                    }))
+                })
                 .into_any_element()
         } else {
             div()
@@ -857,7 +1384,10 @@ impl Render for QueryLibraryDialog {
                         div()
                             .flex()
                             .items_center()
-                            .gap(spacing::xs())
+                            .gap(spacing::sm())
+                            .when_some(identity, |row, identity| {
+                                row.child(connection_identity_badge(&identity, true, cx))
+                            })
                             .child(current_button)
                             .child(all_button),
                     ),
@@ -877,6 +1407,33 @@ impl Render for QueryLibraryDialog {
                             .min_w(px(0.0))
                             .child(Input::new(&self.search_state).w_full()),
                     )
+                    .when(self.mode == LibraryMode::Saved, |row| {
+                        row.child(
+                            Button::new("query-library-import")
+                                .compact()
+                                .label(if self.file_busy { "Working…" } else { "Import…" })
+                                .disabled(self.file_busy)
+                                .on_click({
+                                    let view = view.clone();
+                                    move |_, window, cx| {
+                                        view.update(cx, |this, cx| this.start_import(window, cx));
+                                    }
+                                }),
+                        )
+                        .child(
+                            Button::new("query-library-export")
+                                .compact()
+                                .label("Export all…")
+                                .disabled(self.file_busy || saved_count == 0)
+                                .tooltip("Export all saved queries as portable JSON")
+                                .on_click({
+                                    let view = view.clone();
+                                    move |_, window, cx| {
+                                        view.update(cx, |this, cx| this.start_export(window, cx));
+                                    }
+                                }),
+                        )
+                    })
                     .child(
                         Button::new("query-save-current")
                             .compact()
@@ -891,7 +1448,12 @@ impl Render for QueryLibraryDialog {
                                     view.update(cx, |this, cx| {
                                         this.start_edit(
                                             EditIntent::Save(definition),
-                                            String::new(),
+                                            EditValues {
+                                                name: String::new(),
+                                                description: String::new(),
+                                                tags: Vec::new(),
+                                                scope: SavedQueryScope::Connection,
+                                            },
                                             window,
                                             cx,
                                         );
@@ -901,6 +1463,7 @@ impl Render for QueryLibraryDialog {
                     ),
             )
             .children(edit_panel)
+            .children(import_panel)
             .when_some(self.error.clone(), |this, error| {
                 this.child(
                     div()
@@ -986,6 +1549,16 @@ impl Render for QueryLibraryDialog {
                 )
             })
     }
+}
+
+fn query_applicable(
+    target: &QueryLibraryTarget,
+    saved: bool,
+    scope: SavedQueryScope,
+    definition: &QueryDefinition,
+) -> bool {
+    definition.kind() == target.kind()
+        && (saved && scope == SavedQueryScope::Global || target.matches_scope(definition))
 }
 
 fn parse_optional_document(raw: &str) -> Result<Option<mongodb::bson::Document>, String> {

--- a/src/components/unsaved_guard.rs
+++ b/src/components/unsaved_guard.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use gpui::*;
@@ -9,8 +9,9 @@ use gpui_component::dialog::Dialog;
 use uuid::Uuid;
 
 use crate::bson::parse_document_from_json;
-use crate::components::Button;
+use crate::components::{Button, with_scoped_production_authorizations};
 use crate::error::Error;
+use crate::models::ConnectionWriteIdentity;
 use crate::state::{
     AppCommands, AppEvent, AppState, EditorSession, EditorSessionTarget, StatusMessage,
     UnsavedChange, UnsavedInventory, UnsavedScope,
@@ -28,6 +29,21 @@ fn has_in_flight_editor_save(inventory: &UnsavedInventory) -> bool {
     inventory.changes.iter().any(|change| {
         matches!(change, UnsavedChange::DetachedEditor(EditorSession { save_in_flight: true, .. }))
     })
+}
+
+fn write_counts(inventory: &UnsavedInventory) -> HashMap<Uuid, usize> {
+    let mut counts = HashMap::new();
+    for change in &inventory.changes {
+        let session_key = match change {
+            UnsavedChange::InlineDocument { session_key, .. } => Some(session_key),
+            UnsavedChange::DetachedEditor(session) => Some(&session.session_key),
+            UnsavedChange::InvalidInlineEdit { .. } => None,
+        };
+        if let Some(session_key) = session_key {
+            *counts.entry(session_key.connection_id).or_default() += 1;
+        }
+    }
+    counts
 }
 
 pub fn request_app_quit(state: Entity<AppState>, window: &mut Window, cx: &mut App) {
@@ -155,10 +171,60 @@ fn open_unsaved_dialog(
     let cancel_focus = cx.focus_handle().tab_index(0).tab_stop(true);
     let save_focus = cx.focus_handle().tab_index(1).tab_stop(true);
     let discard_focus = cx.focus_handle().tab_index(2).tab_stop(true);
-    let message = format!(
+    let inventory = state.read(cx).unsaved_inventory(&scope);
+    let production_counts = write_counts(&inventory)
+        .into_iter()
+        .filter(|(connection_id, _)| {
+            state.read(cx).connection_requires_production_write_confirmation(*connection_id)
+        })
+        .collect::<HashMap<_, _>>();
+    let production_writes = production_counts
+        .iter()
+        .filter_map(|(connection_id, uses)| {
+            state
+                .read(cx)
+                .connection_by_id(*connection_id)
+                .map(|connection| (ConnectionWriteIdentity::from(connection), *uses))
+        })
+        .collect::<Vec<_>>();
+    let production_summaries = production_writes
+        .iter()
+        .map(|(identity, _)| {
+            let mut targets = inventory
+                .changes
+                .iter()
+                .filter_map(|change| {
+                    let session_key = match change {
+                        UnsavedChange::InlineDocument { session_key, .. }
+                        | UnsavedChange::InvalidInlineEdit { session_key } => session_key,
+                        UnsavedChange::DetachedEditor(session) => &session.session_key,
+                    };
+                    (session_key.connection_id == identity.id).then(|| session_key.namespace())
+                })
+                .collect::<Vec<_>>();
+            targets.sort();
+            targets.dedup();
+            format!(
+                "{} [{}]: {}",
+                identity.name,
+                identity
+                    .environment
+                    .map(crate::models::ConnectionEnvironment::label)
+                    .unwrap_or("Not set"),
+                targets.join(", ")
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut message = format!(
         "{count} unsaved change{} will be lost. Save changes, discard them, or cancel.",
         if count == 1 { "" } else { "s" }
     );
+    if !production_summaries.is_empty() {
+        message.push_str(&format!(
+            "\n\nProduction write confirmation:\n{}",
+            production_summaries.join("\n")
+        ));
+    }
 
     window.open_dialog(cx, move |dialog: Dialog, window, cx| {
         let dialog_state = window.use_keyed_state("unsaved-dialog-focus", cx, |_window, _cx| {
@@ -218,17 +284,54 @@ fn open_unsaved_dialog(
                                     let state = state.clone();
                                     let scope = scope.clone();
                                     let proceed = proceed.clone();
+                                    let production_writes = production_writes.clone();
                                     move |_, window, cx| {
+                                        let identities_match = production_writes.iter().all(
+                                            |(identity, _)| {
+                                                state
+                                                    .read(cx)
+                                                    .connection_by_id(identity.id)
+                                                    .is_some_and(|connection| identity.matches(connection))
+                                                    && state.read(cx).is_connected(identity.id)
+                                                    && !state.read(cx).connection_read_only(identity.id)
+                                                    && state
+                                                        .read(cx)
+                                                        .connection_requires_production_write_confirmation(identity.id)
+                                            },
+                                        );
+                                        if !identities_match {
+                                            state.update(cx, |state, cx| {
+                                                state.set_status_message(Some(StatusMessage::error(
+                                                    "Save blocked because a Production connection identity changed. Review again.",
+                                                )));
+                                                cx.notify();
+                                            });
+                                            return;
+                                        }
                                         window.close_dialog(cx);
                                         let Some(proceed) = proceed.borrow_mut().take() else {
                                             return;
                                         };
-                                        save_unsaved_changes(
-                                            state.clone(),
-                                            scope.clone(),
-                                            window.window_handle(),
-                                            proceed,
+                                        let grants = production_writes
+                                            .iter()
+                                            .map(|(identity, uses)| (identity.id, *uses))
+                                            .collect::<Vec<_>>();
+                                        let window_handle = window.window_handle();
+                                        let state_for_save = state.clone();
+                                        let scope_for_save = scope.clone();
+                                        with_scoped_production_authorizations(
+                                            &state,
+                                            &grants,
                                             cx,
+                                            move |cx| {
+                                                save_unsaved_changes(
+                                                    state_for_save,
+                                                    scope_for_save,
+                                                    window_handle,
+                                                    proceed,
+                                                    cx,
+                                                );
+                                            },
                                         );
                                     }
                                 }),
@@ -390,8 +493,9 @@ fn save_unsaved_changes(
 fn prepare_saves(
     state: &Entity<AppState>,
     inventory: UnsavedInventory,
-    cx: &App,
+    cx: &mut App,
 ) -> Result<Vec<PreparedSave>, Error> {
+    let required_authorizations = write_counts(&inventory);
     let mut prepared = Vec::new();
     let mut document_targets = HashSet::new();
     for change in inventory.changes {
@@ -451,6 +555,25 @@ fn prepare_saves(
             }
         }
     }
+    let protected = required_authorizations
+        .into_iter()
+        .filter(|(connection_id, _)| {
+            state.read(cx).connection_requires_production_write_confirmation(*connection_id)
+        })
+        .collect::<Vec<_>>();
+    let authorized = protected.iter().all(|(connection_id, uses)| {
+        state.read(cx).has_production_write_authorizations(*connection_id, *uses)
+    });
+    if !authorized {
+        return Err(Error::Parse(
+            "Production writes require confirmation before saving.".to_string(),
+        ));
+    }
+    state.update(cx, |state, _cx| {
+        for (connection_id, uses) in protected {
+            state.consume_production_write_authorizations(connection_id, uses);
+        }
+    });
     Ok(prepared)
 }
 

--- a/src/helpers/connection_io.rs
+++ b/src/helpers/connection_io.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 use crate::helpers::{
     UriSecrets, extract_uri_secrets, inject_uri_password, inject_uri_secrets, strip_uri_secrets,
 };
-use crate::models::{ConnectionColor, ProxyConfig, SavedConnection, SshConfig};
+use crate::models::{
+    ConnectionColor, ConnectionEnvironment, ProxyConfig, SavedConnection, SshConfig,
+};
 
 use super::crypto;
 
@@ -26,6 +28,10 @@ pub struct ExportedConnection {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<ConnectionColor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<ConnectionEnvironment>,
+    #[serde(default)]
+    pub confirm_production_writes: bool,
     pub uri: String,
     #[serde(default)]
     pub read_only: bool,
@@ -98,6 +104,8 @@ pub fn build_export(
             ExportMode::Redacted => ExportedConnection {
                 name: conn.name.clone(),
                 color: conn.color,
+                environment: conn.environment,
+                confirm_production_writes: conn.confirm_production_writes,
                 uri: strip_uri_secrets(&conn.uri),
                 read_only: conn.read_only,
                 encrypted_password: None,
@@ -121,6 +129,8 @@ pub fn build_export(
                 ExportedConnection {
                     name: conn.name.clone(),
                     color: conn.color,
+                    environment: conn.environment,
+                    confirm_production_writes: conn.confirm_production_writes,
                     uri: strip_uri_secrets(&conn.uri),
                     read_only: conn.read_only,
                     encrypted_password: encrypted,
@@ -191,6 +201,8 @@ pub fn resolve_import(
             };
             let mut conn = SavedConnection::new(name, ec.uri.clone());
             conn.color = ec.color;
+            conn.environment = ec.environment;
+            conn.confirm_production_writes = ec.confirm_production_writes;
             conn.read_only = ec.read_only;
             conn.ssh = ec.ssh.clone();
             conn.proxy = ec.proxy.clone();
@@ -257,6 +269,8 @@ mod tests {
                 id: Uuid::new_v4(),
                 name: "Local".into(),
                 color: Some(ConnectionColor::Red),
+                environment: Some(ConnectionEnvironment::Production),
+                confirm_production_writes: true,
                 uri: "mongodb://admin:secret@localhost:27017/?tlsCertificateKeyFilePassword=tls-secret&proxyPassword=uri-proxy-secret&authMechanismProperties=SERVICE_NAME%3Amongodb%2CAWS_SESSION_TOKEN%3Aaws-secret".into(),
                 last_connected: None,
                 read_only: false,
@@ -286,6 +300,8 @@ mod tests {
                 id: Uuid::new_v4(),
                 name: "Atlas".into(),
                 color: None,
+                environment: Some(ConnectionEnvironment::Staging),
+                confirm_production_writes: false,
                 uri: "mongodb+srv://user:pass@cluster0.abc.mongodb.net/mydb".into(),
                 last_connected: Some(Utc::now()),
                 read_only: true,
@@ -302,6 +318,8 @@ mod tests {
         let file = build_export(&conns, ExportMode::Redacted, None).unwrap();
         assert_eq!(file.mode, ExportMode::Redacted);
         assert_eq!(file.connections.len(), 2);
+        assert_eq!(file.connections[0].environment, Some(ConnectionEnvironment::Production));
+        assert!(file.connections[0].confirm_production_writes);
         for ec in &file.connections {
             assert!(!ec.uri.contains("secret"));
             assert!(!ec.uri.contains("pass"));
@@ -334,6 +352,8 @@ mod tests {
         let passphrase = "test-passphrase";
         let mut file = build_export(&conns, ExportMode::Encrypted, Some(passphrase)).unwrap();
         assert_eq!(file.mode, ExportMode::Encrypted);
+        assert_eq!(file.connections[0].environment, Some(ConnectionEnvironment::Production));
+        assert!(file.connections[0].confirm_production_writes);
         for ec in &file.connections {
             assert!(ec.encrypted_password.is_some());
             assert!(!ec.uri.contains("secret"));
@@ -409,6 +429,8 @@ mod tests {
             id: Uuid::new_v4(),
             name: "Local".into(),
             color: None,
+            environment: None,
+            confirm_production_writes: false,
             uri: "mongodb://localhost:27017".into(),
             last_connected: None,
             read_only: false,
@@ -426,6 +448,8 @@ mod tests {
                 ExportedConnection {
                     name: "Local".into(),
                     color: Some(ConnectionColor::Blue),
+                    environment: Some(ConnectionEnvironment::Production),
+                    confirm_production_writes: true,
                     uri: "mongodb://localhost:27017".into(),
                     read_only: false,
                     encrypted_password: None,
@@ -436,6 +460,8 @@ mod tests {
                 ExportedConnection {
                     name: "Atlas".into(),
                     color: None,
+                    environment: None,
+                    confirm_production_writes: false,
                     uri: "mongodb+srv://cluster0.abc.mongodb.net".into(),
                     read_only: true,
                     encrypted_password: None,
@@ -450,6 +476,8 @@ mod tests {
         assert_eq!(resolved.len(), 2);
         assert_eq!(resolved[0].name, "Local (imported)");
         assert_eq!(resolved[0].color, Some(ConnectionColor::Blue));
+        assert_eq!(resolved[0].environment, Some(ConnectionEnvironment::Production));
+        assert!(resolved[0].confirm_production_writes);
         assert_eq!(resolved[1].name, "Atlas");
         // New UUIDs
         assert_ne!(resolved[0].id, existing[0].id);
@@ -461,6 +489,8 @@ mod tests {
             id: Uuid::new_v4(),
             name: "NoAuth".into(),
             color: None,
+            environment: None,
+            confirm_production_writes: false,
             uri: "mongodb://localhost:27017".into(),
             last_connected: None,
             read_only: false,

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -3,6 +3,7 @@ pub mod connection_io;
 pub mod crypto;
 pub mod format;
 pub mod keystore;
+pub mod query_library_io;
 pub mod support;
 pub mod validate;
 

--- a/src/helpers/query_library_io.rs
+++ b/src/helpers/query_library_io.rs
@@ -1,0 +1,447 @@
+//! Portable saved-query import and export.
+
+use std::io::{Read as _, Write as _};
+use std::path::Path;
+
+use anyhow::{Context as _, Result, bail};
+use chrono::{DateTime, Utc};
+use mongodb::bson::{Bson, Document};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::bson::format_relaxed_json_compact;
+use crate::state::{QueryContent, QueryDefinition, SavedQuery, SavedQueryInput, SavedQueryScope};
+
+pub const CURRENT_VERSION: u32 = 1;
+pub const MAX_IMPORT_BYTES: u64 = 5 * 1024 * 1024;
+pub const MAX_IMPORT_QUERIES: usize = 1_000;
+const MAX_NAMESPACE_CHARS: usize = 255;
+const MAX_CONTENT_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QueryLibraryExportFile {
+    pub version: u32,
+    pub app: String,
+    pub exported_at: DateTime<Utc>,
+    pub queries: Vec<PortableSavedQuery>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortableSavedQuery {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub scope: SavedQueryScope,
+    pub database: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collection: Option<String>,
+    pub content: PortableQueryContent,
+}
+
+/// The portable Documents shape intentionally contains only executable BSON.
+/// Display text is regenerated from these documents during import, so a file
+/// cannot present one query while executing another.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortableDocumentQuery {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    filter: Option<Document>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sort: Option<Document>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    projection: Option<Document>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "query", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PortableQueryContent {
+    Documents(Box<PortableDocumentQuery>),
+    Aggregation {
+        stages: Vec<crate::state::app_state::PipelineStage>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        selected_stage: Option<usize>,
+    },
+    Forge {
+        statement: String,
+    },
+}
+
+impl PortableQueryContent {
+    fn from_saved(content: &QueryContent) -> Self {
+        match content {
+            QueryContent::Documents(query) => Self::Documents(Box::new(PortableDocumentQuery {
+                filter: query.filter.clone(),
+                sort: query.sort.clone(),
+                projection: query.projection.clone(),
+            })),
+            QueryContent::Aggregation { stages, selected_stage } => {
+                Self::Aggregation { stages: stages.clone(), selected_stage: *selected_stage }
+            }
+            QueryContent::Forge { statement } => Self::Forge { statement: statement.clone() },
+        }
+    }
+
+    fn into_query_content(self) -> QueryContent {
+        match self {
+            Self::Documents(query) => {
+                let filter_raw =
+                    query.filter.as_ref().map(canonical_document).unwrap_or_else(|| "{}".into());
+                let sort_raw = query.sort.as_ref().map(canonical_document).unwrap_or_default();
+                let projection_raw =
+                    query.projection.as_ref().map(canonical_document).unwrap_or_default();
+                QueryContent::Documents(Box::new(crate::state::DocumentQuery {
+                    filter_raw,
+                    filter: query.filter,
+                    sort_raw,
+                    sort: query.sort,
+                    projection_raw,
+                    projection: query.projection,
+                }))
+            }
+            Self::Aggregation { stages, selected_stage } => {
+                QueryContent::Aggregation { stages, selected_stage }
+            }
+            Self::Forge { statement } => QueryContent::Forge { statement },
+        }
+    }
+}
+
+impl PortableSavedQuery {
+    pub fn into_input(self, connection_id: Uuid) -> Result<SavedQueryInput> {
+        SavedQueryInput {
+            name: self.name,
+            description: self.description,
+            tags: self.tags,
+            scope: self.scope,
+            definition: QueryDefinition {
+                connection_id,
+                database: self.database.trim().to_string(),
+                collection: self.collection.map(|value| value.trim().to_string()),
+                content: self.content.into_query_content(),
+            },
+        }
+        .normalized()
+        .map_err(anyhow::Error::msg)
+    }
+
+    fn validate(&self) -> Result<()> {
+        validate_namespace("database", &self.database)?;
+        if let Some(collection) = self.collection.as_deref() {
+            validate_namespace("collection", collection)?;
+        }
+        let content_bytes = serde_json::to_vec(&self.content)?.len();
+        if content_bytes > MAX_CONTENT_BYTES {
+            bail!("saved query content exceeds the 1 MiB limit");
+        }
+        self.clone().into_input(Uuid::nil())?;
+        Ok(())
+    }
+}
+
+pub fn build_export(saved: &[SavedQuery]) -> Result<QueryLibraryExportFile> {
+    if saved.len() > MAX_IMPORT_QUERIES {
+        bail!("query library has too many saved queries to export");
+    }
+    let queries = saved
+        .iter()
+        .map(|query| PortableSavedQuery {
+            name: query.name.clone(),
+            description: query.description.clone(),
+            tags: query.tags.clone(),
+            scope: query.scope,
+            database: query.definition.database.clone(),
+            collection: query.definition.collection.clone(),
+            content: PortableQueryContent::from_saved(&query.definition.content),
+        })
+        .map(|query| {
+            query.validate()?;
+            Ok(query)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let file = QueryLibraryExportFile {
+        version: CURRENT_VERSION,
+        app: "openmango".to_string(),
+        exported_at: Utc::now(),
+        queries,
+    };
+    encoded_export(&file)?;
+    Ok(file)
+}
+
+pub fn parse_import(json: &str) -> Result<QueryLibraryExportFile> {
+    if json.len() as u64 > MAX_IMPORT_BYTES {
+        bail!("query library file exceeds the 5 MiB limit");
+    }
+    let file: QueryLibraryExportFile =
+        serde_json::from_str(json).context("invalid query library JSON")?;
+    if file.app != "openmango" {
+        bail!("this is not an OpenMango query library file");
+    }
+    if file.version != CURRENT_VERSION {
+        bail!(
+            "unsupported query library version {} (supported: {})",
+            file.version,
+            CURRENT_VERSION
+        );
+    }
+    if file.queries.is_empty() {
+        bail!("query library file contains no saved queries");
+    }
+    if file.queries.len() > MAX_IMPORT_QUERIES {
+        bail!("query library file contains more than {MAX_IMPORT_QUERIES} saved queries");
+    }
+    for query in &file.queries {
+        query.validate()?;
+    }
+    Ok(file)
+}
+
+pub fn read_import(path: &Path) -> Result<QueryLibraryExportFile> {
+    let file =
+        std::fs::File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut bytes = Vec::new();
+    file.take(MAX_IMPORT_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_IMPORT_BYTES {
+        bail!("query library file exceeds the 5 MiB limit");
+    }
+    let json = String::from_utf8(bytes).context("query library file must be UTF-8")?;
+    parse_import(&json)
+}
+
+pub fn write_export(path: &Path, file: &QueryLibraryExportFile) -> Result<()> {
+    let json = encoded_export(file)?;
+    let dir = path.parent().unwrap_or(path);
+    let mut temp = tempfile::NamedTempFile::new_in(dir)
+        .with_context(|| format!("failed to create export beside {}", path.display()))?;
+    temp.write_all(&json)?;
+    temp.flush()?;
+    temp.persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+fn encoded_export(file: &QueryLibraryExportFile) -> Result<Vec<u8>> {
+    let json = serde_json::to_vec_pretty(file)?;
+    if json.len() as u64 > MAX_IMPORT_BYTES {
+        bail!("query library export exceeds the 5 MiB limit");
+    }
+    Ok(json)
+}
+
+fn canonical_document(document: &Document) -> String {
+    format_relaxed_json_compact(&Bson::Document(document.clone()).into_relaxed_extjson())
+}
+
+fn validate_namespace(label: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("saved query {label} cannot be empty");
+    }
+    if value.chars().count() > MAX_NAMESPACE_CHARS {
+        bail!("saved query {label} exceeds {MAX_NAMESPACE_CHARS} characters");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use mongodb::bson::doc;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::state::{DocumentQuery, QueryLibrary};
+
+    fn saved_query(scope: SavedQueryScope, content: QueryContent) -> SavedQuery {
+        let mut library = QueryLibrary::default();
+        let id = library
+            .save_input(SavedQueryInput {
+                name: "Active users".into(),
+                description: "Reusable account query".into(),
+                tags: vec!["accounts".into(), "active".into()],
+                scope,
+                definition: QueryDefinition {
+                    connection_id: Uuid::new_v4(),
+                    database: "app".into(),
+                    collection: Some("users".into()),
+                    content,
+                },
+            })
+            .unwrap();
+        library.saved_query(id).unwrap().clone()
+    }
+
+    fn document_query() -> SavedQuery {
+        saved_query(
+            SavedQueryScope::Global,
+            QueryContent::Documents(Box::new(DocumentQuery {
+                filter_raw: "status = active".into(),
+                filter: Some(doc! { "status": "active" }),
+                sort_raw: "{ createdAt: -1 }".into(),
+                sort: Some(doc! { "createdAt": -1 }),
+                projection_raw: String::new(),
+                projection: None,
+            })),
+        )
+    }
+
+    #[test]
+    fn portable_round_trip_omits_local_identity_and_canonicalizes_documents() {
+        let connection_id = Uuid::new_v4();
+        let mut query = document_query();
+        query.definition.connection_id = connection_id;
+
+        let file = build_export(&[query]).unwrap();
+        let json = serde_json::to_string_pretty(&file).unwrap();
+        assert!(!json.contains(&connection_id.to_string()));
+        assert!(!json.contains("filter_raw"));
+        assert!(!json.contains("created_at"));
+        assert!(!json.contains("updated_at"));
+        assert!(!json.contains("history"));
+
+        let parsed = parse_import(&json).unwrap();
+        let input = parsed.queries.into_iter().next().unwrap().into_input(Uuid::nil()).unwrap();
+        let QueryContent::Documents(query) = input.definition.content else {
+            panic!("expected Documents query");
+        };
+        assert_eq!(query.filter, Some(doc! { "status": "active" }));
+        assert!(query.filter_raw.contains("active"));
+        assert!(!query.filter_raw.contains("status = active"));
+    }
+
+    #[test]
+    fn rejects_document_display_execution_mismatch_fields() {
+        let file = build_export(&[document_query()]).unwrap();
+        let mut value = serde_json::to_value(file).unwrap();
+        value["queries"][0]["content"]["query"]["filter_raw"] =
+            serde_json::Value::String("{ role: 'admin' }".into());
+        assert!(parse_import(&serde_json::to_string(&value).unwrap()).is_err());
+    }
+
+    #[test]
+    fn all_query_kinds_round_trip() {
+        let queries = vec![
+            document_query(),
+            saved_query(
+                SavedQueryScope::Global,
+                QueryContent::Aggregation {
+                    stages: vec![crate::state::app_state::PipelineStage {
+                        operator: "$match".into(),
+                        body: "{ active: true }".into(),
+                        enabled: true,
+                    }],
+                    selected_stage: Some(0),
+                },
+            ),
+            saved_query(
+                SavedQueryScope::Connection,
+                QueryContent::Forge { statement: "db.users.find({})".into() },
+            ),
+        ];
+        let json = serde_json::to_string(&build_export(&queries).unwrap()).unwrap();
+        let parsed = parse_import(&json).unwrap();
+        assert_eq!(parsed.queries.len(), 3);
+        assert!(matches!(parsed.queries[0].content, PortableQueryContent::Documents(_)));
+        assert!(matches!(parsed.queries[1].content, PortableQueryContent::Aggregation { .. }));
+        assert!(matches!(parsed.queries[2].content, PortableQueryContent::Forge { .. }));
+    }
+
+    #[test]
+    fn rejects_wrong_envelope_credentials_and_invalid_stage() {
+        let query = saved_query(
+            SavedQueryScope::Connection,
+            QueryContent::Forge { statement: "db.users.find({})".into() },
+        );
+        let mut file = build_export(&[query]).unwrap();
+        file.version = CURRENT_VERSION + 1;
+        assert!(parse_import(&serde_json::to_string(&file).unwrap()).is_err());
+        file.version = CURRENT_VERSION;
+        file.app = "other".into();
+        assert!(parse_import(&serde_json::to_string(&file).unwrap()).is_err());
+        file.app = "openmango".into();
+        file.queries[0].content =
+            PortableQueryContent::Forge { statement: "db.auth('admin', 'secret')".into() };
+        assert!(parse_import(&serde_json::to_string(&file).unwrap()).is_err());
+
+        let mut legacy = saved_query(
+            SavedQueryScope::Connection,
+            QueryContent::Forge { statement: "db.users.find({})".into() },
+        );
+        legacy.description = "AWS_ACCESS_KEY_ID : secret-value".into();
+        assert!(build_export(&[legacy]).is_err());
+
+        let mut aggregation = saved_query(
+            SavedQueryScope::Global,
+            QueryContent::Aggregation {
+                stages: vec![crate::state::app_state::PipelineStage {
+                    operator: "$match".into(),
+                    body: "{}".into(),
+                    enabled: true,
+                }],
+                selected_stage: Some(0),
+            },
+        );
+        if let QueryContent::Aggregation { selected_stage, .. } =
+            &mut aggregation.definition.content
+        {
+            *selected_stage = Some(2);
+        }
+        assert!(build_export(&[aggregation]).is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_empty_oversized_and_non_utf8_files() {
+        assert!(parse_import("not json").is_err());
+        let empty = QueryLibraryExportFile {
+            version: CURRENT_VERSION,
+            app: "openmango".into(),
+            exported_at: Utc::now(),
+            queries: Vec::new(),
+        };
+        assert!(parse_import(&serde_json::to_string(&empty).unwrap()).is_err());
+        assert!(parse_import(&" ".repeat(MAX_IMPORT_BYTES as usize + 1)).is_err());
+
+        let dir = TempDir::new().unwrap();
+        let oversized = dir.path().join("oversized.json");
+        std::fs::write(&oversized, vec![b' '; MAX_IMPORT_BYTES as usize + 2]).unwrap();
+        assert!(read_import(&oversized).is_err());
+        let invalid = dir.path().join("invalid.json");
+        std::fs::write(&invalid, [0xff, 0xfe]).unwrap();
+        assert!(read_import(&invalid).is_err());
+    }
+
+    #[test]
+    fn export_size_limit_is_enforced_before_writing() {
+        let base = saved_query(
+            SavedQueryScope::Global,
+            QueryContent::Forge { statement: "x".repeat(900_000) },
+        );
+        let queries = (0..6)
+            .map(|index| {
+                let mut query = base.clone();
+                query.id = Uuid::new_v4();
+                query.name = format!("Large {index}");
+                query
+            })
+            .collect::<Vec<_>>();
+        assert!(build_export(&queries).is_err());
+    }
+
+    #[test]
+    fn atomic_export_replaces_complete_destination() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("queries.json");
+        std::fs::write(&path, b"old").unwrap();
+        let query = saved_query(
+            SavedQueryScope::Connection,
+            QueryContent::Forge { statement: "db.users.find({})".into() },
+        );
+        write_export(&path, &build_export(&[query]).unwrap()).unwrap();
+        assert!(parse_import(&std::fs::read_to_string(path).unwrap()).is_ok());
+    }
+}

--- a/src/models/connection.rs
+++ b/src/models/connection.rs
@@ -141,6 +141,26 @@ impl ConnectionColor {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionEnvironment {
+    Development,
+    Staging,
+    Production,
+}
+
+impl ConnectionEnvironment {
+    pub const ALL: [Self; 3] = [Self::Development, Self::Staging, Self::Production];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Development => "Development",
+            Self::Staging => "Staging",
+            Self::Production => "Production",
+        }
+    }
+}
+
 /// A saved connection configuration (persisted to disk)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedConnection {
@@ -148,6 +168,10 @@ pub struct SavedConnection {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<ConnectionColor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<ConnectionEnvironment>,
+    #[serde(default)]
+    pub confirm_production_writes: bool,
     pub uri: String,
     pub last_connected: Option<DateTime<Utc>>,
     #[serde(default)]
@@ -160,12 +184,64 @@ pub struct SavedConnection {
     pub secret_id: Option<Uuid>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ConnectionTransportIdentity {
+    pub ssh: Option<SshConfig>,
+    pub proxy: Option<ProxyConfig>,
+    pub secret_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionWriteIdentity {
+    pub id: Uuid,
+    pub name: String,
+    pub uri: String,
+    pub color: Option<ConnectionColor>,
+    pub environment: Option<ConnectionEnvironment>,
+    pub confirm_production_writes: bool,
+    pub read_only: bool,
+    pub transport: Box<ConnectionTransportIdentity>,
+}
+
+impl ConnectionWriteIdentity {
+    pub fn matches(&self, connection: &SavedConnection) -> bool {
+        self == &Self::from(connection)
+    }
+
+    pub fn requires_production_confirmation(&self) -> bool {
+        self.environment == Some(ConnectionEnvironment::Production)
+            && self.confirm_production_writes
+    }
+}
+
+impl From<&SavedConnection> for ConnectionWriteIdentity {
+    fn from(connection: &SavedConnection) -> Self {
+        let stripped = connection.with_secrets_stripped();
+        Self {
+            id: stripped.id,
+            name: stripped.name,
+            uri: stripped.uri,
+            color: stripped.color,
+            environment: stripped.environment,
+            confirm_production_writes: stripped.confirm_production_writes,
+            read_only: stripped.read_only,
+            transport: Box::new(ConnectionTransportIdentity {
+                ssh: stripped.ssh,
+                proxy: stripped.proxy,
+                secret_id: stripped.secret_id,
+            }),
+        }
+    }
+}
+
 impl SavedConnection {
     pub fn new(name: String, uri: String) -> Self {
         Self {
             id: Uuid::new_v4(),
             name,
             color: None,
+            environment: None,
+            confirm_production_writes: false,
             uri,
             last_connected: None,
             read_only: false,
@@ -173,6 +249,11 @@ impl SavedConnection {
             proxy: None,
             secret_id: None,
         }
+    }
+
+    pub fn requires_production_write_confirmation(&self) -> bool {
+        self.environment == Some(ConnectionEnvironment::Production)
+            && self.confirm_production_writes
     }
 
     /// Return a copy with all secrets removed (for disk persistence).
@@ -200,4 +281,69 @@ pub struct ActiveConnection {
     /// Collections per database (db_name -> collection_names)
     pub collections: HashMap<String, Vec<String>>,
     pub runtime_meta: ConnectionRuntimeMeta,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn environment_is_explicit_and_legacy_safe() {
+        let legacy = serde_json::json!({
+            "id": Uuid::new_v4(),
+            "name": "prod-looking-host",
+            "uri": "mongodb://prod.example.test",
+            "last_connected": null
+        });
+        let connection: SavedConnection = serde_json::from_value(legacy).unwrap();
+        assert_eq!(connection.environment, None);
+        assert!(!connection.confirm_production_writes);
+        assert!(!connection.requires_production_write_confirmation());
+
+        let mut connection =
+            SavedConnection::new("not-production-by-name".into(), "mongodb://localhost".into());
+        connection.confirm_production_writes = true;
+        for environment in
+            [None, Some(ConnectionEnvironment::Development), Some(ConnectionEnvironment::Staging)]
+        {
+            connection.environment = environment;
+            assert!(!connection.requires_production_write_confirmation());
+        }
+        connection.environment = Some(ConnectionEnvironment::Production);
+        assert!(connection.requires_production_write_confirmation());
+    }
+
+    #[test]
+    fn environments_round_trip_with_stable_values() {
+        for (environment, expected) in [
+            (ConnectionEnvironment::Development, "\"development\""),
+            (ConnectionEnvironment::Staging, "\"staging\""),
+            (ConnectionEnvironment::Production, "\"production\""),
+        ] {
+            let json = serde_json::to_string(&environment).unwrap();
+            assert_eq!(json, expected);
+            assert_eq!(serde_json::from_str::<ConnectionEnvironment>(&json).unwrap(), environment);
+        }
+    }
+
+    #[test]
+    fn write_identity_rejects_endpoint_or_label_changes() {
+        let mut connection =
+            SavedConnection::new("Production".into(), "mongodb://localhost/app".into());
+        connection.environment = Some(ConnectionEnvironment::Production);
+        connection.confirm_production_writes = true;
+        let identity = ConnectionWriteIdentity::from(&connection);
+        assert!(identity.matches(&connection));
+
+        connection.name = "Renamed".into();
+        assert!(!identity.matches(&connection));
+        connection.name = "Production".into();
+        connection.uri = "mongodb://other-host/app".into();
+        assert!(!identity.matches(&connection));
+
+        connection.uri = "mongodb://localhost/app".into();
+        connection.ssh =
+            Some(SshConfig { enabled: true, host: "jump.example".into(), ..Default::default() });
+        assert!(!identity.matches(&connection));
+    }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,7 +5,7 @@ pub mod connection;
 mod tree_node_id;
 
 pub use connection::{
-    ActiveConnection, ConnectionColor, ConnectionRuntimeMeta, ProxyConfig, ProxyKind,
-    SavedConnection, SshAuth, SshConfig,
+    ActiveConnection, ConnectionColor, ConnectionEnvironment, ConnectionRuntimeMeta,
+    ConnectionWriteIdentity, ProxyConfig, ProxyKind, SavedConnection, SshAuth, SshConfig,
 };
 pub use tree_node_id::TreeNodeId;

--- a/src/state/app_state/connection.rs
+++ b/src/state/app_state/connection.rs
@@ -142,7 +142,71 @@ impl AppState {
     }
 
     pub fn connection_read_only(&self, connection_id: Uuid) -> bool {
-        self.conn.active.get(&connection_id).map(|conn| conn.config.read_only).unwrap_or(false)
+        self.conn.active.get(&connection_id).map(|conn| conn.config.read_only).unwrap_or_else(
+            || self.connection_by_id(connection_id).is_some_and(|connection| connection.read_only),
+        )
+    }
+
+    pub fn connection_requires_production_write_confirmation(&self, connection_id: Uuid) -> bool {
+        self.connection_by_id(connection_id)
+            .is_some_and(SavedConnection::requires_production_write_confirmation)
+    }
+
+    pub fn authorize_production_writes(&mut self, connection_id: Uuid, uses: usize) {
+        if uses > 0 {
+            *self.production_write_authorizations.entry(connection_id).or_default() += uses;
+        }
+    }
+
+    pub fn authorize_next_production_write(&mut self, connection_id: Uuid) {
+        self.authorize_production_writes(connection_id, 1);
+    }
+
+    pub(crate) fn has_production_write_authorizations(
+        &self,
+        connection_id: Uuid,
+        uses: usize,
+    ) -> bool {
+        self.production_write_authorizations.get(&connection_id).copied().unwrap_or(0) >= uses
+    }
+
+    pub(crate) fn revoke_production_write_authorizations(
+        &mut self,
+        connection_id: Uuid,
+        uses: usize,
+    ) {
+        let Some(remaining) = self.production_write_authorizations.get_mut(&connection_id) else {
+            return;
+        };
+        *remaining = remaining.saturating_sub(uses);
+        if *remaining == 0 {
+            self.production_write_authorizations.remove(&connection_id);
+        }
+    }
+
+    pub(crate) fn consume_production_write_authorizations(
+        &mut self,
+        connection_id: Uuid,
+        uses: usize,
+    ) -> bool {
+        if uses == 0 {
+            return true;
+        }
+        let Some(remaining) = self.production_write_authorizations.get_mut(&connection_id) else {
+            return false;
+        };
+        if *remaining < uses {
+            return false;
+        }
+        *remaining -= uses;
+        if *remaining == 0 {
+            self.production_write_authorizations.remove(&connection_id);
+        }
+        true
+    }
+
+    pub(crate) fn consume_production_write_authorization(&mut self, connection_id: Uuid) -> bool {
+        self.consume_production_write_authorizations(connection_id, 1)
     }
 
     pub fn is_connected(&self, connection_id: Uuid) -> bool {
@@ -358,10 +422,10 @@ impl AppState {
 
     fn finish_update_connection(&mut self, connection: SavedConnection, cx: &mut Context<Self>) {
         let mut updated = false;
-        let mut uri_changed = false;
+        let mut transport_changed = false;
         for existing in &mut self.connections {
             if existing.id == connection.id {
-                uri_changed = existing.uri != connection.uri;
+                transport_changed = connection_transport_changed(existing, &connection);
                 *existing = connection.clone();
                 updated = true;
                 break;
@@ -377,7 +441,7 @@ impl AppState {
 
         if let Some(active) = self.conn.active.get_mut(&connection.id) {
             active.config = connection.clone();
-            if uri_changed {
+            if transport_changed {
                 self.connection_manager().disconnect(connection.id);
                 self.conn.active.remove(&connection.id);
                 self.reset_connection_runtime_state(connection.id, cx);
@@ -688,6 +752,10 @@ impl AppState {
     // Disconnect functionality is not wired yet.
 }
 
+fn connection_transport_changed(existing: &SavedConnection, updated: &SavedConnection) -> bool {
+    existing.uri != updated.uri || existing.ssh != updated.ssh || existing.proxy != updated.proxy
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -710,6 +778,34 @@ mod tests {
 
         assert_eq!(state.take_connections_waiting_for_secrets(), vec![connection_id]);
         assert!(state.connections_waiting_for_secret_sync.is_empty());
+    }
+
+    #[test]
+    fn connection_transport_changes_require_a_new_client() {
+        let connection = SavedConnection::new("Local".into(), "mongodb://localhost".into());
+        let mut updated = connection.clone();
+        updated.name = "Renamed".into();
+        updated.color = Some(crate::models::ConnectionColor::Blue);
+        assert!(!connection_transport_changed(&connection, &updated));
+
+        updated.ssh = Some(crate::models::SshConfig {
+            enabled: true,
+            host: "jump.example".into(),
+            ..Default::default()
+        });
+        assert!(connection_transport_changed(&connection, &updated));
+
+        updated = connection.clone();
+        updated.proxy = Some(crate::models::ProxyConfig {
+            enabled: true,
+            host: "proxy.example".into(),
+            ..Default::default()
+        });
+        assert!(connection_transport_changed(&connection, &updated));
+
+        updated = connection.clone();
+        updated.uri = "mongodb://remote".into();
+        assert!(connection_transport_changed(&connection, &updated));
     }
 
     #[test]

--- a/src/state/app_state/mod.rs
+++ b/src/state/app_state/mod.rs
@@ -110,6 +110,7 @@ pub struct AppState {
     keybinding_capture: Option<KeybindingCapture>,
     unsaved_guard_active: bool,
     invalid_inline_edits: HashSet<SessionKey>,
+    production_write_authorizations: HashMap<Uuid, usize>,
 
     /// Copied tree item for paste operation (internal clipboard)
     pub copied_tree_item: Option<CopiedTreeItem>,
@@ -217,6 +218,7 @@ impl AppState {
             keybinding_capture: None,
             unsaved_guard_active: false,
             invalid_inline_edits: HashSet::new(),
+            production_write_authorizations: HashMap::new(),
             copied_tree_item: None,
             config,
             connections_persistence_blocked: connection_load_error.is_some(),

--- a/src/state/app_state/query_library.rs
+++ b/src/state/app_state/query_library.rs
@@ -2,8 +2,9 @@ use anyhow::{Result, anyhow};
 use uuid::Uuid;
 
 use crate::state::{
-    CollectionSubview, ForgeTabKey, QueryContent, QueryDefinition, QueryHistoryEntry, QueryLibrary,
-    QueryLibraryPersistenceError, SavedQuery, SessionKey,
+    CollectionSubview, ForgeTabKey, QueryContent, QueryDefinition, QueryHistoryEntry,
+    QueryImportReport, QueryLibrary, QueryLibraryPersistenceError, SavedQuery, SavedQueryInput,
+    SessionKey,
 };
 
 use super::AppState;
@@ -38,6 +39,43 @@ impl AppState {
 
     pub fn save_query(&mut self, definition: QueryDefinition, name: &str) -> Result<Uuid> {
         self.update_query_library(|library| library.save(definition, name))
+    }
+
+    pub fn save_query_input(&mut self, input: SavedQueryInput) -> Result<Uuid> {
+        self.update_query_library(|library| library.save_input(input))
+    }
+
+    pub fn edit_saved_query(&mut self, id: Uuid, input: SavedQueryInput) -> Result<()> {
+        self.update_query_library(|library| library.edit_saved(id, input))
+    }
+
+    pub fn preview_saved_query_import(
+        &self,
+        inputs: &[SavedQueryInput],
+    ) -> Result<QueryImportReport> {
+        self.query_library.preview_import(inputs).map_err(anyhow::Error::msg)
+    }
+
+    pub fn import_saved_queries(
+        &mut self,
+        inputs: Vec<SavedQueryInput>,
+    ) -> Result<QueryImportReport> {
+        if self.query_library_persistence_blocked {
+            return Err(QueryLibraryPersistenceError(
+                "Saved queries were not imported because query_library.json is invalid. Fix or remove the file, then restart OpenMango."
+                    .to_string(),
+            )
+            .into());
+        }
+        let mut next = self.query_library.clone();
+        let report = next.import_saved(inputs).map_err(anyhow::Error::msg)?;
+        self.config.save_query_library(&next).map_err(|error| {
+            QueryLibraryPersistenceError(format!(
+                "Saved queries were not imported because the library could not be saved: {error}"
+            ))
+        })?;
+        self.query_library = next;
+        Ok(report)
     }
 
     pub fn update_saved_query(&mut self, id: Uuid, definition: QueryDefinition) -> Result<()> {
@@ -232,6 +270,27 @@ mod tests {
         assert_eq!(aggregation.stages, stages);
         assert_eq!(aggregation.selected_stage, Some(0));
         assert_eq!(state.session_subview(&key), Some(CollectionSubview::Aggregation));
+    }
+
+    #[test]
+    fn blocked_persistence_rejects_import_without_mutating_memory() {
+        let mut state = AppState::new();
+        state.query_library_persistence_blocked = true;
+        let before = state.query_library.clone();
+        let result = state.import_saved_queries(vec![SavedQueryInput {
+            name: "Users".into(),
+            description: String::new(),
+            tags: Vec::new(),
+            scope: crate::state::SavedQueryScope::Connection,
+            definition: QueryDefinition {
+                connection_id: Uuid::new_v4(),
+                database: "app".into(),
+                collection: None,
+                content: QueryContent::Forge { statement: "db.users.find({})".into() },
+            },
+        }]);
+        assert!(result.is_err());
+        assert_eq!(state.query_library, before);
     }
 
     #[test]

--- a/src/state/app_state/types.rs
+++ b/src/state/app_state/types.rs
@@ -84,6 +84,10 @@ impl SessionKey {
     ) -> Self {
         Self { connection_id, database: database.into(), collection: collection.into() }
     }
+
+    pub fn namespace(&self) -> String {
+        format!("{}.{}", self.database, self.collection)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/state/commands/collections.rs
+++ b/src/state/commands/collections.rs
@@ -20,6 +20,17 @@ impl AppCommands {
         let Some(conn_id) = connection_id else {
             return;
         };
+        Self::create_collection_authorized(state, conn_id, database, collection, cx);
+    }
+
+    pub(super) fn create_collection_authorized(
+        state: Entity<AppState>,
+        conn_id: Uuid,
+        database: String,
+        collection: String,
+        cx: &mut App,
+    ) {
+        let connection_id = Some(conn_id);
         let Some(client) = Self::active_client(&state, conn_id, cx) else {
             return;
         };

--- a/src/state/commands/databases.rs
+++ b/src/state/commands/databases.rs
@@ -15,11 +15,13 @@ impl AppCommands {
         collection: String,
         cx: &mut App,
     ) {
-        let connection_id = state.read(cx).selected_connection_id();
-        if !Self::ensure_writable(&state, connection_id, cx) {
+        let Some(connection_id) = state.read(cx).selected_connection_id() else {
+            return;
+        };
+        if !Self::ensure_writable(&state, Some(connection_id), cx) {
             return;
         }
-        Self::create_collection(state, database, collection, cx);
+        Self::create_collection_authorized(state, connection_id, database, collection, cx);
     }
 
     /// Drop a database.

--- a/src/state/commands/mod.rs
+++ b/src/state/commands/mod.rs
@@ -14,17 +14,32 @@ impl AppCommands {
         connection_id: Option<Uuid>,
         cx: &mut App,
     ) -> bool {
-        let read_only =
-            connection_id.map(|id| state.read(cx).connection_read_only(id)).unwrap_or(false);
-        if read_only {
+        let Some(connection_id) = connection_id else {
+            return true;
+        };
+        if state.read(cx).connection_read_only(connection_id) {
             state.update(cx, |state, cx| {
                 state.set_status_message(Some(StatusMessage::error(
                     "Read-only connection: writes are disabled.",
                 )));
                 cx.notify();
             });
+            return false;
         }
-        !read_only
+        if !state.read(cx).connection_requires_production_write_confirmation(connection_id) {
+            return true;
+        }
+        let authorized = state
+            .update(cx, |state, _cx| state.consume_production_write_authorization(connection_id));
+        if !authorized {
+            state.update(cx, |state, cx| {
+                state.set_status_message(Some(StatusMessage::error(
+                    "Production write blocked: review and confirm this operation first.",
+                )));
+                cx.notify();
+            });
+        }
+        authorized
     }
 
     pub(super) fn active_client(
@@ -59,3 +74,31 @@ pub use schema::{schema_to_compass, schema_to_json_schema, schema_to_summary};
 mod stats;
 mod transfer;
 mod updater;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{ConnectionEnvironment, SavedConnection};
+
+    #[test]
+    fn production_write_authorization_is_explicit_and_one_shot() {
+        let mut state = AppState::new();
+        state.connections.clear();
+        let mut connection =
+            SavedConnection::new("prod-looking-host".into(), "mongodb://localhost".into());
+        connection.environment = Some(ConnectionEnvironment::Production);
+        connection.confirm_production_writes = true;
+        let connection_id = connection.id;
+        state.connections.push(connection);
+
+        assert!(state.connection_requires_production_write_confirmation(connection_id));
+        assert!(!state.consume_production_write_authorization(connection_id));
+        state.authorize_next_production_write(connection_id);
+        assert!(state.consume_production_write_authorization(connection_id));
+        assert!(!state.consume_production_write_authorization(connection_id));
+
+        state.authorize_next_production_write(connection_id);
+        state.revoke_production_write_authorizations(connection_id, 1);
+        assert!(!state.consume_production_write_authorization(connection_id));
+    }
+}

--- a/src/state/config.rs
+++ b/src/state/config.rs
@@ -248,6 +248,38 @@ mod tests {
     }
 
     #[test]
+    fn legacy_query_library_defaults_saved_metadata() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let manager = ConfigManager::with_config_dir(temp_dir.path().to_path_buf());
+        let now = chrono::Utc::now();
+        let fixture = serde_json::json!({
+            "history": [],
+            "saved": [{
+                "id": uuid::Uuid::new_v4(),
+                "name": "Legacy",
+                "created_at": now,
+                "updated_at": now,
+                "definition": {
+                    "connection_id": uuid::Uuid::new_v4(),
+                    "database": "app",
+                    "content": { "type": "forge", "query": { "statement": "db.users.find({})" } }
+                }
+            }]
+        });
+        fs::write(
+            temp_dir.path().join(ConfigManager::QUERY_LIBRARY_FILE),
+            serde_json::to_vec_pretty(&fixture).unwrap(),
+        )
+        .unwrap();
+
+        let loaded = manager.load_query_library().unwrap();
+        assert_eq!(loaded.saved().len(), 1);
+        assert_eq!(loaded.saved()[0].description, "");
+        assert!(loaded.saved()[0].tags.is_empty());
+        assert_eq!(loaded.saved()[0].scope, crate::state::SavedQueryScope::Connection);
+    }
+
+    #[test]
     fn malformed_query_library_is_left_untouched() {
         let temp_dir = TempDir::new().expect("failed to create temp dir");
         let manager = ConfigManager::with_config_dir(temp_dir.path().to_path_buf());
@@ -265,8 +297,10 @@ mod tests {
         let manager = ConfigManager::with_config_dir(temp_dir.path().to_path_buf());
         fs::create_dir_all(temp_dir.path()).expect("failed to create config dir");
 
-        let connection =
+        let mut connection =
             SavedConnection::new("json".to_string(), "mongodb://localhost:27017".into());
+        connection.environment = Some(crate::models::ConnectionEnvironment::Production);
+        connection.confirm_production_writes = true;
         fs::write(
             temp_dir.path().join(ConfigManager::CONNECTIONS_FILE),
             serde_json::to_string_pretty(&vec![connection.clone()])
@@ -277,5 +311,7 @@ mod tests {
         let loaded = manager.load_connections().expect("failed to load json connections");
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].name, connection.name);
+        assert_eq!(loaded[0].environment, connection.environment);
+        assert!(loaded[0].confirm_production_writes);
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -32,8 +32,8 @@ pub use editor_sessions::{
 };
 pub use events::AppEvent;
 pub use query_library::{
-    DocumentQuery, QueryContent, QueryDefinition, QueryHistoryEntry, QueryKind, QueryLibrary,
-    QueryLibraryPersistenceError, SavedQuery,
+    DocumentQuery, QueryContent, QueryDefinition, QueryHistoryEntry, QueryImportReport, QueryKind,
+    QueryLibrary, QueryLibraryPersistenceError, SavedQuery, SavedQueryInput, SavedQueryScope,
 };
 pub use settings::{
     AppSettings, AppTheme, AppearanceSettings, DATABASE_SCOPE_FILENAME_TEMPLATE,
@@ -44,6 +44,7 @@ pub use settings::{
 pub use status::{StatusLevel, StatusMessage};
 pub use transfer_rules::{
     TransferValidation, available_transfer_formats, coerce_transfer_format,
-    parse_export_query_document, resolved_export_destination, validate_transfer,
+    parse_export_query_document, resolved_export_destination, transfer_write_connection,
+    validate_transfer,
 };
 pub use workspace::{WindowMode, WindowState, WorkspaceState, WorkspaceTab, WorkspaceTabKind};

--- a/src/state/query_library.rs
+++ b/src/state/query_library.rs
@@ -6,6 +6,10 @@ use uuid::Uuid;
 use crate::state::app_state::PipelineStage;
 
 pub const QUERY_HISTORY_LIMIT: usize = 200;
+pub const QUERY_NAME_LIMIT: usize = 80;
+pub const QUERY_DESCRIPTION_LIMIT: usize = 500;
+pub const QUERY_TAG_LIMIT: usize = 20;
+pub const QUERY_TAG_LENGTH_LIMIT: usize = 30;
 
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
@@ -193,16 +197,90 @@ pub struct QueryHistoryEntry {
     pub definition: QueryDefinition,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SavedQueryScope {
+    Global,
+    #[default]
+    Connection,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SavedQueryInput {
+    pub name: String,
+    pub description: String,
+    pub tags: Vec<String>,
+    pub scope: SavedQueryScope,
+    pub definition: QueryDefinition,
+}
+
+impl SavedQueryInput {
+    pub fn normalized(mut self) -> Result<Self, String> {
+        self.name = validate_name(&self.name)?.to_string();
+        self.description = self.description.trim().to_string();
+        if self.description.chars().count() > QUERY_DESCRIPTION_LIMIT {
+            return Err(format!(
+                "Query descriptions must be {QUERY_DESCRIPTION_LIMIT} characters or fewer."
+            ));
+        }
+        self.tags = normalize_tags(self.tags)?;
+        validate_metadata(&self.name, &self.description, &self.tags)?;
+        validate_definition(&self.definition)?;
+        Ok(self)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SavedQuery {
     pub id: Uuid,
     pub name: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub scope: SavedQueryScope,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub definition: QueryDefinition,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+impl SavedQuery {
+    pub fn matches_scope(
+        &self,
+        kind: QueryKind,
+        connection_id: Uuid,
+        database: &str,
+        collection: Option<&str>,
+    ) -> bool {
+        if self.definition.kind() != kind {
+            return false;
+        }
+        self.scope == SavedQueryScope::Global
+            || self.definition.matches_scope(kind, connection_id, database, collection)
+    }
+
+    pub fn matches_search(&self, query: &str) -> bool {
+        let query = query.trim().to_ascii_lowercase();
+        query.is_empty()
+            || self.name.to_ascii_lowercase().contains(&query)
+            || self.description.to_ascii_lowercase().contains(&query)
+            || self.tags.iter().any(|tag| tag.to_ascii_lowercase().contains(&query))
+            || self.definition.kind().label().to_ascii_lowercase().contains(&query)
+            || self.definition.namespace().to_ascii_lowercase().contains(&query)
+            || self.definition.content.copy_text().to_ascii_lowercase().contains(&query)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QueryImportReport {
+    pub imported: usize,
+    pub renamed: usize,
+    pub global: usize,
+    pub connection: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct QueryLibrary {
     #[serde(default)]
     history: Vec<QueryHistoryEntry>,
@@ -257,38 +335,80 @@ impl QueryLibrary {
     }
 
     pub fn save(&mut self, definition: QueryDefinition, name: &str) -> Result<Uuid, String> {
-        validate_definition(&definition)?;
-        let name = validate_name(name)?;
-        if self.saved.iter().any(|query| query.name.eq_ignore_ascii_case(name)) {
-            return Err(format!("A saved query named \"{name}\" already exists."));
+        self.save_input(SavedQueryInput {
+            name: name.to_string(),
+            description: String::new(),
+            tags: Vec::new(),
+            scope: SavedQueryScope::Connection,
+            definition,
+        })
+    }
+
+    pub fn save_input(&mut self, input: SavedQueryInput) -> Result<Uuid, String> {
+        let input = input.normalized()?;
+        if self.saved.iter().any(|query| query.name.eq_ignore_ascii_case(&input.name)) {
+            return Err(format!("A saved query named \"{}\" already exists.", input.name));
         }
         let id = Uuid::new_v4();
         let now = Utc::now();
         self.saved.push(SavedQuery {
             id,
-            name: name.to_string(),
+            name: input.name,
+            description: input.description,
+            tags: input.tags,
+            scope: input.scope,
             created_at: now,
             updated_at: now,
-            definition,
+            definition: input.definition,
         });
         self.sort_saved();
         Ok(id)
     }
 
     pub fn update_saved(&mut self, id: Uuid, definition: QueryDefinition) -> Result<(), String> {
-        validate_definition(&definition)?;
+        let source = self
+            .saved_query(id)
+            .cloned()
+            .ok_or_else(|| "That saved query no longer exists.".to_string())?;
+        self.edit_saved(
+            id,
+            SavedQueryInput {
+                name: source.name,
+                description: source.description,
+                tags: source.tags,
+                scope: source.scope,
+                definition,
+            },
+        )
+    }
+
+    pub fn edit_saved(&mut self, id: Uuid, input: SavedQueryInput) -> Result<(), String> {
+        let input = input.normalized()?;
+        if self
+            .saved
+            .iter()
+            .any(|query| query.id != id && query.name.eq_ignore_ascii_case(&input.name))
+        {
+            return Err(format!("A saved query named \"{}\" already exists.", input.name));
+        }
         let query = self
             .saved
             .iter_mut()
             .find(|query| query.id == id)
             .ok_or_else(|| "That saved query no longer exists.".to_string())?;
-        query.definition = definition;
+        query.name = input.name;
+        query.description = input.description;
+        query.tags = input.tags;
+        query.scope = input.scope;
+        query.definition = input.definition;
         query.updated_at = Utc::now();
+        self.sort_saved();
         Ok(())
     }
 
     pub fn rename_saved(&mut self, id: Uuid, name: &str) -> Result<(), String> {
         let name = validate_name(name)?;
+        validate_metadata(name, "", &[])?;
         if self.saved.iter().any(|query| query.id != id && query.name.eq_ignore_ascii_case(name)) {
             return Err(format!("A saved query named \"{name}\" already exists."));
         }
@@ -323,12 +443,64 @@ impl QueryLibrary {
         self.saved.push(SavedQuery {
             id,
             name,
+            description: source.description,
+            tags: source.tags,
+            scope: source.scope,
             created_at: now,
             updated_at: now,
             definition: source.definition,
         });
         self.sort_saved();
         Ok(id)
+    }
+
+    pub fn preview_import(&self, inputs: &[SavedQueryInput]) -> Result<QueryImportReport, String> {
+        let mut preview = self.clone();
+        preview.import_saved(inputs.to_vec())
+    }
+
+    pub fn import_saved(
+        &mut self,
+        inputs: Vec<SavedQueryInput>,
+    ) -> Result<QueryImportReport, String> {
+        let mut normalized =
+            inputs.into_iter().map(SavedQueryInput::normalized).collect::<Result<Vec<_>, _>>()?;
+        let mut names = self
+            .saved
+            .iter()
+            .map(|query| query.name.to_ascii_lowercase())
+            .collect::<std::collections::HashSet<_>>();
+        let mut renamed = 0;
+        for input in &mut normalized {
+            if names.contains(&input.name.to_ascii_lowercase()) {
+                input.name = available_import_name(&input.name, &names);
+                renamed += 1;
+            }
+            names.insert(input.name.to_ascii_lowercase());
+        }
+
+        let mut report =
+            QueryImportReport { imported: normalized.len(), renamed, ..Default::default() };
+        for input in normalized {
+            match input.scope {
+                SavedQueryScope::Global => report.global += 1,
+                SavedQueryScope::Connection => report.connection += 1,
+            }
+            let id = Uuid::new_v4();
+            let now = Utc::now();
+            self.saved.push(SavedQuery {
+                id,
+                name: input.name,
+                description: input.description,
+                tags: input.tags,
+                scope: input.scope,
+                created_at: now,
+                updated_at: now,
+                definition: input.definition,
+            });
+        }
+        self.sort_saved();
+        Ok(report)
     }
 
     pub fn delete_saved(&mut self, id: Uuid) -> bool {
@@ -351,6 +523,12 @@ impl QueryLibrary {
 }
 
 fn validate_definition(definition: &QueryDefinition) -> Result<(), String> {
+    if let QueryContent::Aggregation { stages, selected_stage: Some(selected_stage) } =
+        &definition.content
+        && *selected_stage >= stages.len()
+    {
+        return Err("The selected aggregation stage is outside the pipeline.".to_string());
+    }
     if definition.content.is_empty() {
         Err("Enter a query before saving it.".to_string())
     } else if definition.content.may_contain_credentials() {
@@ -364,10 +542,56 @@ fn validate_name(name: &str) -> Result<&str, String> {
     let name = name.trim();
     if name.is_empty() {
         Err("Enter a name for this query.".to_string())
-    } else if name.chars().count() > 80 {
-        Err("Query names must be 80 characters or fewer.".to_string())
+    } else if name.chars().count() > QUERY_NAME_LIMIT {
+        Err(format!("Query names must be {QUERY_NAME_LIMIT} characters or fewer."))
     } else {
         Ok(name)
+    }
+}
+
+fn normalize_tags(tags: Vec<String>) -> Result<Vec<String>, String> {
+    let mut normalized = Vec::new();
+    for tag in tags {
+        let tag = tag.trim();
+        if tag.is_empty() || normalized.iter().any(|saved: &String| saved.eq_ignore_ascii_case(tag))
+        {
+            continue;
+        }
+        if tag.chars().count() > QUERY_TAG_LENGTH_LIMIT {
+            return Err(format!(
+                "Query tags must be {QUERY_TAG_LENGTH_LIMIT} characters or fewer."
+            ));
+        }
+        normalized.push(tag.to_string());
+        if normalized.len() > QUERY_TAG_LIMIT {
+            return Err(format!("Queries can have at most {QUERY_TAG_LIMIT} tags."));
+        }
+    }
+    Ok(normalized)
+}
+
+fn validate_metadata(name: &str, description: &str, tags: &[String]) -> Result<(), String> {
+    if std::iter::once(name)
+        .chain(std::iter::once(description))
+        .chain(tags.iter().map(String::as_str))
+        .any(may_contain_credentials)
+    {
+        Err("Query metadata that may contain credentials cannot be saved.".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn available_import_name(source: &str, names: &std::collections::HashSet<String>) -> String {
+    let mut number = 1;
+    loop {
+        let suffix =
+            if number == 1 { " Imported".to_string() } else { format!(" Imported {number}") };
+        let candidate = copy_name(source, &suffix);
+        if !names.contains(&candidate.to_ascii_lowercase()) {
+            return candidate;
+        }
+        number += 1;
     }
 }
 
@@ -393,10 +617,27 @@ fn copy_name(source: &str, suffix: &str) -> String {
 
 fn may_contain_credentials(raw: &str) -> bool {
     let lower = raw.to_ascii_lowercase();
-    [
+    if [
         "mongodb://",
         "mongodb+srv://",
-        "db.auth",
+        "db.auth(",
+        "db.auth (",
+        "db.createuser(",
+        "db.updateuser(",
+        "db.changeuserpassword(",
+        "bearer ",
+        "-----begin private key-----",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+    {
+        return true;
+    }
+
+    [
+        "authenticate",
+        "saslstart",
+        "saslcontinue",
         "createuser",
         "updateuser",
         "changeuserpassword",
@@ -407,20 +648,57 @@ fn may_contain_credentials(raw: &str) -> bool {
         "secret",
         "credential",
         "api_key",
+        "api key",
         "apikey",
         "access_key",
+        "access key",
         "accesskey",
         "access_token",
         "auth_token",
         "token",
         "authorization",
-        "bearer ",
+        "bearer",
         "client_secret",
+        "client secret",
         "private_key",
+        "private key",
         "privatekey",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "nonce",
     ]
     .iter()
-    .any(|needle| lower.contains(needle))
+    .any(|key| contains_sensitive_assignment(&lower, key))
+}
+
+fn contains_sensitive_assignment(raw: &str, key: &str) -> bool {
+    raw.match_indices(key).any(|(start, _)| {
+        let end = start + key.len();
+        let before_is_word = raw[..start]
+            .chars()
+            .next_back()
+            .is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_');
+        let after_is_word =
+            raw[end..].chars().next().is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_');
+        if before_is_word || after_is_word {
+            return false;
+        }
+
+        let tail = &raw[end..];
+        let trimmed = tail
+            .trim_start_matches(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\'' | '`'));
+        let separated_by_whitespace = tail.len() != tail.trim_start().len();
+        trimmed.starts_with(':')
+            || trimmed.starts_with('=')
+            || trimmed.starts_with("->")
+            || trimmed.starts_with("=>")
+            || (separated_by_whitespace
+                && trimmed
+                    .chars()
+                    .next()
+                    .is_some_and(|ch| !matches!(ch, '.' | ',' | ')' | ']' | '}' | ';')))
+    })
 }
 
 #[cfg(test)]
@@ -460,11 +738,18 @@ mod tests {
             "db.auth('user', 'secret-value')",
             "db.createUser({ user: 'admin', pwd : 'secret-value' })",
             "db.tokens.find({ bearer: 'secret-value' })",
+            "db.users.find({ token: 'secret-value' })",
+            "db.runCommand({ authenticate: 1, user: 'admin', nonce: 'n', key: 'k' })",
             "const privateKey = 'secret-value'",
         ] {
             assert!(!library.record(forge_definition(statement)), "recorded {statement}");
         }
         assert!(library.history().is_empty());
+        assert!(library.record(forge_definition("db.tokens.find({ active: true })")));
+        assert!(library.record(forge_definition("db.secretsArchive.find({ active: true })")));
+        assert!(library.record(forge_definition("db.authTokens.find({ active: true })")));
+        assert!(library.record(forge_definition("db.createUsersAudit.find({ active: true })")));
+        assert_eq!(library.history().len(), 4);
         assert!(
             library
                 .save(forge_definition("db.auth('user', 'secret-value')"), "Credentials")
@@ -516,5 +801,152 @@ mod tests {
 
         assert_eq!(library.saved_query(copy_id).unwrap().name.chars().count(), 80);
         assert!(library.saved_query(copy_id).unwrap().name.ends_with(" Copy"));
+    }
+
+    #[test]
+    fn legacy_saved_query_defaults_metadata_and_connection_scope() {
+        let now = Utc::now();
+        let json = serde_json::json!({
+            "id": Uuid::new_v4(),
+            "name": "Legacy",
+            "created_at": now,
+            "updated_at": now,
+            "definition": forge_definition("db.users.find({})")
+        });
+        let saved: SavedQuery = serde_json::from_value(json).unwrap();
+        assert_eq!(saved.description, "");
+        assert!(saved.tags.is_empty());
+        assert_eq!(saved.scope, SavedQueryScope::Connection);
+    }
+
+    #[test]
+    fn metadata_is_normalized_searchable_and_global_across_namespaces() {
+        let mut library = QueryLibrary::default();
+        let id = library
+            .save_input(SavedQueryInput {
+                name: "  Active users  ".into(),
+                description: "  Accounts needing review  ".into(),
+                tags: vec![" Team ".into(), "team".into(), "Review".into()],
+                scope: SavedQueryScope::Global,
+                definition: forge_definition("db.users.find({ active: true })"),
+            })
+            .unwrap();
+        let saved = library.saved_query(id).unwrap();
+        assert_eq!(saved.name, "Active users");
+        assert_eq!(saved.description, "Accounts needing review");
+        assert_eq!(saved.tags, ["Team", "Review"]);
+        assert!(saved.matches_search("review"));
+        assert!(saved.matches_scope(QueryKind::Forge, Uuid::new_v4(), "other", None));
+        assert!(!saved.matches_scope(QueryKind::Documents, Uuid::new_v4(), "other", None));
+
+        let mut duplicate = saved.clone();
+        duplicate.scope = SavedQueryScope::Connection;
+        assert!(!duplicate.matches_scope(QueryKind::Forge, Uuid::new_v4(), "other", None));
+    }
+
+    #[test]
+    fn import_resolves_all_collisions_and_is_all_or_nothing() {
+        let mut library = QueryLibrary::default();
+        library.save(forge_definition("db.a.find({})"), "Users").unwrap();
+        let input = |name: &str, statement: &str| SavedQueryInput {
+            name: name.into(),
+            description: String::new(),
+            tags: Vec::new(),
+            scope: SavedQueryScope::Connection,
+            definition: forge_definition(statement),
+        };
+
+        let report = library
+            .import_saved(vec![input("Users", "db.b.find({})"), input("users", "db.c.find({})")])
+            .unwrap();
+        assert_eq!(report.imported, 2);
+        assert_eq!(report.renamed, 2);
+        assert!(library.saved().iter().any(|query| query.name == "Users Imported"));
+        assert!(library.saved().iter().any(|query| query.name == "users Imported 2"));
+
+        let before = library.clone();
+        assert!(
+            library
+                .import_saved(vec![
+                    input("Valid", "db.valid.find({})"),
+                    input("Unsafe", "db.auth('admin', 'secret-value')"),
+                ])
+                .is_err()
+        );
+        assert_eq!(library, before);
+    }
+
+    #[test]
+    fn metadata_limits_and_explicit_secret_assignments_are_rejected() {
+        let input = |description: String, tags: Vec<String>| SavedQueryInput {
+            name: "Users".into(),
+            description,
+            tags,
+            scope: SavedQueryScope::Connection,
+            definition: forge_definition("db.users.find({})"),
+        };
+        for secret in [
+            "password = hunter2",
+            "credential: hunter2",
+            "private_key -> hunter2",
+            "AWS_ACCESS_KEY_ID : AKIA123",
+            "aws_secret_access_key=>secret-value",
+            "token abc123",
+            "password hunter2",
+            "-----BEGIN PRIVATE KEY-----",
+        ] {
+            assert!(input(secret.into(), vec![]).normalized().is_err(), "accepted {secret}");
+        }
+        assert!(input("x".repeat(QUERY_DESCRIPTION_LIMIT + 1), vec![]).normalized().is_err());
+        assert!(
+            input(
+                String::new(),
+                (0..=QUERY_TAG_LIMIT).map(|index| format!("tag-{index}")).collect(),
+            )
+            .normalized()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn invalid_aggregation_selection_is_rejected() {
+        let input = SavedQueryInput {
+            name: "Invalid pipeline".into(),
+            description: String::new(),
+            tags: Vec::new(),
+            scope: SavedQueryScope::Global,
+            definition: QueryDefinition {
+                connection_id: Uuid::nil(),
+                database: "app".into(),
+                collection: Some("users".into()),
+                content: QueryContent::Aggregation {
+                    stages: vec![PipelineStage {
+                        operator: "$match".into(),
+                        body: "{}".into(),
+                        enabled: true,
+                    }],
+                    selected_stage: Some(1),
+                },
+            },
+        };
+        assert!(input.normalized().is_err());
+    }
+
+    #[test]
+    fn import_preview_uses_the_same_collision_resolver_without_mutation() {
+        let mut library = QueryLibrary::default();
+        library.save(forge_definition("db.a.find({})"), "Users").unwrap();
+        let input = SavedQueryInput {
+            name: "Users".into(),
+            description: String::new(),
+            tags: Vec::new(),
+            scope: SavedQueryScope::Connection,
+            definition: forge_definition("db.b.find({})"),
+        };
+        let before = library.clone();
+        let preview = library.preview_import(&[input]).unwrap();
+        assert_eq!(preview.imported, 1);
+        assert_eq!(preview.renamed, 1);
+        assert_eq!(library, before);
     }
 }

--- a/src/state/transfer_rules.rs
+++ b/src/state/transfer_rules.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use mongodb::bson::Document;
+use uuid::Uuid;
 
 use crate::bson::parse_document_from_json;
 use crate::state::app_state::{
@@ -51,6 +52,14 @@ pub fn coerce_transfer_format(
         format
     } else {
         default_transfer_format(mode, scope)
+    }
+}
+
+pub fn transfer_write_connection(tab: &TransferTabState) -> Option<Uuid> {
+    match tab.config.mode {
+        TransferMode::Import => tab.config.source_connection_id,
+        TransferMode::Copy => tab.config.destination_connection_id,
+        TransferMode::Export => None,
     }
 }
 
@@ -462,6 +471,22 @@ mod tests {
 
         assert!(validation.can_run());
         assert!(validation.requires_confirmation);
+    }
+
+    #[test]
+    fn transfer_write_target_uses_import_target_and_copy_destination() {
+        let source = Uuid::new_v4();
+        let destination = Uuid::new_v4();
+        let mut tab = TransferTabState::default();
+        tab.config.source_connection_id = Some(source);
+        tab.config.destination_connection_id = Some(destination);
+
+        tab.config.mode = TransferMode::Export;
+        assert_eq!(transfer_write_connection(&tab), None);
+        tab.config.mode = TransferMode::Import;
+        assert_eq!(transfer_write_connection(&tab), Some(source));
+        tab.config.mode = TransferMode::Copy;
+        assert_eq!(transfer_write_connection(&tab), Some(destination));
     }
 
     #[test]

--- a/src/views/ai.rs
+++ b/src/views/ai.rs
@@ -475,10 +475,13 @@ impl AiView {
                 let client = s.active_connection_client(id)?;
                 let db = s.selected_database_name()?;
                 let col = s.selected_collection_name();
+                let write_identity =
+                    crate::models::ConnectionWriteIdentity::from(s.connection_by_id(id)?);
                 Some(MongoContext {
                     client,
                     database: db,
                     collection: col,
+                    write_identity,
                     read_only: s.connection_read_only(id),
                     event_tx: None,
                 })
@@ -2289,6 +2292,7 @@ fn handle_stream_event(state: &mut AppState, message_id: Uuid, event: StreamEven
             description,
             tier,
             preview,
+            write_identity,
             response_tx,
         } => {
             state.ai_chat.set_tool_awaiting_confirmation(
@@ -2296,6 +2300,7 @@ fn handle_stream_event(state: &mut AppState, message_id: Uuid, event: StreamEven
                 description,
                 tier,
                 preview,
+                write_identity,
                 response_tx,
             );
         }
@@ -2337,6 +2342,39 @@ fn is_danger_tool(tool_name: &str) -> bool {
     matches!(tool_name, "update_documents" | "delete_documents" | "drop_index")
 }
 
+fn ai_write_identity_is_current(
+    state: &AppState,
+    write_identity: &crate::models::ConnectionWriteIdentity,
+) -> bool {
+    state
+        .connection_by_id(write_identity.id)
+        .is_some_and(|connection| write_identity.matches(connection))
+        && !state.connection_read_only(write_identity.id)
+}
+
+fn approve_ai_tool_confirmation(
+    state: &Entity<AppState>,
+    write_identity: &crate::models::ConnectionWriteIdentity,
+    response_tx: &crate::ai::safety::ConfirmationSender,
+    activity_id: Uuid,
+    cx: &mut App,
+) {
+    let allowed = state.read(cx).is_connected(write_identity.id)
+        && ai_write_identity_is_current(state.read(cx), write_identity);
+    response_tx.respond(allowed);
+    state.update(cx, |state, cx| {
+        if allowed {
+            state.ai_chat.approve_tool_confirmation(activity_id);
+        } else {
+            state.ai_chat.reject_tool_confirmation(activity_id);
+            state.set_status_message(Some(crate::state::StatusMessage::error(
+                "AI write blocked because the connection identity changed. Review it again.",
+            )));
+        }
+        cx.notify();
+    });
+}
+
 fn render_confirmation_card(
     activity: &ToolActivity,
     state: Entity<AppState>,
@@ -2347,12 +2385,14 @@ fn render_confirmation_card(
         ref description,
         ref tier,
         ref preview,
+        ref write_identity,
         ref response_tx,
     } = activity.status
     else {
         unreachable!();
     };
     let activity_id = activity.id;
+    let identity = crate::components::ConnectionIdentity::from(write_identity);
     let tool_name = &activity.tool_name;
     let is_blocked = matches!(tier, SafetyTier::Blocked);
     let danger = is_blocked || is_danger_tool(tool_name);
@@ -2382,28 +2422,34 @@ fn render_confirmation_card(
     let reject_tx = response_tx.clone();
     let approve_state = state.clone();
     let reject_state = state;
+    let approve_identity = write_identity.clone();
 
     let confirm_id: SharedString = format!("confirm-{activity_id}").into();
     let cancel_id: SharedString = format!("cancel-{activity_id}").into();
 
     let confirm_button = if danger {
         Button::new(confirm_id).danger().compact().label(confirm_label).on_click(move |_, _, cx| {
-            approve_tx.respond(true);
-            approve_state.update(cx, |s, cx| {
-                s.ai_chat.approve_tool_confirmation(activity_id);
-                cx.notify();
-            });
+            approve_ai_tool_confirmation(
+                &approve_state,
+                &approve_identity,
+                &approve_tx,
+                activity_id,
+                cx,
+            );
         })
     } else {
-        Button::new(confirm_id).primary().compact().label(confirm_label).on_click(
+        Button::new(confirm_id).primary().compact().label(confirm_label).on_click({
+            let approve_identity = approve_identity.clone();
             move |_, _, cx| {
-                approve_tx.respond(true);
-                approve_state.update(cx, |s, cx| {
-                    s.ai_chat.approve_tool_confirmation(activity_id);
-                    cx.notify();
-                });
-            },
-        )
+                approve_ai_tool_confirmation(
+                    &approve_state,
+                    &approve_identity,
+                    &approve_tx,
+                    activity_id,
+                    cx,
+                );
+            }
+        })
     };
 
     let cancel_button =
@@ -2487,6 +2533,11 @@ fn render_confirmation_card(
                     .text_color(summary_color)
                     .child(summary),
             ),
+        )
+        .child(
+            div()
+                .mt(spacing::xs())
+                .child(crate::components::connection_identity_badge(&identity, true, cx)),
         )
         .children(blocked_reason)
         .children(sample_preview)
@@ -2718,6 +2769,22 @@ fn download_report_as_excel(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[::core::prelude::v1::test]
+    fn ai_confirmation_uses_captured_connection_identity() {
+        let mut state = AppState::new();
+        state.connections.clear();
+        let connection = crate::models::SavedConnection::new(
+            "Production".into(),
+            "mongodb://localhost/app".into(),
+        );
+        let identity = crate::models::ConnectionWriteIdentity::from(&connection);
+        state.connections.push(connection);
+        assert!(ai_write_identity_is_current(&state, &identity));
+
+        state.connections[0].name = "Other".into();
+        assert!(!ai_write_identity_is_current(&state, &identity));
+    }
 
     #[::core::prelude::v1::test]
     fn coalesce_stream_events_merges_adjacent_text_chunks() {

--- a/src/views/documents/actions.rs
+++ b/src/views/documents/actions.rs
@@ -5,7 +5,7 @@ use crate::bson::{
     PathSegment, bson_value_for_edit, document_to_shell_string, format_relaxed_json_value,
     get_bson_at_path,
 };
-use crate::components::open_confirm_dialog;
+use crate::components::{WriteConfirmation, open_confirm_dialog, request_connection_write};
 use crate::keyboard::{
     AddElement, AddField, ClearAggregationStage, CloseSearch, CopyAs, CopyAsCsv, CopyAsJson,
     CopyAsJsonLines, CopyAsMarkdown, CopyAsTsv, CopyDocumentJson, CopyKey, CopyValue, CreateIndex,
@@ -110,7 +110,7 @@ impl CollectionView {
                 cx,
             );
         }))
-        .on_action(cx.listener(|this, _: &DuplicateDocument, _window, cx| {
+        .on_action(cx.listener(|this, _: &DuplicateDocument, window, cx| {
             let Some((session_key, _doc_key, doc)) = this.selected_document_for_current_session(cx)
             else {
                 return;
@@ -126,7 +126,23 @@ impl CollectionView {
             }
             let mut new_doc = doc.clone();
             new_doc.insert("_id", ObjectId::new());
-            AppCommands::insert_document(this.state.clone(), session_key, new_doc, cx);
+            let state = this.state.clone();
+            let state_for_write = state.clone();
+            let target = session_key.namespace();
+            request_connection_write(
+                state,
+                crate::components::WriteRequest::new(
+                    session_key.connection_id,
+                    target,
+                    "Insert a duplicated document",
+                    None,
+                ),
+                window,
+                cx,
+                move |_window, cx| {
+                    AppCommands::insert_document(state_for_write, session_key, new_doc, cx);
+                },
+            );
         }))
         .on_action(cx.listener(|this, _: &DeleteDocument, window, cx| {
             let Some(session_key) = this.view_model.current_session() else {
@@ -145,18 +161,27 @@ impl CollectionView {
             if selected_docs.len() == 1 {
                 let doc_key = selected_docs.into_iter().next().unwrap();
                 let message = format!("Delete document {}? This cannot be undone.", doc_key);
-                open_confirm_dialog(window, cx, "Delete document", message, "Delete", true, {
-                    let state = this.state.clone();
-                    let session_key = session_key.clone();
+                let state = this.state.clone();
+                let state_for_write = state.clone();
+                request_connection_write(
+                    state,
+                    crate::components::WriteRequest::new(
+                        session_key.connection_id,
+                        session_key.namespace(),
+                        "Delete a document",
+                        Some(WriteConfirmation {
+                            title: "Delete document".into(),
+                            message,
+                            confirm_label: "Delete".into(),
+                            destructive: true,
+                        }),
+                    ),
+                    window,
+                    cx,
                     move |_window, cx| {
-                        AppCommands::delete_document(
-                            state.clone(),
-                            session_key.clone(),
-                            doc_key.clone(),
-                            cx,
-                        );
-                    }
-                });
+                        AppCommands::delete_document(state_for_write, session_key, doc_key, cx);
+                    },
+                );
             } else {
                 let ids: Vec<Bson> = {
                     let state_ref = this.state.read(cx);
@@ -176,18 +201,32 @@ impl CollectionView {
                 let filter = doc! { "_id": { "$in": ids } };
                 let message =
                     format!("Delete {} documents? This cannot be undone.", affected_count);
-                open_confirm_dialog(window, cx, "Delete documents", message, "Delete", true, {
-                    let state = this.state.clone();
-                    let session_key = session_key.clone();
+                let state = this.state.clone();
+                let state_for_write = state.clone();
+                request_connection_write(
+                    state,
+                    crate::components::WriteRequest::new(
+                        session_key.connection_id,
+                        session_key.namespace(),
+                        format!("Delete {affected_count} documents"),
+                        Some(WriteConfirmation {
+                            title: "Delete documents".into(),
+                            message,
+                            confirm_label: "Delete".into(),
+                            destructive: true,
+                        }),
+                    ),
+                    window,
+                    cx,
                     move |_window, cx| {
                         AppCommands::delete_documents_by_filter(
-                            state.clone(),
-                            session_key.clone(),
-                            filter.clone(),
+                            state_for_write,
+                            session_key,
+                            filter,
                             cx,
                         );
-                    }
-                });
+                    },
+                );
             }
         }))
         .on_action(cx.listener(|this, _: &DeleteCollection, window, cx| {
@@ -196,25 +235,39 @@ impl CollectionView {
             };
             let message =
                 format!("Drop collection {}? This cannot be undone.", session_key.collection);
-            open_confirm_dialog(window, cx, "Drop collection", message, "Drop", true, {
-                let state = this.state.clone();
-                let session_key = session_key.clone();
+            let state = this.state.clone();
+            let state_for_write = state.clone();
+            request_connection_write(
+                state,
+                crate::components::WriteRequest::new(
+                    session_key.connection_id,
+                    session_key.namespace(),
+                    "Drop a collection",
+                    Some(WriteConfirmation {
+                        title: "Drop collection".into(),
+                        message,
+                        confirm_label: "Drop".into(),
+                        destructive: true,
+                    }),
+                ),
+                window,
+                cx,
                 move |_window, cx| {
                     AppCommands::drop_collection(
-                        state.clone(),
+                        state_for_write,
                         session_key.connection_id,
-                        session_key.database.clone(),
-                        session_key.collection.clone(),
+                        session_key.database,
+                        session_key.collection,
                         cx,
                     );
-                }
-            });
+                },
+            );
         }))
-        .on_action(cx.listener(|this, _: &PasteDocuments, _window, cx| {
+        .on_action(cx.listener(|this, _: &PasteDocuments, window, cx| {
             let Some(session_key) = this.view_model.current_session() else {
                 return;
             };
-            paste_documents_from_clipboard(this.state.clone(), session_key, cx);
+            paste_documents_from_clipboard(this.state.clone(), session_key, window, cx);
         }))
         .on_action(cx.listener(|this, _: &CopyDocumentJson, _window, cx| {
             let Some(session_key) = this.view_model.current_session() else {
@@ -258,7 +311,7 @@ impl CollectionView {
                 .detach();
             }
         }))
-        .on_action(cx.listener(|this, _: &SaveDocument, _window, cx| {
+        .on_action(cx.listener(|this, _: &SaveDocument, window, cx| {
             this.view_model.commit_inline_edit(&this.state, cx);
             let Some(session_key) = this.view_model.current_session() else {
                 return;
@@ -276,18 +329,44 @@ impl CollectionView {
                     .cloned()
                     .collect()
             };
-            for doc_key in dirty_selected {
-                let doc = this.state.read(cx).session_draft(&session_key, &doc_key);
-                if let Some(doc) = doc {
-                    AppCommands::save_document(
-                        this.state.clone(),
-                        session_key.clone(),
-                        doc_key,
-                        doc,
-                        cx,
-                    );
-                }
+            let documents = dirty_selected
+                .into_iter()
+                .filter_map(|doc_key| {
+                    this.state
+                        .read(cx)
+                        .session_draft(&session_key, &doc_key)
+                        .map(|document| (doc_key, document))
+                })
+                .collect::<Vec<_>>();
+            if documents.is_empty() {
+                return;
             }
+            let state = this.state.clone();
+            let state_for_write = state.clone();
+            let write_count = documents.len();
+            request_connection_write(
+                state,
+                crate::components::WriteRequest::new(
+                    session_key.connection_id,
+                    session_key.namespace(),
+                    format!("Save {write_count} document change(s)"),
+                    None,
+                )
+                .for_writes(write_count),
+                window,
+                cx,
+                move |_window, cx| {
+                    for (doc_key, document) in documents {
+                        AppCommands::save_document(
+                            state_for_write.clone(),
+                            session_key.clone(),
+                            doc_key,
+                            document,
+                            cx,
+                        );
+                    }
+                },
+            );
         }))
         .on_action(cx.listener(|this, _: &EditValueType, window, cx| {
             let Some((session_key, meta)) = this.selected_property_context(cx) else {

--- a/src/views/documents/dialogs/bulk_update.rs
+++ b/src/views/documents/dialogs/bulk_update.rs
@@ -9,7 +9,7 @@ use gpui_component::menu::{DropdownMenu as _, PopupMenu, PopupMenuItem};
 use mongodb::bson::{Bson, Document, doc};
 
 use crate::bson::{DocumentKey, document_to_shell_string, parse_document_from_json};
-use crate::components::{Button, cancel_button, open_confirm_dialog};
+use crate::components::{Button, WriteConfirmation, cancel_button, request_connection_write};
 use crate::state::{AppCommands, AppEvent, AppState, SessionKey};
 use crate::theme::spacing;
 
@@ -198,7 +198,7 @@ impl BulkUpdateDialog {
     }
 
     fn is_read_only(&self, cx: &mut Context<Self>) -> bool {
-        self.state.read(cx).active_connection().map(|conn| conn.config.read_only).unwrap_or(false)
+        self.state.read(cx).connection_read_only(self.session_key.connection_id)
     }
 
     fn start_operation(&mut self, filter: Document, update_doc: Document, cx: &mut Context<Self>) {
@@ -282,16 +282,25 @@ impl BulkUpdateDialog {
                 session_key.database,
                 session_key.collection
             );
-            open_confirm_dialog(
+            let state = self.state.clone();
+            request_connection_write(
+                state,
+                crate::components::WriteRequest::new(
+                    session_key.connection_id,
+                    session_key.namespace(),
+                    format!("{} one document", mode.label()),
+                    Some(WriteConfirmation {
+                        title,
+                        message,
+                        confirm_label: confirm_label.to_string(),
+                        destructive: true,
+                    }),
+                ),
                 window,
                 cx,
-                title,
-                message,
-                confirm_label,
-                true,
                 move |_window, cx| {
                     view.update(cx, |this, cx| {
-                        this.start_operation(filter.clone(), update_doc.clone(), cx);
+                        this.start_operation(filter, update_doc, cx);
                     });
                 },
             );
@@ -321,6 +330,7 @@ impl BulkUpdateDialog {
         });
         let window_handle = window.window_handle();
 
+        let state = self.state.clone();
         cx.spawn(async move |view: WeakEntity<Self>, cx: &mut AsyncApp| {
             let result: Result<u64, crate::error::Error> = task.await;
             let _ = cx.update_window(window_handle, |_root, window, cx| match result {
@@ -348,16 +358,24 @@ impl BulkUpdateDialog {
                         mode.label(),
                         if count == 1 { "" } else { "s" }
                     );
-                    open_confirm_dialog(
+                    request_connection_write(
+                        state.clone(),
+                        crate::components::WriteRequest::new(
+                            session_key.connection_id,
+                            session_key.namespace(),
+                            format!("{} {count} documents", mode.label()),
+                            Some(WriteConfirmation {
+                            title,
+                            message,
+                            confirm_label: confirm_label.to_string(),
+                            destructive: true,
+                        }),
+                        ),
                         window,
                         cx,
-                        title,
-                        message,
-                        confirm_label,
-                        true,
                         move |_window, cx| {
                             let _ = confirm_view.update(cx, |this, cx| {
-                                this.start_operation(filter.clone(), update_doc.clone(), cx);
+                                this.start_operation(filter, update_doc, cx);
                             });
                         },
                     );
@@ -548,6 +566,12 @@ impl Render for BulkUpdateDialog {
             .flex_col()
             .gap(spacing::sm())
             .p(spacing::md())
+            .child(crate::components::connection_identity_for(
+                &self.state,
+                self.session_key.connection_id,
+                true,
+                cx,
+            ))
             .child(scope_row)
             .child(custom_filter_row)
             .child(

--- a/src/views/documents/dialogs/index_create/render.rs
+++ b/src/views/documents/dialogs/index_create/render.rs
@@ -416,40 +416,64 @@ impl Render for IndexCreateDialog {
                                         let confirm_view = view.clone();
                                         let confirm_state = state.clone();
                                         let confirm_session = session_key.clone();
-                                        crate::components::open_confirm_dialog(
+                                        crate::components::request_connection_write(
+                                            confirm_state.clone(),
+                                            crate::components::WriteRequest::new(
+                                                confirm_session.connection_id,
+                                                confirm_session.namespace(),
+                                                "Replace an index",
+                                                Some(crate::components::WriteConfirmation {
+                                                title: "Replace index".into(),
+                                                message: format!(
+                                                    "Replace index \"{original_name}\"? The existing index may be dropped during replacement."
+                                                ),
+                                                confirm_label: "Replace".into(),
+                                                destructive: true,
+                                            }),
+                                            ),
                                             window,
                                             cx,
-                                            "Replace index",
-                                            format!(
-                                                "Replace index \"{original_name}\"? The existing index may be dropped during replacement."
-                                            ),
-                                            "Replace",
-                                            true,
                                             move |_window, cx| {
                                                 confirm_view.update(cx, |this, cx| {
                                                     this.creating = true;
                                                     cx.notify();
                                                     AppCommands::replace_collection_index(
-                                                        confirm_state.clone(),
-                                                        confirm_session.clone(),
-                                                        original_name.clone(),
-                                                        index_doc.clone(),
+                                                        confirm_state,
+                                                        confirm_session,
+                                                        original_name,
+                                                        index_doc,
                                                         cx,
                                                     );
                                                 });
                                             },
                                         );
                                     } else {
-                                        view.update(cx, |this, cx| {
-                                            this.creating = true;
-                                            cx.notify();
-                                            AppCommands::create_collection_index(
-                                                state.clone(),
-                                                session_key.clone(),
-                                                index_doc,
-                                                cx,
-                                            );
-                                        });
+                                        let confirm_view = view.clone();
+                                        let confirm_state = state.clone();
+                                        let confirm_session = session_key.clone();
+                                        crate::components::request_connection_write(
+                                            state.clone(),
+                                            crate::components::WriteRequest::new(
+                                                session_key.connection_id,
+                                                session_key.namespace(),
+                                                "Create an index",
+                                                None,
+                                            ),
+                                            window,
+                                            cx,
+                                            move |_window, cx| {
+                                                confirm_view.update(cx, |this, cx| {
+                                                    this.creating = true;
+                                                    cx.notify();
+                                                    AppCommands::create_collection_index(
+                                                        confirm_state,
+                                                        confirm_session,
+                                                        index_doc,
+                                                        cx,
+                                                    );
+                                                });
+                                            },
+                                        );
                                     }
                                 }
                             })
@@ -461,6 +485,12 @@ impl Render for IndexCreateDialog {
             .flex_col()
             .gap(spacing::sm())
             .p(spacing::md())
+            .child(crate::components::connection_identity_for(
+                &self.state,
+                self.session_key.connection_id,
+                true,
+                cx,
+            ))
             .child(tabs)
             .child(if self.mode == IndexMode::Form { form_view } else { json_view })
             .child(action_row)

--- a/src/views/documents/dialogs/property_dialog.rs
+++ b/src/views/documents/dialogs/property_dialog.rs
@@ -9,7 +9,7 @@ use gpui_component::{Disableable as _, WindowExt as _};
 use mongodb::bson::{self, Bson, Document, doc, oid::ObjectId};
 
 use crate::bson::{DocumentKey, PathSegment, parse_document_from_json};
-use crate::components::{Button, cancel_button, open_confirm_dialog};
+use crate::components::{Button, WriteConfirmation, cancel_button, request_connection_write};
 use crate::state::{AppCommands, AppEvent, AppState, SessionKey};
 use crate::theme::spacing;
 use crate::views::documents::node_meta::NodeMeta;
@@ -401,14 +401,35 @@ impl PropertyActionDialog {
 
         match self.effective_scope() {
             UpdateScope::CurrentDocument => {
-                self.updating = true;
-                cx.notify();
-                AppCommands::update_document_by_key(
-                    self.state.clone(),
-                    self.session_key.clone(),
-                    self.doc_key.clone(),
-                    update_doc,
+                let state = self.state.clone();
+                let state_for_write = state.clone();
+                let session_key = self.session_key.clone();
+                let session_for_write = session_key.clone();
+                let doc_key = self.doc_key.clone();
+                let view = cx.entity();
+                request_connection_write(
+                    state,
+                    crate::components::WriteRequest::new(
+                        session_key.connection_id,
+                        session_key.namespace(),
+                        "Update a document property",
+                        None,
+                    ),
+                    window,
                     cx,
+                    move |_window, cx| {
+                        view.update(cx, |view, cx| {
+                            view.updating = true;
+                            cx.notify();
+                            AppCommands::update_document_by_key(
+                                state_for_write,
+                                session_for_write,
+                                doc_key,
+                                update_doc,
+                                cx,
+                            );
+                        });
+                    },
                 );
             }
             UpdateScope::MatchQuery => {
@@ -478,22 +499,30 @@ impl PropertyActionDialog {
                         "Update every document matching this filter in {database}.{collection}? {count} document{} currently match. This cannot be undone.\n\nFilter: {filter_text}",
                         if count == 1 { "" } else { "s" }
                     );
-                    open_confirm_dialog(
+                    request_connection_write(
+                        state.clone(),
+                        crate::components::WriteRequest::new(
+                            session_key.connection_id,
+                            session_key.namespace(),
+                            format!("Update {count} documents"),
+                            Some(WriteConfirmation {
+                            title: "Confirm property update".into(),
+                            message,
+                            confirm_label: "Update".into(),
+                            destructive: true,
+                        }),
+                        ),
                         window,
                         cx,
-                        "Confirm property update",
-                        message,
-                        "Update",
-                        true,
                         move |_window, cx| {
                             let _ = confirm_view.update(cx, |this, cx| {
                                 this.updating = true;
                                 this.error_message = None;
                                 AppCommands::update_documents_by_filter(
-                                    state.clone(),
-                                    session_key.clone(),
-                                    filter.clone(),
-                                    update_doc.clone(),
+                                    state,
+                                    session_key,
+                                    filter,
+                                    update_doc,
                                     cx,
                                 );
                                 cx.notify();
@@ -783,6 +812,12 @@ impl Render for PropertyActionDialog {
             .flex_col()
             .gap(spacing::sm())
             .p(spacing::md())
+            .child(crate::components::connection_identity_for(
+                &self.state,
+                self.session_key.connection_id,
+                true,
+                cx,
+            ))
             .child(
                 div()
                     .flex()

--- a/src/views/documents/header/actions.rs
+++ b/src/views/documents/header/actions.rs
@@ -14,7 +14,7 @@ use gpui_component::{Disableable as _, Icon, IconName, Sizable as _, Size};
 use mongodb::bson::Document;
 
 use crate::bson::DocumentKey;
-use crate::components::{Button, open_confirm_dialog};
+use crate::components::{Button, WriteConfirmation, request_connection_write};
 use crate::keyboard::RunAggregation;
 use crate::state::{
     AppCommands, AppState, DocumentViewMode, SessionKey, TransferMode, TransferScope,
@@ -125,24 +125,29 @@ fn render_delete_menu(
                                 let doc_key = selected_docs[0].clone();
                                 let message =
                                     format!("Delete document {}? This cannot be undone.", doc_key);
-                                open_confirm_dialog(
+                                let state_for_write = state_for_delete.clone();
+                                request_connection_write(
+                                    state_for_delete.clone(),
+                                    crate::components::WriteRequest::new(
+                                        session_key.connection_id,
+                                        session_key.namespace(),
+                                        "Delete a document",
+                                        Some(WriteConfirmation {
+                                            title: "Delete document".into(),
+                                            message,
+                                            confirm_label: "Delete".into(),
+                                            destructive: true,
+                                        }),
+                                    ),
                                     window,
                                     cx,
-                                    "Delete document",
-                                    message,
-                                    "Delete",
-                                    true,
-                                    {
-                                        let state_for_delete = state_for_delete.clone();
-                                        let session_key = session_key.clone();
-                                        move |_window, cx| {
-                                            AppCommands::delete_document(
-                                                state_for_delete.clone(),
-                                                session_key.clone(),
-                                                doc_key.clone(),
-                                                cx,
-                                            );
-                                        }
+                                    move |_window, cx| {
+                                        AppCommands::delete_document(
+                                            state_for_write,
+                                            session_key,
+                                            doc_key,
+                                            cx,
+                                        );
                                     },
                                 );
                             } else {
@@ -166,24 +171,29 @@ fn render_delete_menu(
                                     "Delete {} documents? This cannot be undone.",
                                     affected_count
                                 );
-                                open_confirm_dialog(
+                                let state_for_write = state_for_delete.clone();
+                                request_connection_write(
+                                    state_for_delete.clone(),
+                                    crate::components::WriteRequest::new(
+                                        session_key.connection_id,
+                                        session_key.namespace(),
+                                        format!("Delete {affected_count} documents"),
+                                        Some(WriteConfirmation {
+                                            title: "Delete documents".into(),
+                                            message,
+                                            confirm_label: "Delete".into(),
+                                            destructive: true,
+                                        }),
+                                    ),
                                     window,
                                     cx,
-                                    "Delete documents",
-                                    message,
-                                    "Delete",
-                                    true,
-                                    {
-                                        let state_for_delete = state_for_delete.clone();
-                                        let session_key = session_key.clone();
-                                        move |_window, cx| {
-                                            AppCommands::delete_documents_by_filter(
-                                                state_for_delete.clone(),
-                                                session_key.clone(),
-                                                filter.clone(),
-                                                cx,
-                                            );
-                                        }
+                                    move |_window, cx| {
+                                        AppCommands::delete_documents_by_filter(
+                                            state_for_write,
+                                            session_key,
+                                            filter,
+                                            cx,
+                                        );
                                     },
                                 );
                             }
@@ -448,7 +458,7 @@ fn render_documents_actions_clean(
         Button::new("apply-clean").compact().disabled(!any_selected_dirty).on_click({
             let state_for_apply = state_for_apply.clone();
             let view = view.clone();
-            move |_: &ClickEvent, _window: &mut Window, cx: &mut App| {
+            move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
                 view.update(cx, |this, cx| {
                     this.view_model.commit_inline_edit(&this.state, cx);
                 });
@@ -468,18 +478,43 @@ fn render_documents_actions_clean(
                         .cloned()
                         .collect()
                 };
-                for doc_key in dirty_docs {
-                    let doc = state_for_apply.read(cx).session_draft(&session_key, &doc_key);
-                    if let Some(doc) = doc {
-                        AppCommands::save_document(
-                            state_for_apply.clone(),
-                            session_key.clone(),
-                            doc_key,
-                            doc,
-                            cx,
-                        );
-                    }
+                let documents = dirty_docs
+                    .into_iter()
+                    .filter_map(|doc_key| {
+                        state_for_apply
+                            .read(cx)
+                            .session_draft(&session_key, &doc_key)
+                            .map(|document| (doc_key, document))
+                    })
+                    .collect::<Vec<_>>();
+                if documents.is_empty() {
+                    return;
                 }
+                let write_count = documents.len();
+                let state_for_write = state_for_apply.clone();
+                request_connection_write(
+                    state_for_apply.clone(),
+                    crate::components::WriteRequest::new(
+                        session_key.connection_id,
+                        session_key.namespace(),
+                        format!("Save {write_count} document change(s)"),
+                        None,
+                    )
+                    .for_writes(write_count),
+                    window,
+                    cx,
+                    move |_window, cx| {
+                        for (doc_key, document) in documents {
+                            AppCommands::save_document(
+                                state_for_write.clone(),
+                                session_key.clone(),
+                                doc_key,
+                                document,
+                                cx,
+                            );
+                        }
+                    },
+                );
             }
         }),
         IconName::Check,

--- a/src/views/documents/mod.rs
+++ b/src/views/documents/mod.rs
@@ -72,16 +72,25 @@ pub(crate) fn request_run_aggregation(
     } else {
         format!("$merge will write pipeline output into {target} using the configured merge rules.")
     };
-    crate::components::open_confirm_dialog(
+    let state_for_write = state.clone();
+    crate::components::request_connection_write(
+        state,
+        crate::components::WriteRequest::new(
+            session_key.connection_id,
+            target,
+            format!("Run an aggregation {operator} write stage"),
+            Some(crate::components::WriteConfirmation {
+                title: "Run aggregation write stage".into(),
+                message: format!("{semantics}\n\nRun this write operation?"),
+                confirm_label: "Run write stage".into(),
+                destructive: true,
+            }),
+        ),
         window,
         cx,
-        "Run aggregation write stage",
-        format!("{semantics}\n\nRun this write operation?"),
-        "Run write stage",
-        true,
         move |_window, cx| {
             AppCommands::run_aggregation_confirmed(
-                state,
+                state_for_write,
                 session_key,
                 preview,
                 confirmed_stages,
@@ -147,18 +156,27 @@ pub(crate) fn request_delete_confirmation(
                     "Delete every {scope_label} document matching this filter from {database}.{collection}? {count} document{} currently match. This cannot be undone.\n\nFilter: {filter_text}",
                     if count == 1 { "" } else { "s" }
                 );
-                crate::components::open_confirm_dialog(
+                let state_for_write = state.clone();
+                crate::components::request_connection_write(
+                    state.clone(),
+                    crate::components::WriteRequest::new(
+                        session_key.connection_id,
+                        session_key.namespace(),
+                        format!("Delete {count} documents"),
+                        Some(crate::components::WriteConfirmation {
+                        title: "Delete documents".into(),
+                        message,
+                        confirm_label: "Delete".into(),
+                        destructive: true,
+                    }),
+                    ),
                     window,
                     cx,
-                    "Delete documents",
-                    message,
-                    "Delete",
-                    true,
                     move |_window, cx| {
                         AppCommands::delete_documents_by_filter(
-                            state.clone(),
-                            session_key.clone(),
-                            filter.clone(),
+                            state_for_write,
+                            session_key,
+                            filter,
                             cx,
                         );
                     },

--- a/src/views/documents/state.rs
+++ b/src/views/documents/state.rs
@@ -122,24 +122,46 @@ impl CollectionView {
             view.update(cx, |this, cx| {
                 let mut handled = false;
 
-                let save_selected_document = |this: &mut CollectionView, cx: &mut Context<Self>| {
-                    let Some(session_key) = this.view_model.current_session() else {
-                        return false;
+                let save_selected_document =
+                    |this: &mut CollectionView, window: &mut Window, cx: &mut Context<Self>| {
+                        let Some(session_key) = this.view_model.current_session() else {
+                            return false;
+                        };
+                        let (doc_key, doc) = {
+                            let state_ref = this.state.read(cx);
+                            let doc_key = state_ref.session_selected_doc(&session_key);
+                            let doc = doc_key
+                                .as_ref()
+                                .and_then(|doc_key| state_ref.session_draft(&session_key, doc_key));
+                            (doc_key, doc)
+                        };
+                        let (Some(doc_key), Some(doc)) = (doc_key, doc) else {
+                            return false;
+                        };
+                        let state = this.state.clone();
+                        let state_for_write = state.clone();
+                        crate::components::request_connection_write(
+                            state,
+                            crate::components::WriteRequest::new(
+                                session_key.connection_id,
+                                session_key.namespace(),
+                                "Save document changes",
+                                None,
+                            ),
+                            window,
+                            cx,
+                            move |_window, cx| {
+                                AppCommands::save_document(
+                                    state_for_write,
+                                    session_key,
+                                    doc_key,
+                                    doc,
+                                    cx,
+                                );
+                            },
+                        );
+                        true
                     };
-                    let (doc_key, doc) = {
-                        let state_ref = this.state.read(cx);
-                        let doc_key = state_ref.session_selected_doc(&session_key);
-                        let doc = doc_key
-                            .as_ref()
-                            .and_then(|doc_key| state_ref.session_draft(&session_key, doc_key));
-                        (doc_key, doc)
-                    };
-                    let (Some(doc_key), Some(doc)) = (doc_key, doc) else {
-                        return false;
-                    };
-                    AppCommands::save_document(this.state.clone(), session_key, doc_key, doc, cx);
-                    true
-                };
                 let is_aggregation = this
                     .view_model
                     .current_session()
@@ -182,12 +204,12 @@ impl CollectionView {
                         if committed {
                             window.focus(&this.documents_focus);
                             if cmd_or_ctrl {
-                                save_selected_document(this, cx);
+                                save_selected_document(this, window, cx);
                             }
                         }
                         handled = true;
                     } else if cmd_or_ctrl {
-                        handled = save_selected_document(this, cx);
+                        handled = save_selected_document(this, window, cx);
                     } else if this.documents_focus.is_focused(window) {
                         let Some(session_key) = this.view_model.current_session() else {
                             return;

--- a/src/views/documents/tree/tree_menus.rs
+++ b/src/views/documents/tree/tree_menus.rs
@@ -8,6 +8,7 @@ use crate::bson::{
     format_relaxed_json_value, get_bson_at_path, parse_document_from_json,
     parse_documents_from_json,
 };
+use crate::components::request_connection_write;
 use crate::keyboard::{
     AddElement, AddField, CopyAsCsv, CopyAsJson, CopyAsJsonLines, CopyAsMarkdown, CopyAsTsv,
     CopyDocumentJson, CopyKey, CopyValue, DeleteDocument, DiscardDocumentChanges,
@@ -109,15 +110,30 @@ pub(in crate::views::documents) fn build_document_menu(
                     let state = state.clone();
                     let session_key = session_key.clone();
                     let doc_key = doc_key.clone();
-                    move |_, _window, cx| {
+                    move |_, window, cx| {
                         if let Some(doc) = resolve_document(&state, &session_key, &doc_key, cx) {
                             let mut new_doc = doc.clone();
                             new_doc.insert("_id", mongodb::bson::oid::ObjectId::new());
-                            AppCommands::insert_document(
+                            let state_for_write = state.clone();
+                            let session_for_write = session_key.clone();
+                            request_connection_write(
                                 state.clone(),
-                                session_key.clone(),
-                                new_doc,
+                                crate::components::WriteRequest::new(
+                                    session_key.connection_id,
+                                    session_key.namespace(),
+                                    "Insert a duplicated document",
+                                    None,
+                                ),
+                                window,
                                 cx,
+                                move |_window, cx| {
+                                    AppCommands::insert_document(
+                                        state_for_write,
+                                        session_for_write,
+                                        new_doc,
+                                        cx,
+                                    );
+                                },
                             );
                         }
                     }
@@ -126,8 +142,8 @@ pub(in crate::views::documents) fn build_document_menu(
         .item(PopupMenuItem::new("Paste Document(s)").action(Box::new(PasteDocuments)).on_click({
             let state = state.clone();
             let session_key = session_key.clone();
-            move |_, _window, cx| {
-                paste_documents_from_clipboard(state.clone(), session_key.clone(), cx);
+            move |_, window, cx| {
+                paste_documents_from_clipboard(state.clone(), session_key.clone(), window, cx);
             }
         }))
         .item(
@@ -453,6 +469,7 @@ fn resolve_document(
 pub(crate) fn paste_documents_from_clipboard(
     state: Entity<AppState>,
     session_key: SessionKey,
+    window: &mut Window,
     cx: &mut App,
 ) {
     let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) else {
@@ -493,7 +510,22 @@ pub(crate) fn paste_documents_from_clipboard(
         })
         .collect::<Vec<_>>();
 
-    AppCommands::insert_documents(state, session_key, docs, cx);
+    let state_for_write = state.clone();
+    let target = session_key.namespace();
+    request_connection_write(
+        state,
+        crate::components::WriteRequest::new(
+            session_key.connection_id,
+            target,
+            format!("Insert {} documents from the clipboard", docs.len()),
+            None,
+        ),
+        window,
+        cx,
+        move |_window, cx| {
+            AppCommands::insert_documents(state_for_write, session_key, docs, cx);
+        },
+    );
 }
 
 fn format_bson_for_clipboard(value: &Bson) -> String {

--- a/src/views/documents/views/indexes_view.rs
+++ b/src/views/documents/views/indexes_view.rs
@@ -8,7 +8,7 @@ use mongodb::bson::Document;
 use gpui_component::ActiveTheme as _;
 
 use crate::bson::bson_value_preview;
-use crate::components::{Button, open_confirm_dialog};
+use crate::components::{Button, WriteConfirmation, request_connection_write};
 use crate::state::{AppCommands, SessionKey};
 use crate::theme::spacing;
 
@@ -246,25 +246,30 @@ impl CollectionView {
                                                         "Drop index {}? This cannot be undone.",
                                                         drop_name
                                                     );
-                                                    open_confirm_dialog(
+                                                    let state_for_write = state.clone();
+                                                    let target = session_key.namespace();
+                                                    request_connection_write(
+                                                        state.clone(),
+                                                        crate::components::WriteRequest::new(
+                                                            session_key.connection_id,
+                                                            target,
+                                                            "Drop an index",
+                                                            Some(WriteConfirmation {
+                                                            title: "Drop index".into(),
+                                                            message,
+                                                            confirm_label: "Drop".into(),
+                                                            destructive: true,
+                                                        }),
+                                                        ),
                                                         window,
                                                         cx,
-                                                        "Drop index",
-                                                        message,
-                                                        "Drop",
-                                                        true,
-                                                        {
-                                                            let state = state.clone();
-                                                            let session_key = session_key.clone();
-                                                            let drop_name = drop_name.clone();
-                                                            move |_window, cx| {
-                                                                AppCommands::drop_collection_index(
-                                                                    state.clone(),
-                                                                    session_key.clone(),
-                                                                    drop_name.clone(),
-                                                                    cx,
-                                                                );
-                                                            }
+                                                        move |_window, cx| {
+                                                            AppCommands::drop_collection_index(
+                                                                state_for_write,
+                                                                session_key,
+                                                                drop_name,
+                                                                cx,
+                                                            );
                                                         },
                                                     );
                                                 }

--- a/src/views/forge/actions.rs
+++ b/src/views/forge/actions.rs
@@ -1,5 +1,7 @@
 use gpui::{Context, Div, InteractiveElement, Window};
 
+use crate::components::request_connection_write;
+
 use crate::keyboard::{
     CancelForgeRun, ClearForgeOutput, FindInForgeOutput, FocusForgeEditor, FocusForgeOutput,
     RunForgeAll, RunForgeSelectionOrStatement,
@@ -8,12 +10,54 @@ use crate::keyboard::{
 use super::ForgeView;
 
 pub fn bind_root_actions(root: Div, _window: &mut Window, cx: &mut Context<ForgeView>) -> Div {
-    root.on_action(cx.listener(|this, _: &RunForgeAll, _window, cx| {
-        super::controller::ForgeController::run_all(this, cx);
+    root.on_action(cx.listener(|this, _: &RunForgeAll, window, cx| {
+        let Some(key) = this.app_state.read(cx).active_forge_tab_key().cloned() else {
+            return;
+        };
+        let app_state = this.app_state.clone();
+        let view = cx.entity();
+        request_connection_write(
+            app_state,
+            crate::components::WriteRequest::new(
+                key.connection_id,
+                key.database,
+                "Run Forge code that may write to MongoDB",
+                None,
+            ),
+            window,
+            cx,
+            move |_window, cx| {
+                view.update(cx, |view, cx| {
+                    super::controller::ForgeController::run_all(view, cx);
+                });
+            },
+        );
         cx.stop_propagation();
     }))
     .on_action(cx.listener(|this, _: &RunForgeSelectionOrStatement, window, cx| {
-        super::controller::ForgeController::run_selection_or_statement(this, window, cx);
+        let Some(key) = this.app_state.read(cx).active_forge_tab_key().cloned() else {
+            return;
+        };
+        let app_state = this.app_state.clone();
+        let view = cx.entity();
+        request_connection_write(
+            app_state,
+            crate::components::WriteRequest::new(
+                key.connection_id,
+                key.database,
+                "Run Forge code that may write to MongoDB",
+                None,
+            ),
+            window,
+            cx,
+            move |window, cx| {
+                view.update(cx, |view, cx| {
+                    super::controller::ForgeController::run_selection_or_statement(
+                        view, window, cx,
+                    );
+                });
+            },
+        );
         cx.stop_propagation();
     }))
     .on_action(cx.listener(|this, _: &CancelForgeRun, _window, cx| {

--- a/src/views/forge/mod.rs
+++ b/src/views/forge/mod.rs
@@ -25,7 +25,9 @@ use gpui_component::spinner::Spinner;
 use gpui_component::tab::{Tab, TabBar};
 use gpui_component::{Icon, IconName, Sizable};
 
-use crate::components::{Button, QueryLibraryDialog, QueryLibraryTarget};
+use crate::components::{
+    Button, ConnectionIdentity, QueryLibraryDialog, QueryLibraryTarget, connection_identity_badge,
+};
 use crate::state::{AppEvent, AppState, View};
 use crate::theme::{fonts, islands, spacing};
 use controller::ForgeController;
@@ -80,6 +82,12 @@ impl ForgeView {
             .as_ref()
             .map(|key| key.database.clone())
             .unwrap_or_else(|| "Unknown".to_string());
+        let identity = target.as_ref().and_then(|key| {
+            self.app_state
+                .read(cx)
+                .connection_by_id(key.connection_id)
+                .map(ConnectionIdentity::from)
+        });
 
         div()
             .flex()
@@ -99,6 +107,9 @@ impl ForgeView {
                             .text_color(cx.theme().foreground)
                             .child("Forge"),
                     )
+                    .when_some(identity, |header, identity| {
+                        header.child(connection_identity_badge(&identity, true, cx))
+                    })
                     .child(div().text_xs().text_color(cx.theme().muted_foreground).child(database)),
             )
             .child(

--- a/src/views/forge/runtime.rs
+++ b/src/views/forge/runtime.rs
@@ -50,9 +50,17 @@ pub fn active_forge_session_info(
 
 const READ_ONLY_FORGE_ERROR: &str = "Forge execution is disabled for read-only connections. Use a writable connection or a server-enforced read-only MongoDB account.";
 
-fn ensure_forge_execution_allowed(read_only: bool) -> Result<(), crate::error::Error> {
+fn ensure_forge_execution_allowed(
+    read_only: bool,
+    protected_production: bool,
+    authorized: bool,
+) -> Result<(), crate::error::Error> {
     if read_only {
         Err(crate::error::Error::Parse(READ_ONLY_FORGE_ERROR.to_string()))
+    } else if protected_production && !authorized {
+        Err(crate::error::Error::Parse(
+            "Production Forge execution requires confirmation.".to_string(),
+        ))
     } else {
         Ok(())
     }
@@ -61,7 +69,16 @@ fn ensure_forge_execution_allowed(read_only: bool) -> Result<(), crate::error::E
 impl ForgeView {
     pub fn handle_execute_query(&mut self, text: &str, cx: &mut Context<Self>) {
         self.state.editor.current_text = text.to_string();
-        let (session_id, uri, database, runtime_handle, read_only, forge_key) = {
+        let (
+            session_id,
+            uri,
+            database,
+            runtime_handle,
+            read_only,
+            protected_production,
+            connection_id,
+            forge_key,
+        ) = {
             let state_ref = self.app_state.read(cx);
             let (session_id, uri, database) = match active_forge_session_info(state_ref) {
                 Ok(Some(info)) => info,
@@ -82,17 +99,34 @@ impl ForgeView {
             let read_only = forge_key
                 .as_ref()
                 .is_some_and(|key| state_ref.connection_read_only(key.connection_id));
+            let protected_production = forge_key.as_ref().is_some_and(|key| {
+                state_ref.connection_requires_production_write_confirmation(key.connection_id)
+            });
+            let connection_id = forge_key.as_ref().map(|key| key.connection_id);
             (
                 session_id,
                 uri,
                 database,
                 state_ref.connection_manager().runtime_handle(),
                 read_only,
+                protected_production,
+                connection_id,
                 forge_key,
             )
         };
 
-        if let Err(error) = ensure_forge_execution_allowed(read_only) {
+        let authorized = if protected_production {
+            connection_id.is_some_and(|connection_id| {
+                self.app_state.update(cx, |state, _cx| {
+                    state.consume_production_write_authorization(connection_id)
+                })
+            })
+        } else {
+            true
+        };
+        if let Err(error) =
+            ensure_forge_execution_allowed(read_only, protected_production, authorized)
+        {
             let message = error.to_string();
             self.state.output.last_error = Some(message.clone());
             self.state.output.last_result = None;
@@ -470,8 +504,11 @@ mod tests {
 
     #[test]
     fn read_only_connections_cannot_execute_forge() {
-        let error = ensure_forge_execution_allowed(true).expect_err("read-only Forge must fail");
+        let error = ensure_forge_execution_allowed(true, true, true)
+            .expect_err("read-only Forge must fail");
         assert!(error.to_string().contains("read-only"));
-        assert!(ensure_forge_execution_allowed(false).is_ok());
+        assert!(ensure_forge_execution_allowed(false, false, false).is_ok());
+        assert!(ensure_forge_execution_allowed(false, true, false).is_err());
+        assert!(ensure_forge_execution_allowed(false, true, true).is_ok());
     }
 }

--- a/src/views/json_editor_detached.rs
+++ b/src/views/json_editor_detached.rs
@@ -11,7 +11,7 @@ use crate::bson::{
     DocumentKey, document_to_shell_string, format_relaxed_json_value, parse_bson_from_relaxed_json,
     parse_document_from_json, parse_value_from_relaxed_json,
 };
-use crate::components::{Button, request_unsaved_action};
+use crate::components::{Button, request_connection_write, request_unsaved_action};
 use crate::keyboard::CloseEditorWindow;
 use crate::state::{
     AppCommands, AppEvent, AppState, EditorSessionId, EditorSessionStore, EditorSessionTarget,
@@ -245,7 +245,35 @@ impl DetachedJsonEditorView {
         self.set_notice(false, "Formatted");
     }
 
-    fn save_or_insert(&mut self, cx: &mut Context<Self>) {
+    fn save_or_insert(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(session) = self.sessions.snapshot(self.session_id) else {
+            self.set_error("Editor session is no longer available.");
+            return;
+        };
+        if matches!(session.target, EditorSessionTarget::Document { .. }) {
+            self.save_or_insert_authorized(cx);
+            return;
+        }
+
+        let state = self.state.clone();
+        let view = cx.entity();
+        request_connection_write(
+            state,
+            crate::components::WriteRequest::new(
+                session.session_key.connection_id,
+                session.session_key.namespace(),
+                "Save the document editor contents",
+                None,
+            ),
+            window,
+            cx,
+            move |_window, cx| {
+                view.update(cx, |view, cx| view.save_or_insert_authorized(cx));
+            },
+        );
+    }
+
+    fn save_or_insert_authorized(&mut self, cx: &mut Context<Self>) {
         if self.state.read(cx).unsaved_guard_is_active() {
             self.set_notice(false, "Finish the open unsaved-changes prompt before saving.");
             cx.notify();
@@ -362,6 +390,8 @@ impl DetachedJsonEditorView {
         let task = cx.background_spawn(async move {
             manager.find_document_by_id(&client, &database, &collection, &id_for_task)
         });
+        let window_handle = self.window_handle;
+        let state = self.state.clone();
 
         cx.spawn({
             let session_key = session_key.clone();
@@ -370,45 +400,80 @@ impl DetachedJsonEditorView {
             async move |view: WeakEntity<Self>, cx: &mut AsyncApp| {
                 let result: Result<Option<Document>, crate::error::Error> = task.await;
                 let _ = cx.update(|cx| {
-                    let _ = view.update(cx, |this, cx| match result {
-                        Ok(Some(current)) => {
-                            if current != baseline_document {
+                    match result {
+                        Ok(Some(current)) if current == baseline_document => {
+                            let _ = view.update(cx, |this, cx| {
+                                this.set_save_in_flight(false);
+                                this.clear_sync_issue();
+                                this.set_notice(false, "Latest document confirmed.");
+                                cx.notify();
+                            });
+                            let Some(window_handle) = window_handle else {
+                                let _ = view.update(cx, |this, cx| {
+                                    this.set_error("Editor window is no longer available.");
+                                    cx.notify();
+                                });
+                                return;
+                            };
+                            let view_for_save = view.clone();
+                            let _ = window_handle.update(cx, move |_root, window, cx| {
+                                request_connection_write(
+                                    state,
+                                    crate::components::WriteRequest::new(
+                                        session_key.connection_id,
+                                        session_key.namespace(),
+                                        "Save the document editor contents",
+                                        None,
+                                    ),
+                                    window,
+                                    cx,
+                                    move |_window, cx| {
+                                        let _ = view_for_save.update(cx, |this, cx| {
+                                            this.set_save_in_flight(true);
+                                            this.set_notice(false, "Saving...");
+                                            AppCommands::save_document_for_editor(
+                                                this.state.clone(),
+                                                session_key,
+                                                doc_key,
+                                                updated_document,
+                                                baseline_document,
+                                                this.session_id,
+                                                cx,
+                                            );
+                                        });
+                                    },
+                                );
+                            });
+                        }
+                        Ok(Some(_)) => {
+                            let _ = view.update(cx, |this, cx| {
                                 this.set_save_in_flight(false);
                                 this.set_sync_issue(
                                     SyncIssue::ConflictChanged,
                                     "Document changed on server. Reload to review latest version before saving.",
                                 );
                                 cx.notify();
-                                return;
-                            }
-
-                            this.clear_sync_issue();
-                            this.set_notice(false, "Saving...");
-                            AppCommands::save_document_for_editor(
-                                this.state.clone(),
-                                session_key.clone(),
-                                doc_key.clone(),
-                                updated_document.clone(),
-                                baseline_document.clone(),
-                                this.session_id,
-                                cx,
-                            );
+                            });
                         }
                         Ok(None) => {
-                            this.set_save_in_flight(false);
-                            this.set_sync_issue(
-                                SyncIssue::MissingOriginal,
-                                "Original document was deleted. Reload or create current JSON as new.",
-                            );
+                            let _ = view.update(cx, |this, _cx| {
+                                this.set_save_in_flight(false);
+                                this.set_sync_issue(
+                                    SyncIssue::MissingOriginal,
+                                    "Original document was deleted. Reload or create current JSON as new.",
+                                );
+                            });
                         }
                         Err(err) => {
-                            this.set_save_in_flight(false);
-                            this.set_sync_issue(
-                                SyncIssue::ReloadFailed,
-                                format!("Failed to reload latest document: {err}"),
-                            );
+                            let _ = view.update(cx, |this, _cx| {
+                                this.set_save_in_flight(false);
+                                this.set_sync_issue(
+                                    SyncIssue::ReloadFailed,
+                                    format!("Failed to reload latest document: {err}"),
+                                );
+                            });
                         }
-                    });
+                    }
                 });
             }
         })
@@ -539,7 +604,7 @@ impl DetachedJsonEditorView {
         .detach();
     }
 
-    fn create_as_new(&mut self, cx: &mut Context<Self>) {
+    fn create_as_new(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.state.read(cx).unsaved_guard_is_active() {
             self.set_notice(false, "Finish the open unsaved-changes prompt before saving.");
             cx.notify();
@@ -582,15 +647,32 @@ impl DetachedJsonEditorView {
         let mut document = document;
         document.insert("_id", ObjectId::new());
 
-        self.awaiting_create_as_new = true;
-        self.set_save_in_flight(true);
-        self.set_notice(false, "Creating as new document...");
-        AppCommands::insert_document_for_editor(
-            self.state.clone(),
-            session.session_key,
-            document,
-            self.session_id,
+        let state = self.state.clone();
+        let view = cx.entity();
+        request_connection_write(
+            state,
+            crate::components::WriteRequest::new(
+                session.session_key.connection_id,
+                session.session_key.namespace(),
+                "Create the editor contents as a new document",
+                None,
+            ),
+            window,
             cx,
+            move |_window, cx| {
+                view.update(cx, |this, cx| {
+                    this.awaiting_create_as_new = true;
+                    this.set_save_in_flight(true);
+                    this.set_notice(false, "Creating as new document...");
+                    AppCommands::insert_document_for_editor(
+                        this.state.clone(),
+                        session.session_key,
+                        document,
+                        this.session_id,
+                        cx,
+                    );
+                });
+            },
         );
     }
 
@@ -652,6 +734,12 @@ impl Render for DetachedJsonEditorView {
         let state_ref = self.state.read(cx);
         let appearance = state_ref.settings.appearance.clone();
         let vibrancy = state_ref.startup_vibrancy;
+        let connection_identity = crate::components::connection_identity_for(
+            &self.state,
+            session.session_key.connection_id,
+            true,
+            cx,
+        );
 
         let Some(editor) = self.editor_state.clone() else {
             return div()
@@ -693,7 +781,7 @@ impl Render for DetachedJsonEditorView {
                         cx.stop_propagation();
                     } else if cmd_or_ctrl && key == "s" {
                         cx.stop_propagation();
-                        view.update(cx, |this, cx| this.save_or_insert(cx));
+                        view.update(cx, |this, cx| this.save_or_insert(window, cx));
                     } else if cmd_or_ctrl && !modifiers.alt && !modifiers.shift && key == "c" {
                         cx.stop_propagation();
                         view.update(cx, |this, cx| this.copy_json(window, cx));
@@ -726,7 +814,8 @@ impl Render for DetachedJsonEditorView {
                                     .text_xs()
                                     .text_color(cx.theme().muted_foreground)
                                     .child(format!("{}  •  {}", subtitle, session.title())),
-                            ),
+                            )
+                            .child(connection_identity),
                     )
                     .child(
                         div()
@@ -764,8 +853,10 @@ impl Render for DetachedJsonEditorView {
                                     .label(primary_label)
                                     .on_click({
                                         let view = view.clone();
-                                        move |_: &ClickEvent, _window: &mut Window, cx: &mut App| {
-                                            view.update(cx, |this, cx| this.save_or_insert(cx));
+                                        move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
+                                            view.update(cx, |this, cx| {
+                                                this.save_or_insert(window, cx)
+                                            });
                                         }
                                     }),
                             ),
@@ -831,8 +922,8 @@ impl Render for DetachedJsonEditorView {
                                 .label("Create as New")
                                 .on_click({
                                     let view = view.clone();
-                                    move |_: &ClickEvent, _window: &mut Window, cx: &mut App| {
-                                        view.update(cx, |this, cx| this.create_as_new(cx));
+                                    move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
+                                        view.update(cx, |this, cx| this.create_as_new(window, cx));
                                     }
                                 }),
                         );

--- a/src/views/transfer/mod.rs
+++ b/src/views/transfer/mod.rs
@@ -22,12 +22,13 @@ use gpui_component::tab::{Tab, TabBar};
 use gpui_component::{ActiveTheme as _, Icon, IconName, IndexPath, Sizable as _, Size};
 use uuid::Uuid;
 
-use crate::components::{Button, open_confirm_dialog};
+use crate::components::{Button, WriteConfirmation, open_confirm_dialog, request_connection_write};
 use crate::keyboard::{CancelTransfer, CloseTransferQueryModal, RunTransfer, SaveTransferQuery};
 use crate::state::{
     AppCommands, AppState, CompressionMode, InsertMode, StatusMessage, TargetWriteMode,
     TransferMode, TransferScope, TransferTabState, available_transfer_formats,
-    coerce_transfer_format, resolved_export_destination, validate_transfer,
+    coerce_transfer_format, resolved_export_destination, transfer_write_connection,
+    validate_transfer,
 };
 use crate::theme::{borders, colors, islands, sizing, spacing};
 
@@ -60,7 +61,7 @@ pub struct TransferView {
     export_path_input_state: Option<Entity<InputState>>,
 
     // Track previous items to avoid resetting search state on every render
-    prev_conn_ids: Vec<Uuid>,
+    prev_connections: Vec<(Uuid, crate::components::ConnectionIdentity)>,
     prev_db_names: Vec<String>,
     prev_coll_names: Vec<String>,
     prev_dest_db_names: Vec<String>,
@@ -93,7 +94,7 @@ impl TransferView {
             dest_coll_input_state: None,
             exclude_coll_state: None,
             export_path_input_state: None,
-            prev_conn_ids: Vec::new(),
+            prev_connections: Vec::new(),
             prev_db_names: Vec::new(),
             prev_coll_names: Vec::new(),
             prev_dest_db_names: Vec::new(),
@@ -174,7 +175,11 @@ fn run_active_transfer(state: Entity<AppState>, window: &mut Window, cx: &mut Ap
     let overwrite_destination =
         resolved_destination.clone().filter(|destination| destination.exists());
     let requires_confirmation = validation.requires_confirmation || overwrite_destination.is_some();
-    if !requires_confirmation {
+    let write_connection = transfer_write_connection(&transfer_state);
+    let production_confirmation = write_connection.is_some_and(|connection_id| {
+        state.read(cx).connection_requires_production_write_confirmation(connection_id)
+    });
+    if !requires_confirmation && !production_confirmation {
         AppCommands::execute_transfer(state, transfer_id, cx);
         return;
     }
@@ -190,37 +195,75 @@ fn run_active_transfer(state: Entity<AppState>, window: &mut Window, cx: &mut Ap
     );
     let expected_config = transfer_state.config.clone();
     let expected_options = transfer_state.options.clone();
-    open_confirm_dialog(
-        window,
-        cx,
-        "Confirm destructive transfer",
-        message,
-        "Run Transfer",
-        true,
-        move |_window, cx| {
-            let unchanged = state.read(cx).transfer_tab(transfer_id).is_some_and(|tab| {
-                tab.config == expected_config && tab.options == expected_options
+    let target_database = if transfer_state.config.destination_database.is_empty() {
+        transfer_state.config.source_database.clone()
+    } else {
+        transfer_state.config.destination_database.clone()
+    };
+    let target_collection = if transfer_state.config.destination_collection.is_empty() {
+        transfer_state.config.source_collection.clone()
+    } else {
+        transfer_state.config.destination_collection.clone()
+    };
+    let target = if transfer_state.config.scope == TransferScope::Collection {
+        format!("{target_database}.{target_collection}")
+    } else {
+        target_database
+    };
+    let state_for_run = state.clone();
+    let run = move |_window: &mut Window, cx: &mut App| {
+        let unchanged = state_for_run
+            .read(cx)
+            .transfer_tab(transfer_id)
+            .is_some_and(|tab| tab.config == expected_config && tab.options == expected_options);
+        if !unchanged {
+            state_for_run.update(cx, |state, cx| {
+                let message = "Transfer options changed after confirmation. Review and run again.";
+                if let Some(tab) = state.transfer_tab_mut(transfer_id) {
+                    tab.runtime.error_message = Some(message.to_string());
+                }
+                state.set_status_message(Some(StatusMessage::error(message)));
+                cx.notify();
             });
-            if !unchanged {
-                state.update(cx, |state, cx| {
-                    let message =
-                        "Transfer options changed after confirmation. Review and run again.";
-                    if let Some(tab) = state.transfer_tab_mut(transfer_id) {
-                        tab.runtime.error_message = Some(message.to_string());
-                    }
-                    state.set_status_message(Some(StatusMessage::error(message)));
-                    cx.notify();
-                });
-                return;
-            }
-            AppCommands::execute_confirmed_transfer(
-                state.clone(),
-                transfer_id,
-                resolved_destination.clone(),
-                cx,
-            );
-        },
-    );
+            return;
+        }
+        AppCommands::execute_confirmed_transfer(
+            state_for_run.clone(),
+            transfer_id,
+            resolved_destination.clone(),
+            cx,
+        );
+    };
+    if let Some(connection_id) = write_connection {
+        let ordinary = requires_confirmation.then(|| WriteConfirmation {
+            title: "Confirm destructive transfer".to_string(),
+            message,
+            confirm_label: "Run Transfer".to_string(),
+            destructive: true,
+        });
+        request_connection_write(
+            state.clone(),
+            crate::components::WriteRequest::new(
+                connection_id,
+                target,
+                "Run a data transfer that writes to MongoDB",
+                ordinary,
+            ),
+            window,
+            cx,
+            run,
+        );
+    } else {
+        open_confirm_dialog(
+            window,
+            cx,
+            "Confirm destructive transfer",
+            message,
+            "Run Transfer",
+            true,
+            run,
+        );
+    }
 }
 
 fn cancel_active_transfer(state: Entity<AppState>, cx: &mut App) {
@@ -262,8 +305,14 @@ impl Render for TransferView {
             let transfer = state_ref.transfer_tab(id).cloned().unwrap_or_default();
 
             let active = state_ref.active_connections_snapshot();
-            let connections: Vec<(Uuid, String)> =
-                active.iter().map(|(id, conn)| (*id, conn.config.name.clone())).collect();
+            let connections: Vec<(Uuid, crate::components::ConnectionIdentity)> = active
+                .keys()
+                .filter_map(|id| {
+                    state_ref.connection_by_id(*id).map(|connection| {
+                        (*id, crate::components::ConnectionIdentity::from(connection))
+                    })
+                })
+                .collect();
 
             let databases: Vec<String> = transfer
                 .config
@@ -318,12 +367,13 @@ impl Render for TransferView {
         let conn_ids: Vec<Uuid> = connections.iter().map(|(id, _)| *id).collect();
 
         // Update connection items if changed
-        if conn_ids != self.prev_conn_ids {
+        if connections != self.prev_connections {
             let conn_items: Vec<ConnectionItem> = connections
                 .iter()
-                .map(|(id, name)| ConnectionItem {
+                .map(|(id, identity)| ConnectionItem {
                     id: *id,
-                    name: SharedString::from(name.clone()),
+                    name: SharedString::from(identity.display_name()),
+                    identity: identity.clone(),
                 })
                 .collect();
 
@@ -337,7 +387,7 @@ impl Render for TransferView {
                     s.set_items(SearchableVec::new(conn_items), window, cx);
                 });
             }
-            self.prev_conn_ids = conn_ids.clone();
+            self.prev_connections = connections.clone();
         }
 
         // Sync source connection selected value
@@ -728,25 +778,21 @@ impl Render for TransferView {
                 (source_panel, destination_panel)
             };
 
-        let source_conn_name = transfer_state
-            .config
-            .source_connection_id
-            .and_then(|id| {
-                connections.iter().find(|(cid, _)| *cid == id).map(|(_, name)| name.clone())
-            })
-            .unwrap_or_else(|| "Select connection".to_string());
+        let source_identity = transfer_state.config.source_connection_id.and_then(|id| {
+            connections
+                .iter()
+                .find(|(connection_id, _)| *connection_id == id)
+                .map(|(_, identity)| identity)
+        });
+        let destination_identity = transfer_state.config.destination_connection_id.and_then(|id| {
+            connections
+                .iter()
+                .find(|(connection_id, _)| *connection_id == id)
+                .map(|(_, identity)| identity)
+        });
 
-        let dest_conn_name = transfer_state
-            .config
-            .destination_connection_id
-            .and_then(|id| {
-                connections.iter().find(|(cid, _)| *cid == id).map(|(_, name)| name.clone())
-            })
-            .unwrap_or_else(|| "Select connection".to_string());
-
-        // Summary panel (now inline)
         let summary_panel =
-            render_summary_panel(&transfer_state, &source_conn_name, &dest_conn_name, cx);
+            render_summary_panel(&transfer_state, source_identity, destination_identity, cx);
 
         // Progress panel
         let progress_panel: AnyElement =

--- a/src/views/transfer/select_states.rs
+++ b/src/views/transfer/select_states.rs
@@ -5,6 +5,7 @@ use gpui_component::input::{InputEvent, InputState};
 use gpui_component::select::{SearchableVec, SelectEvent, SelectItem, SelectState};
 use uuid::Uuid;
 
+use crate::components::{ConnectionIdentity, connection_identity_badge};
 use crate::state::{AppCommands, TransferMode};
 
 use super::TransferView;
@@ -14,6 +15,7 @@ use super::TransferView;
 pub(super) struct ConnectionItem {
     pub id: Uuid,
     pub name: SharedString,
+    pub identity: ConnectionIdentity,
 }
 
 impl SelectItem for ConnectionItem {
@@ -21,6 +23,10 @@ impl SelectItem for ConnectionItem {
 
     fn title(&self) -> SharedString {
         self.name.clone()
+    }
+
+    fn render(&self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        connection_identity_badge(&self.identity, true, cx)
     }
 
     fn value(&self) -> &Self::Value {

--- a/src/views/transfer/summary_panel.rs
+++ b/src/views/transfer/summary_panel.rs
@@ -1,8 +1,10 @@
 //! Summary panel showing transfer configuration at a glance.
 
+use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{ActiveTheme as _, Icon, IconName, Sizable as _};
 
+use crate::components::{ConnectionIdentity, connection_identity_badge};
 use crate::state::{
     BsonOutputFormat, CompressionMode, TransferFormat, TransferMode, TransferScope,
     TransferTabState,
@@ -14,10 +16,16 @@ use super::helpers::{fallback_text, summary_item};
 /// Render the compact summary panel showing source, destination, and format.
 pub(super) fn render_summary_panel(
     transfer_state: &TransferTabState,
-    _source_conn_name: &str,
-    dest_conn_name: &str,
+    source_identity: Option<&ConnectionIdentity>,
+    destination_identity: Option<&ConnectionIdentity>,
     cx: &App,
 ) -> AnyElement {
+    let source_conn_name = source_identity
+        .map(ConnectionIdentity::display_name)
+        .unwrap_or_else(|| "Select connection".into());
+    let dest_conn_name = destination_identity
+        .map(ConnectionIdentity::display_name)
+        .unwrap_or_else(|| "Select connection".into());
     let source_db = fallback_text(&transfer_state.config.source_database, "...");
     let source_coll = if matches!(transfer_state.config.scope, TransferScope::Collection) {
         format!(".{}", fallback_text(&transfer_state.config.source_collection, "..."))
@@ -37,7 +45,25 @@ pub(super) fn render_summary_panel(
         transfer_state.config.destination_collection.clone()
     };
 
-    let source_desc = format!("{source_db}{source_coll}");
+    let source_namespace = format!("{source_db}{source_coll}");
+    let source_connection =
+        if source_conn_name == "Select connection" { "..." } else { &source_conn_name };
+    let source_desc = match transfer_state.config.mode {
+        TransferMode::Import => {
+            if transfer_state.config.file_path.is_empty() {
+                "Choose file...".to_string()
+            } else {
+                std::path::Path::new(&transfer_state.config.file_path)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or(&transfer_state.config.file_path)
+                    .to_string()
+            }
+        }
+        TransferMode::Export | TransferMode::Copy => {
+            format!("{source_connection}:{source_namespace}")
+        }
+    };
 
     let dest_desc = match transfer_state.config.mode {
         TransferMode::Export => {
@@ -59,14 +85,14 @@ pub(super) fn render_summary_panel(
             }
         }
         TransferMode::Import => {
-            let mut label = fallback_text(&target_db, "...");
+            let mut label = format!("{source_connection}:{}", fallback_text(&target_db, "..."));
             if matches!(transfer_state.config.scope, TransferScope::Collection) {
                 label.push_str(&format!(".{}", fallback_text(&target_coll, "...")));
             }
             label
         }
         TransferMode::Copy => {
-            let conn = if dest_conn_name == "Select connection" { "..." } else { dest_conn_name };
+            let conn = if dest_conn_name == "Select connection" { "..." } else { &dest_conn_name };
             let mut label = format!("{conn}:{}", fallback_text(&target_db, "..."));
             if matches!(transfer_state.config.scope, TransferScope::Collection) {
                 label.push_str(&format!(".{}", fallback_text(&target_coll, "...")));
@@ -90,16 +116,38 @@ pub(super) fn render_summary_panel(
         _ => format_label,
     };
 
-    // Compact horizontal summary
-    div()
+    let identity_row = div()
         .flex()
         .items_center()
+        .gap(spacing::md())
+        .when_some(source_identity, |row, identity| {
+            row.child(connection_identity_badge(identity, true, cx))
+        })
+        .when_some(
+            (transfer_state.config.mode == TransferMode::Copy)
+                .then_some(destination_identity)
+                .flatten(),
+            |row, identity| {
+                row.child(
+                    Icon::new(IconName::ArrowRight)
+                        .xsmall()
+                        .text_color(cx.theme().muted_foreground),
+                )
+                .child(connection_identity_badge(identity, true, cx))
+            },
+        );
+
+    div()
+        .flex()
+        .flex_col()
+        .gap(spacing::sm())
         .justify_between()
         .p(spacing::md())
         .bg(cx.theme().sidebar)
         .border_1()
         .border_color(cx.theme().border)
         .rounded(borders::radius_sm())
+        .child(identity_row)
         .child(
             div()
                 .flex()

--- a/tests/read_only_tests.rs
+++ b/tests/read_only_tests.rs
@@ -11,7 +11,15 @@ use openmango::ai::tools::aggregate::{AggregateArgs, AggregateTool};
 use openmango::ai::tools::insert::{InsertArgs, InsertDocumentsTool};
 use openmango::ai::tools::update::{UpdateArgs, UpdateDocumentsTool};
 use openmango::ai::tools::{MongoContext, StreamEvent};
+use openmango::models::{ConnectionWriteIdentity, SavedConnection};
 use rig::tool::Tool;
+
+fn write_identity(read_only: bool) -> ConnectionWriteIdentity {
+    let mut connection =
+        SavedConnection::new("Integration test".into(), "mongodb://localhost".into());
+    connection.read_only = read_only;
+    ConnectionWriteIdentity::from(&connection)
+}
 
 #[tokio::test]
 async fn read_only_ai_update_is_rejected_without_mutating_data() {
@@ -26,6 +34,7 @@ async fn read_only_ai_update_is_rejected_without_mutating_data() {
         client: mongo.client.clone(),
         database: mongo.db_name("test_db"),
         collection: Some("ai_read_only_update".to_string()),
+        write_identity: write_identity(true),
         read_only: true,
         event_tx: None,
     });
@@ -53,6 +62,7 @@ async fn ai_write_fails_closed_without_confirmation_channel() {
         client: mongo.client.clone(),
         database: mongo.db_name("test_db"),
         collection: Some("ai_missing_confirmation".to_string()),
+        write_identity: write_identity(false),
         read_only: false,
         event_tx: None,
     });
@@ -79,6 +89,7 @@ async fn ai_update_one_confirmation_reports_one_affected_document() {
         client: mongo.client.clone(),
         database: mongo.db_name("test_db"),
         collection: Some("ai_update_one_preview".to_string()),
+        write_identity: write_identity(false),
         read_only: false,
         event_tx: Some(event_tx),
     });
@@ -118,6 +129,7 @@ async fn read_only_ai_output_stage_is_rejected_without_creating_target() {
         client: mongo.client.clone(),
         database: mongo.db_name("test_db"),
         collection: Some("ai_read_only_aggregate".to_string()),
+        write_identity: write_identity(true),
         read_only: true,
         event_tx: None,
     });
@@ -148,6 +160,7 @@ async fn writable_ai_output_stage_requires_confirmation_before_execution() {
         client: mongo.client.clone(),
         database: mongo.db_name("test_db"),
         collection: Some("ai_confirmed_aggregate".to_string()),
+        write_identity: write_identity(false),
         read_only: false,
         event_tx: Some(event_tx),
     });


### PR DESCRIPTION
## Summary

- complete the shared Query Library saved-query model with descriptions, tags, search, duplicate/update/delete, and explicit connection/global scope
- add bounded, versioned, atomic JSON import/export that excludes history, local connection identity, and credential-like content
- add explicit Development, Staging, and Production connection identity with consistent text/color presentation across the workspace
- add optional fail-closed confirmation for Production writes and Forge execution while preserving read-only precedence
- document the product principles and update the feature/changelog records

## Safety

- Production is never inferred from names, hosts, URIs, databases, or colors
- write approval snapshots and revalidates connection endpoint, transport, secret identity, environment, and read-only state
- authorization is callback-scoped and revoked after aborts or failed preflight checks
- destructive and Production confirmation compose into one prompt
- query import validates the complete bounded payload before one atomic persistence step
- connection-scoped saved queries cannot cross connections or namespaces

## Validation

- `just precommit`
  - 343 library tests passed
  - all integration suites passed
  - release check, Clippy with warnings denied, formatting, and sidecar checks passed
- final independent safety and product reviews found no remaining P0-P2 issues
- `git diff --check`

## Manual QA

Maintainer smoke test requested before merge:

- Query Library save/edit/duplicate/search/scope/import/export flows and focus restoration
- native import/export file pickers
- connection environment controls and identity in narrow tabs/sidebar/Transfer
- Production confirmation across Documents, detached editor, aggregation, Forge, AI, Transfer, and database/collection actions
- cancellation and read-only behavior

Screenshots are pending that native GPUI smoke-test pass.
