### PR TITLE
Redesign connection workflow and fix manager crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,20 @@ jobs:
       - name: Verify Docker availability
         run: docker version
 
+      - name: Pull integration test images
+        run: |
+          for test_image in mongo:7.0 testcontainers/sshd:1.3.0; do
+            for pull_attempt in 1 2 3; do
+              if docker pull "$test_image"; then
+                break
+              fi
+              if [ "$pull_attempt" -eq 3 ]; then
+                exit 1
+              fi
+              sleep 5
+            done
+          done
+
       - name: Download MongoDB Database Tools
         run: ./scripts/download_tools.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Searchable native connection list, visible disconnected connections with row actions, and separate Save and Save & Connect actions
 - Copy ID action for documents, including ID-only copying of a selected collapsed document
 - Open a highlighted collection in Forge with Cmd/Ctrl+Shift+F, or choose Open Forge as the collection double-click action in Settings; queries start with `find({})`, ready to run ([#12](https://github.com/ggagosh/openmango/issues/12))
 - Authenticated local MCP agent access with per-connection sharing and write controls, bounded read tools, direct document insert/update/replace/delete, and metadata-only History restore tools
@@ -38,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Reload a database to refresh its collection list from the server without reconnecting
 
 ### Fixed
+- Prevent a crash when opening New Connection or switching saved connections; retain drafts and active sessions when connection persistence fails
+- Keep pasted URI options and encoded credentials in sync with the editor, and ignore connection test results after the tested settings change
 - Workspace tabs now stay within the title bar, follow the active tab when overflowing, and accept shortcuts immediately after launch
 - Query editors retain focus and place the caret correctly on left-click, including collapsed and scrolled inputs
 - Forge completions preserve existing arguments and apply the inserted text and caret position together

--- a/docs/CONNECTION_WORKFLOW_RESEARCH.md
+++ b/docs/CONNECTION_WORKFLOW_RESEARCH.md
@@ -1,0 +1,140 @@
+# Native connection workflow research
+
+Reviewed 2026-09-10. Research and implementation notes for `redesign/connection-workflow`; no dependencies added.
+Sources: current primary Apple, MongoDB Compass, and JetBrains documentation; installed GPUI Kit/Base/Component 0.6.0 source.
+Reference clone: [`refs/gpui-kit` at 36b51819deb52c947a79f8de29e0e9175eda7464](https://github.com/longbridge/gpui-kit/tree/36b51819deb52c947a79f8de29e0e9175eda7464).
+Recommendations below are OpenMango design decisions inferred from those sources, not claims that another product implements every detail.
+
+## Implemented workflow
+
+- The sidebar shows every saved connection. **Connections** opens the manager, **New** starts a draft, and each connection has its own Connect and actions menu. The global globe dropdown and settings gear are removed.
+- The manager uses GPUI Kit's searchable List, native form fields, tabs, switches, buttons, and button groups. URI and optional name come first; Auth, TLS, Network, Advanced, and Access hold the remaining settings.
+- **Test** validates the current draft and is optional. Results belong to the full draft snapshot, including credentials and transport settings, and cannot overwrite a newer test or another connection's status.
+- **Save** persists settings without connecting. Existing sessions retain their original connection settings until **Reconnect**; the editor indicates when saved changes require it. **Save & Connect / Reconnect** waits for persistence and rechecks unsaved database work before reconnecting.
+- Failed persistence preserves both the editor draft and any existing session. URI editing preserves unknown options, encoded credentials, TLS aliases, and in-progress query delimiters. Credentials are hidden even when a pasted URI is incomplete.
+- Opening the manager no longer reads its entity while it is under construction or update, addressing the reported New Connection crash.
+
+Headless checks cover opening/reusing the manager, unsaved-change cancellation, native list confirmation, URI typing/pasting, persistence success/failure, active-session preservation, stale test results, and rendering each tab at normal and narrow sizes. Desktop visual review remains manual: open New, paste a URI, Save, connect from its sidebar row, edit and Save while connected, then Reconnect.
+
+## Recommended direction
+
+Use one clearly labeled **Connections…** entry to a saved-connection list and detail editor.
+Put **New connection** inside that surface; keep direct Connect/Disconnect commands with the connection they affect.
+Remove the competing global globe dropdown and gear route; menu/keyboard equivalents can invoke the same entry point.
+The application sidebar remains the place to navigate active databases, while the connection surface owns configuration.
+This simplifies ownership without making double-click the only way to connect or edit.
+
+Apple describes toolbars as convenient access to frequently used commands; the inference here is to expose distinct tasks, not several ambiguous routes to the same task.
+DataGrip provides a concrete list/detail precedent: selecting a saved data source displays its settings in the adjacent pane.
+[Apple: Toolbars](https://developer.apple.com/design/human-interface-guidelines/toolbars), [DataGrip: Data Sources and Drivers](https://www.jetbrains.com/help/datagrip/data-sources-and-drivers-dialog.html)
+
+## Saved configuration and active session are different things
+
+| Concept | Meaning in OpenMango | Visible treatment |
+| --- | --- | --- |
+| Saved connection | Persisted name, endpoint, credentials reference, and options | Searchable row; editable without connecting |
+| Draft | Unsaved edits to a new or saved connection | Unsaved marker; preserved while Test runs |
+| Test result | Result for one exact configuration snapshot | Inline success/error; invalidated when connection-affecting fields change |
+| Active session | A live connection established from a configuration snapshot | Connected/Connecting/Disconnected state beside its name |
+
+DataGrip explicitly separates a data source configuration from a session that wraps a live connection.
+Compass separately documents saved/favorite connections, currently active connections, connection actions, and connected-row metadata editing.
+Those distinctions support clear labels; they do not require exposing technical session machinery to the user.
+[DataGrip: Connection to a database](https://www.jetbrains.com/help/datagrip/connecting-to-a-database.html), [Compass: Connections Sidebar](https://www.mongodb.com/docs/compass/connect/connections/)
+
+## One predictable editing flow
+
+1. Open Connections: show saved rows and the selected connection's details; opening or selecting a row performs no network operation.
+2. New connection: create a local draft, focus the connection-string field, and retain it until saved or explicitly discarded.
+3. Edit: select an existing row, then modify the adjacent form; leave the saved record unchanged until Save.
+4. Test: test the current draft as entered, without saving it or replacing the active session.
+5. Save: persist validated settings and retain the editor/selection; show a quiet saved state.
+6. Connect: use the selected saved configuration; for a new or dirty draft, label the combined action **Save & Connect**.
+7. A successful connection reveals/focuses the corresponding database navigation; failure leaves the form and its draft available for correction.
+
+Compass documents Save, Connect, and Save & Connect as separate outcomes, including an unsaved one-off Connect path.
+For OpenMango, the primary recommendation is saved connections plus an explicitly named combined action; one-off connections need not become a new feature in this redesign.
+DataGrip documents Test Connection as a distinct check of connection settings and communication.
+[Compass: Connect](https://www.mongodb.com/docs/compass/connect/), [DataGrip: connection settings](https://www.jetbrains.com/help/datagrip/data-sources-and-drivers-dialog.html)
+
+## Form composition and action hierarchy
+
+Keep name and connection string near the top, with an endpoint summary that excludes credentials.
+Offer paste-first URI entry; expose Authentication as a clear nearby section rather than requiring users to edit a password inside a URI.
+Keep TLS, Network/SSH, and other advanced settings in progressive sections or a short native tab strip.
+The initial section should answer what to connect to and how to authenticate; optional configuration should not dominate first use.
+Keep fields left-aligned at a readable width beside the connection list, with one scrollable form region and a stable action footer.
+
+Compass supports pasting a connection string and exposes Authentication, TLS/SSL, and SSH through advanced options.
+Its documentation warns that editing a connection string can expose credentials and points to Authentication fields for password editing.
+Apple's data-entry guidance emphasizes reducing the amount people must supply and preventing mistakes.
+[Compass: Connect](https://www.mongodb.com/docs/compass/connect/), [Apple: Entering data](https://developer.apple.com/design/human-interface-guidelines/entering-data)
+
+| State | Secondary actions | Primary action |
+| --- | --- | --- |
+| New draft | Test Connection; Save | Save & Connect |
+| Saved, unchanged, disconnected | Test Connection | Connect |
+| Saved, dirty, disconnected | Test Connection; Save | Save & Connect |
+| Saved, unchanged, connected | Test Connection; Disconnect | Open databases |
+| Connected configuration with edits | Test Connection | Save; explicit reconnect only if requested |
+
+Avoid two equally prominent Connect buttons on the same surface. A list-row quick action and the editor footer can share one command implementation.
+Do not advertise test success as a prerequisite for Save or Connect: it is useful feedback, not a mandatory extra click.
+
+## Dirty navigation and editing connected configurations
+
+Switching rows, starting another New draft, or closing the editor with unsaved changes uses one **Save / Discard / Cancel** decision.
+Cancel keeps the current draft and focus; Save resumes the original navigation only after persistence succeeds.
+Keep routine validation and successful tests inline. Reserve alerts for a pending decision that would otherwise lose work.
+Apple recommends using alerts sparingly and avoiding them for information alone; the three-way dirty decision is this design's application of that guidance.
+[Apple: Alerts](https://developer.apple.com/design/human-interface-guidelines/alerts)
+
+Editing and saving an endpoint, authentication, TLS, or network option must not silently mutate or replace a live session.
+Show **Saved changes apply on the next connection** while the active session continues with its original configuration.
+Metadata-only changes such as name/color may update presentation immediately; distinguish them from connection-affecting edits.
+An explicit Reconnect operation can apply the new settings through the application's existing session/dirty-work guards.
+Compass provides a useful conservative precedent: its documented connected edits are name, color, and favorite status.
+[Compass: edit connected connections](https://www.mongodb.com/docs/compass/connect/connections/#edit-connections)
+
+## Testing, errors, and asynchronous work
+
+Test Connection shows **Testing…** on the initiating button and a local pending indicator, preserving all entered values.
+On success, show a brief inline result; on failure, show a readable category, concise message, and expandable technical detail.
+Connection failures should remain reviewable next to the relevant configuration rather than existing only in a transient toast.
+Compass exposes a row error indicator and additional error review; OpenMango can retain the detail directly in its editor.
+[Compass: connection errors](https://www.mongodb.com/docs/compass/connect/connections/#connect-to-mongodb)
+
+Associate every request with the draft identity and revision that started it; late results must not attach to another connection or overwrite a newer test.
+Changing connection-affecting fields invalidates the displayed test result; changing only the display name need not.
+During Save & Connect, persist first. If connecting fails afterward, report **Saved, but could not connect** rather than implying the save failed.
+Keep retry explicit. Show Cancel only when the operation actually supports cancellation, and keep request completion separate from view lifetime.
+
+## Native GPUI 0.6.0 implementation map
+
+| Need | Verified shipped API | Important boundary |
+| --- | --- | --- |
+| Saved connection list/search | `ListState::new(delegate, window, cx).searchable(true)`; `List::new(&state)` | `ListDelegate` owns search, rows, selection, and confirm behavior |
+| Preserve selected row | `set_selected_index`; `scroll_to_item(ix, ScrollStrategy::Nearest, window, cx)` | Setting selection does not automatically scroll; use stable connection IDs |
+| Name/URI/password fields | Retained `InputState`; `Input::new(&state)`; `.masked(true)` on password state | Labels and masking do not implement URI parsing or credential storage |
+| Authentication/options | `SelectState::new(delegate, selected_index, window, cx)` | Store typed values; display labels are not configuration identity |
+| Sections | `TabBar::new(id).selected_index(index).on_click(...)`; `Tab::new().label(...)` | TabBar callback receives `&usize`; it replaces child click callbacks |
+| Progressive options | `Collapsible::new().open(open).content(...)` | Application owns the open bool and an accessible toggle button/header |
+| Field labels/help | `v_form()` / `h_form()` plus `field().label(...).description(...)` | Form is layout, not validation or automatic submission |
+| Pending/error state | `Button::loading(bool)`; `Alert::error(id, message)` / `Alert::success(...)` | Guard duplicate operations in state; spinner styling is not an async controller |
+
+[Published List](https://docs.rs/crate/gpui-component/0.6.0/source/src/list/list.rs), [ListDelegate](https://docs.rs/crate/gpui-component/0.6.0/source/src/list/delegate.rs), [Input state](https://docs.rs/crate/gpui-base/0.6.0/source/src/input/base/state.rs), [Select](https://docs.rs/crate/gpui-component/0.6.0/source/src/select.rs)
+[Published TabBar](https://docs.rs/crate/gpui-component/0.6.0/source/src/tab/tab_bar.rs), [Collapsible](https://docs.rs/crate/gpui-component/0.6.0/source/src/collapsible.rs), [Form](https://docs.rs/crate/gpui-component/0.6.0/source/src/form/form.rs), [Alert](https://docs.rs/crate/gpui-component/0.6.0/source/src/alert.rs), [Button](https://docs.rs/crate/gpui-component/0.6.0/source/src/button/button.rs)
+
+## API and integration traps
+
+- Current clone/docs expose `Form::new()`, `.label_layout(...)`, and `.footer(...)`; published 0.6.0 does not. Use `Form::vertical()` / `horizontal()` or helper constructors, with an ordinary native footer sibling.
+- Retain field entities across tab/disclosure changes. `InputState::set_value` resets selection, scroll, and undo, so do not refill fields every render.
+- A generic `InputState::validate` boolean predicate is not a connection-validation workflow. Preserve incomplete URI/password drafts and present actionable errors at the appropriate boundary.
+- Make the editor's focus scope explicit. Enter in a multiline field, select popup, or dirty dialog must not accidentally trigger Connect.
+- Snapshot status needed by row/render helpers before rendering child controls. Do not synchronously re-read a manager entity while it is already being updated.
+- Keep existing native sizing, typography, buttons, and input appearance; Base is useful for interaction ownership, not a reason to introduce a second visual language.
+
+[Current Form source](https://github.com/longbridge/gpui-kit/blob/36b51819deb52c947a79f8de29e0e9175eda7464/crates/component/src/form/form.rs#L29), [published input mutation behavior](https://docs.rs/crate/gpui-base/0.6.0/source/src/input/base/state.rs)
+
+This report verifies source/API availability and documents design recommendations; it does not claim rendered UX validation or implementation completeness.
+Apple's JavaScript-rendered pages were read through their official documentation JSON endpoints; linked HIG pages remain the human-readable references.

--- a/src/app/sidebar/mod.rs
+++ b/src/app/sidebar/mod.rs
@@ -92,6 +92,7 @@ impl Sidebar {
             match event {
                 AppEvent::ConnectionAdded
                 | AppEvent::ConnectionUpdated
+                | AppEvent::ConnectionSaveFinished { .. }
                 | AppEvent::ConnectionRemoved
                 | AppEvent::DatabasesLoaded(_) => {
                     this.refresh_tree(cx);
@@ -145,8 +146,10 @@ impl Sidebar {
                     this.model.clear_selection();
                     this.refresh_tree(cx);
                 }
-                AppEvent::ConnectionFailed(_) => {
-                    this.model.connecting_connection = None;
+                AppEvent::ConnectionFailed { connection_id, .. } => {
+                    if this.model.connecting_connection == Some(*connection_id) {
+                        this.model.connecting_connection = None;
+                    }
                     this.model.loading_databases.clear();
                     this.model.clear_selection();
                     cx.notify();

--- a/src/app/sidebar/view.rs
+++ b/src/app/sidebar/view.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use gpui_kit::component::ActiveTheme as _;
 use gpui_kit::component::button::{Button, ButtonVariants as _};
 use gpui_kit::component::input::Input;
-use gpui_kit::component::menu::{ContextMenuExt, DropdownMenu as _, PopupMenu, PopupMenuItem};
+use gpui_kit::component::menu::{ContextMenuExt, DropdownMenu as _};
 use gpui_kit::component::scroll::ScrollableElement;
 use gpui_kit::component::spinner::Spinner;
 use gpui_kit::component::tooltip::Tooltip;
@@ -66,12 +66,6 @@ impl Render for Sidebar {
                 .collect::<HashMap<_, _>>(),
         );
 
-        let disconnected_connections: Vec<_> = self
-            .cached_connections
-            .iter()
-            .filter(|c| !active_connections.contains_key(&c.id))
-            .cloned()
-            .collect();
         let pending_agent_actions = self
             .state
             .read(cx)
@@ -91,7 +85,6 @@ impl Render for Sidebar {
         let state_for_add = state.clone();
         let state_for_activity = state.clone();
         let state_for_manager = state.clone();
-        let state_for_connect = state.clone();
         let state_for_tree = self.state.clone();
         let sidebar_entity = cx.entity();
         let scroll_handle = self.scroll_handle.clone();
@@ -205,21 +198,22 @@ impl Render for Sidebar {
                 this.close_search(window, cx);
             }))
             .child(
-                // Header with "+" button
+                // Keep management actions visible when the sidebar is narrow.
                 div()
                     .flex()
+                    .flex_wrap()
+                    .gap(spacing::xs())
                     .items_center()
                     .justify_between()
                     .px(spacing::md())
-                    .h(sizing::header_height())
+                    .py(spacing::xs())
+                    .min_h(sizing::header_height())
                     .border_b_1()
                     .border_color(islands::panel_border(&appearance, cx))
                     .child(
-                        div()
-                            .text_xs()
-                            .font_weight(FontWeight::NORMAL)
-                            .text_color(cx.theme().secondary_foreground)
-                            .child("CONNECTIONS"),
+                        Button::new("manage-connections-btn").ghost().small()
+                            .label("Connections").tooltip("Manage saved connections")
+                            .on_click(move |_, window, cx| ConnectionManager::open(state_for_manager.clone(), window, cx)),
                     )
                     .child(
                         div()
@@ -236,48 +230,13 @@ impl Render for Sidebar {
                                         window.dispatch_action(Box::new(OpenActionBar), cx);
                                     }),
                             )
-                            .child({
-                                let sidebar_entity = sidebar_entity.clone();
-                                // Connect dropdown button
-                                Button::new("connect-dropdown-btn")
-                                    .icon(Icon::new(IconName::Globe).xsmall())
-                                    .ghost()
-                                    .xsmall()
-                                    .tooltip("Connect saved connection")
-                                    .dropdown_menu(move |mut menu: PopupMenu, _window, _cx| {
-                                        if disconnected_connections.is_empty() {
-                                            menu = menu.item(
-                                                PopupMenuItem::new("All connected").disabled(true),
-                                            );
-                                        } else {
-                                            for conn in &disconnected_connections {
-                                                let conn_id = conn.id;
-                                                let state = state_for_connect.clone();
-                                                let sidebar_entity = sidebar_entity.clone();
-                                                menu = menu.item(
-                                                    PopupMenuItem::new(conn.name.clone())
-                                                        .on_click(move |_, _window, cx| {
-                                                            sidebar_entity.update(cx, |sidebar, cx| {
-                                                                sidebar.expand_connection_and_refresh(conn_id, cx);
-                                                            });
-                                                            AppCommands::connect(
-                                                                state.clone(),
-                                                                conn_id,
-                                                                cx,
-                                                            );
-                                                        }),
-                                                );
-                                            }
-                                        }
-                                        menu
-                                    })
-                            })
                             .child(
                                 Button::new("add-connection-btn")
                                     .icon(Icon::new(IconName::Plus).xsmall())
                                     .ghost()
                                     .xsmall()
-                                    .tooltip("Add connection")
+                                    .label("New")
+                                    .tooltip("New connection")
                                     .on_click(move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
                                         Sidebar::open_add_dialog(state_for_add.clone(), window, cx);
                                     }),
@@ -321,16 +280,6 @@ impl Render for Sidebar {
                                                 .text_color(cx.theme().danger_foreground)
                                                 .child(label),
                                         )
-                                    }),
-                            )
-                            .child(
-                                Button::new("manage-connections-btn")
-                                    .icon(Icon::new(IconName::Settings).xsmall())
-                                    .ghost()
-                                    .xsmall()
-                                    .tooltip("Manage connections")
-                                    .on_click(move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
-                                        ConnectionManager::open(state_for_manager.clone(), window, cx);
                                     }),
                             )
                     ),
@@ -606,6 +555,7 @@ impl Render for Sidebar {
                                         } else {
                                             theme_primary
                                         };
+                                        let is_connected = active_connections.contains_key(&connection_id);
                                         let is_connecting =
                                             is_connection && connecting_id == Some(connection_id);
                                         let is_loading_db =
@@ -778,7 +728,7 @@ impl Render for Sidebar {
                                                 this.child(
                                                     Icon::new(IconName::Globe)
                                                         .size(sizing::icon_md())
-                                                        .text_color(connection_accent.unwrap_or(theme_primary)),
+                                                        .text_color(if is_connected { connection_accent.unwrap_or(theme_primary) } else { theme_muted_foreground }),
                                                 )
                                             })
                                             // Database: dashboard icon (blue)
@@ -819,6 +769,23 @@ impl Render for Sidebar {
                                                     ))
                                                 },
                                             )
+                                            .when(is_connection && !is_connected && !is_connecting, |row| {
+                                                let state = state_clone.clone();
+                                                let sidebar = sidebar_entity.clone();
+                                                row.child(Button::new(format!("connect-sidebar-{connection_id}")).ghost().xsmall().label("Connect")
+                                                    .on_click(move |_, _, cx| {
+                                                        cx.stop_propagation();
+                                                        sidebar.update(cx, |sidebar, cx| sidebar.expand_connection_and_refresh(connection_id, cx));
+                                                        AppCommands::connect(state.clone(), connection_id, cx);
+                                                    }))
+                                            })
+                                            .when(is_connection, |row| {
+                                                let state = state_clone.clone();
+                                                let sidebar = sidebar_entity.clone();
+                                                row.child(Button::new(format!("connection-menu-{connection_id}")).ghost().xsmall()
+                                                    .icon(IconName::Ellipsis).tooltip("Connection actions")
+                                                    .dropdown_menu(move |menu, window, cx| build_connection_menu(menu, state.clone(), sidebar.clone(), connection_id, connecting_id, window, cx)))
+                                            })
                                             .when(is_connecting || is_loading_db, |this| {
                                                 this.child(Spinner::new().xsmall())
                                             });

--- a/src/app/sidebar_model.rs
+++ b/src/app/sidebar_model.rs
@@ -269,13 +269,15 @@ impl SidebarModel {
         let mut items = Vec::new();
         for conn in connections {
             let active_conn = active.get(&conn.id);
-            if active_conn.is_none() {
-                continue; // Only show connected
-            }
-
             let conn_node_id = TreeNodeId::connection(conn.id);
-            let conn_expanded = expanded.contains(&conn_node_id);
-            items.push(SidebarEntry::new(conn_node_id, conn.name.clone(), 0, true, conn_expanded));
+            let conn_expanded = active_conn.is_some() && expanded.contains(&conn_node_id);
+            items.push(SidebarEntry::new(
+                conn_node_id,
+                conn.name.clone(),
+                0,
+                active_conn.is_some(),
+                conn_expanded,
+            ));
 
             if let Some(active_conn) = active_conn
                 && conn_expanded
@@ -330,6 +332,22 @@ impl SidebarModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn disconnected_saved_connections_remain_visible() {
+        let connection = SavedConnection::new("Saved".into(), "mongodb://localhost".into());
+        let id = TreeNodeId::connection(connection.id);
+        let expanded = HashSet::from([id.clone()]);
+        let entries = SidebarModel::build_entries(
+            &[connection],
+            &std::collections::HashMap::new(),
+            &expanded,
+        );
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, id);
+        assert!(!entries[0].is_folder);
+        assert!(!entries[0].is_expanded);
+    }
 
     fn model_with_entries(entries: Vec<SidebarEntry>) -> SidebarModel {
         let entry_index_by_id = SidebarModel::build_index(&entries);

--- a/src/components/connection_manager/actions.rs
+++ b/src/components/connection_manager/actions.rs
@@ -1,24 +1,16 @@
-use gpui_kit::component::ActiveTheme as _;
-use gpui_kit::component::Sizable as _;
-use gpui_kit::component::WindowExt as _;
-use gpui_kit::component::button::ButtonVariants as _;
-use gpui_kit::component::dialog::Dialog;
-use gpui_kit::component::input::{Input, InputState, Position};
-use gpui_kit::{
-    App, AppContext as _, Context, Entity, Focusable as _, IntoElement as _, ParentElement as _,
-    Styled as _, Window, div, px,
-};
+use gpui_kit::component::input::InputState;
+use gpui_kit::{App, AppContext as _, Context, Entity, Focusable as _, Window};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::components::{Button, cancel_button, open_confirm_dialog, request_remove_connection};
+use crate::components::{open_confirm_dialog, request_remove_connection};
+use crate::helpers::validate::{percent_decode, percent_encode};
 use crate::helpers::{
     UriSecrets, extract_host_from_uri, extract_uri_secrets, inject_uri_secrets, strip_uri_secrets,
     validate_mongodb_uri,
 };
 use crate::models::{ProxyConfig, ProxyKind, SavedConnection, SshAuth, SshConfig};
-use crate::state::{AppState, TabKey};
-use crate::theme::spacing;
+use crate::state::{AppCommands, AppState, TabKey, UnsavedScope};
 
 use super::uri::{bool_to_query, parse_bool, parse_uri, value_or_none};
 use super::{ConnectionManager, TestStatus};
@@ -26,11 +18,57 @@ use super::{ConnectionManager, TestStatus};
 const TEST_CONNECTION_TIMEOUT_SECS: u64 = 30;
 
 fn non_empty_value(state: &Entity<InputState>, cx: &App) -> Option<String> {
-    let value = state.read(cx).value().trim().to_string();
+    let value = state.read(cx).value().to_string();
     (!value.is_empty()).then_some(value)
 }
 
 impl ConnectionManager {
+    pub(super) fn request_save(
+        view: Entity<Self>,
+        connect: bool,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        if view.read(cx).pending_save.is_some()
+            || matches!(view.read(cx).status, TestStatus::Testing)
+            || view.read(cx).connecting_id == view.read(cx).selected_id
+                && view.read(cx).connecting_id.is_some()
+        {
+            return;
+        }
+        let state = view.read(cx).state.clone();
+        let selected_id = view.read(cx).selected_id;
+        let save = {
+            let state = state.clone();
+            move |window: &mut Window, cx: &mut App| {
+                if connect
+                    && !view.read(cx).has_unsaved_changes(cx)
+                    && let Some(connection_id) = view.read(cx).selected_id
+                {
+                    AppCommands::connect(state.clone(), connection_id, cx);
+                } else {
+                    view.update(cx, |this, cx| {
+                        this.save_connection(connect, window, cx);
+                    });
+                }
+            }
+        };
+        if connect
+            && let Some(connection_id) = selected_id
+            && state.read(cx).is_connected(connection_id)
+        {
+            crate::components::request_unsaved_action(
+                state,
+                UnsavedScope::Connection(connection_id),
+                window,
+                cx,
+                save,
+            );
+        } else {
+            save(window, cx);
+        }
+    }
+
     pub fn open(state: Entity<AppState>, window: &mut Window, cx: &mut App) {
         Self::open_with_selected(state, None, false, window, cx);
     }
@@ -61,26 +99,27 @@ impl ConnectionManager {
     }
 
     pub(crate) fn apply_open_request(
-        &mut self,
+        view: Entity<Self>,
         selected_id: Option<Uuid>,
         creating_new: bool,
         window: &mut Window,
-        cx: &mut Context<Self>,
+        cx: &mut App,
     ) {
         if creating_new {
-            Self::request_load_connection(cx.entity(), None, window, cx);
+            Self::request_load_connection(view, None, window, cx);
             return;
         }
 
         if let Some(connection) = selected_id.and_then(|connection_id| {
-            self.state
+            view.read(cx)
+                .state
                 .read(cx)
                 .connections
                 .iter()
                 .find(|connection| connection.id == connection_id)
                 .cloned()
         }) {
-            Self::request_load_connection(cx.entity(), Some(connection), window, cx);
+            Self::request_load_connection(view, Some(connection), window, cx);
         }
     }
 
@@ -94,6 +133,9 @@ impl ConnectionManager {
         window: &mut Window,
         cx: &mut App,
     ) {
+        if view.read(cx).pending_save.is_some() {
+            return;
+        }
         let is_same_connection = connection.as_ref().is_some_and(|connection| {
             !view.read(cx).creating_new && view.read(cx).selected_id == Some(connection.id)
         });
@@ -132,7 +174,7 @@ impl ConnectionManager {
             this.load_connection(connection, window, cx);
             this.active_tab = super::ManagerTab::General;
             if creating_new {
-                let focus = this.draft.name_state.read(cx).focus_handle(cx);
+                let focus = this.draft.uri_state.read(cx).focus_handle(cx);
                 window.focus(&focus, cx);
             }
             cx.notify();
@@ -190,9 +232,11 @@ impl ConnectionManager {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.test_generation += 1;
+        self.connecting_id = None;
         self.status = TestStatus::Idle;
-        self.last_tested_uri = None;
-        self.pending_test_uri = None;
+        self.last_tested_fingerprint = None;
+        self.pending_test_fingerprint = None;
         self.testing_step = None;
         self.parse_error = None;
         self.creating_new = connection.is_none();
@@ -218,6 +262,7 @@ impl ConnectionManager {
             self.draft.reset(window, cx);
         }
         self.baseline_fingerprint = self.draft.fingerprint(cx);
+        self.sync_connection_list(window, cx);
     }
 
     fn load_transport_settings(
@@ -405,13 +450,99 @@ impl ConnectionManager {
         if !crate::components::should_capture_uri_change(&mut self.draft.internal_uri_value, &uri) {
             return;
         }
-        let secrets = extract_uri_secrets(&uri);
+        let mut secrets = extract_uri_secrets(&uri);
+        let sanitized = if secrets.is_empty() { uri.clone() } else { strip_uri_secrets(&uri) };
+        if let Ok(parts) = parse_uri(&uri) {
+            let (username, password) = parts.userinfo();
+            let same_user = username.as_deref().unwrap_or_default()
+                == self.draft.username_state.read(cx).value().as_ref();
+            if same_user
+                && parts.get_query("authMechanism").eq_ignore_ascii_case("MONGODB-AWS")
+                && secrets.aws_session_token.is_none()
+            {
+                secrets.aws_session_token = self.draft.uri_secrets.aws_session_token.clone();
+            }
+            if same_user
+                && !parts.get_query("proxyHost").is_empty()
+                && secrets.proxy_password.is_none()
+            {
+                secrets.proxy_password = self.draft.uri_secrets.proxy_password.clone();
+            }
+            if username.as_deref() == Some(self.draft.username_state.read(cx).value().as_ref())
+                && password.is_none()
+            {
+                secrets.password = non_empty_value(&self.draft.password_state, cx)
+                    .map(|value| percent_encode(&value));
+            }
+            if secrets.tls_certificate_key_file_password.is_none() {
+                secrets.tls_certificate_key_file_password =
+                    non_empty_value(&self.draft.tls_cert_key_password_state, cx)
+                        .map(|value| percent_encode(&value));
+            }
+        }
+        // Preserve the authority while a credential-bearing URI has no host yet.
+        if secrets.password.is_some()
+            && let Some(userinfo) = uri
+                .split_once("://")
+                .and_then(|(_, rest)| rest.split_once('@').map(|(userinfo, _)| userinfo))
+        {
+            let username = userinfo.split_once(':').map(|(user, _)| user).unwrap_or(userinfo);
+            self.draft
+                .username_state
+                .update(cx, |input, cx| input.set_value(percent_decode(username), window, cx));
+        }
+        self.import_uri_with_display(
+            inject_uri_secrets(&sanitized, &secrets),
+            sanitized,
+            window,
+            cx,
+        );
+    }
+
+    pub(super) fn real_uri(&self, cx: &App) -> String {
+        let uri = self.draft.uri_state.read(cx).value().to_string();
+        let mut secrets = self.draft.uri_secrets.clone();
+        secrets.password =
+            non_empty_value(&self.draft.password_state, cx).map(|value| percent_encode(&value));
+        secrets.tls_certificate_key_file_password =
+            non_empty_value(&self.draft.tls_cert_key_password_state, cx)
+                .map(|value| percent_encode(&value));
+        inject_uri_secrets(&strip_uri_secrets(&uri), &secrets)
+    }
+
+    fn import_uri(&mut self, uri: String, window: &mut Window, cx: &mut Context<Self>) {
+        let sanitized_uri = strip_uri_secrets(&uri);
+        self.import_uri_with_display(uri, sanitized_uri, window, cx);
+    }
+
+    fn import_uri_with_display(
+        &mut self,
+        uri: String,
+        sanitized_uri: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let uri_secrets = extract_uri_secrets(&uri);
+        if self.draft.uri_state.read(cx).value().as_ref() != sanitized_uri {
+            self.draft.internal_uri_value = Some(sanitized_uri.clone());
+            self.draft
+                .uri_state
+                .update(cx, |state, cx| state.set_value(sanitized_uri.clone(), window, cx));
+        }
         self.draft.password_state.update(cx, |state, cx| {
-            state.set_value(secrets.password.clone().unwrap_or_default(), window, cx)
+            state.set_value(
+                uri_secrets.password.as_deref().map(percent_decode).unwrap_or_default(),
+                window,
+                cx,
+            )
         });
         self.draft.tls_cert_key_password_state.update(cx, |state, cx| {
             state.set_value(
-                secrets.tls_certificate_key_file_password.clone().unwrap_or_default(),
+                uri_secrets
+                    .tls_certificate_key_file_password
+                    .as_deref()
+                    .map(percent_decode)
+                    .unwrap_or_default(),
                 window,
                 cx,
             )
@@ -419,33 +550,9 @@ impl ConnectionManager {
         self.draft.uri_secrets = UriSecrets {
             password: None,
             tls_certificate_key_file_password: None,
-            proxy_password: secrets.proxy_password,
-            aws_session_token: secrets.aws_session_token,
+            proxy_password: uri_secrets.proxy_password,
+            aws_session_token: uri_secrets.aws_session_token,
         };
-        let sanitized = strip_uri_secrets(&uri);
-        if sanitized != uri {
-            self.draft.internal_uri_value = Some(sanitized.clone());
-            self.draft.uri_state.update(cx, |state, cx| state.set_value(sanitized, window, cx));
-        }
-    }
-
-    pub(super) fn real_uri(&self, cx: &App) -> String {
-        let uri = self.draft.uri_state.read(cx).value().to_string();
-        let mut secrets = self.draft.uri_secrets.clone();
-        secrets.password = non_empty_value(&self.draft.password_state, cx);
-        secrets.tls_certificate_key_file_password =
-            non_empty_value(&self.draft.tls_cert_key_password_state, cx);
-        inject_uri_secrets(&strip_uri_secrets(&uri), &secrets)
-    }
-
-    pub(super) fn import_from_uri(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let uri = self.draft.uri_state.read(cx).value().to_string();
-        self.import_uri(uri, window, cx);
-    }
-
-    fn import_uri(&mut self, uri: String, window: &mut Window, cx: &mut Context<Self>) {
-        let uri_secrets = extract_uri_secrets(&uri);
-        let sanitized_uri = strip_uri_secrets(&uri);
         match parse_uri(&sanitized_uri) {
             Ok(parts) => {
                 let (user, _redacted_password) = parts.userinfo();
@@ -453,7 +560,11 @@ impl ConnectionManager {
                     .username_state
                     .update(cx, |state, cx| state.set_value(user.unwrap_or_default(), window, cx));
                 self.draft.password_state.update(cx, |state, cx| {
-                    state.set_value(uri_secrets.password.clone().unwrap_or_default(), window, cx)
+                    state.set_value(
+                        uri_secrets.password.as_deref().map(percent_decode).unwrap_or_default(),
+                        window,
+                        cx,
+                    )
                 });
                 self.draft.app_name_state.update(cx, |state, cx| {
                     state.set_value(parts.get_query("appName"), window, cx)
@@ -508,27 +619,35 @@ impl ConnectionManager {
                 });
                 self.draft.tls_cert_key_password_state.update(cx, |state, cx| {
                     state.set_value(
-                        uri_secrets.tls_certificate_key_file_password.clone().unwrap_or_default(),
+                        uri_secrets
+                            .tls_certificate_key_file_password
+                            .as_deref()
+                            .map(percent_decode)
+                            .unwrap_or_default(),
                         window,
                         cx,
                     )
                 });
                 self.draft.direct_connection = parse_bool(parts.get_query("directConnection"));
-                self.draft.tls = parse_bool(parts.get_query("tls"));
+                let tls = if parts.get_query("tls").is_empty() {
+                    parts.get_query("ssl")
+                } else {
+                    parts.get_query("tls")
+                };
+                self.draft.tls = if tls.is_empty() {
+                    sanitized_uri.starts_with("mongodb+srv://")
+                } else {
+                    parse_bool(tls)
+                };
                 self.draft.tls_insecure = parse_bool(parts.get_query("tlsInsecure"));
                 self.parse_error = None;
 
-                self.draft.uri_secrets = UriSecrets {
-                    password: None,
-                    tls_certificate_key_file_password: None,
-                    proxy_password: uri_secrets.proxy_password,
-                    aws_session_token: uri_secrets.aws_session_token,
-                };
-                self.draft.internal_uri_value = Some(sanitized_uri.clone());
-                self.draft.uri_state.update(cx, |state, cx| {
-                    state.set_value(sanitized_uri, window, cx);
-                    state.set_cursor_position(Position::new(0, 0), window, cx);
-                });
+                if self.draft.uri_state.read(cx).value().as_ref() != sanitized_uri {
+                    self.draft.internal_uri_value = Some(sanitized_uri.clone());
+                    self.draft
+                        .uri_state
+                        .update(cx, |state, cx| state.set_value(sanitized_uri, window, cx));
+                }
             }
             Err(err) => {
                 self.parse_error = Some(err);
@@ -550,8 +669,8 @@ impl ConnectionManager {
             }
         };
 
-        let username = value_or_none(&self.draft.username_state, cx);
-        let password = value_or_none(&self.draft.password_state, cx);
+        let username = non_empty_value(&self.draft.username_state, cx);
+        let password = non_empty_value(&self.draft.password_state, cx);
         parts.set_userinfo(username, password);
         parts.set_query("appName", value_or_none(&self.draft.app_name_state, cx));
         parts.set_query("authSource", value_or_none(&self.draft.auth_source_state, cx));
@@ -584,7 +703,19 @@ impl ConnectionManager {
         );
         parts.set_query("tlsCertificateKeyFilePassword", None);
         parts.set_query("directConnection", bool_to_query(self.draft.direct_connection));
-        parts.set_query("tls", bool_to_query(self.draft.tls));
+        let tls_key = if parts.get_query("tls").is_empty() && !parts.get_query("ssl").is_empty() {
+            "ssl"
+        } else {
+            "tls"
+        };
+        let tls = if parts.get_query(tls_key).is_empty()
+            && self.draft.tls == uri.starts_with("mongodb+srv://")
+        {
+            None
+        } else {
+            Some(self.draft.tls.to_string())
+        };
+        parts.set_query(tls_key, tls);
         parts.set_query("tlsInsecure", bool_to_query(self.draft.tls_insecure));
 
         let rebuilt = parts.to_uri();
@@ -596,17 +727,24 @@ impl ConnectionManager {
             self.draft.uri_secrets.proxy_password = extracted.proxy_password;
         }
         let updated = strip_uri_secrets(&rebuilt);
-        self.draft.internal_uri_value = Some(updated.clone());
-        self.draft.uri_state.update(cx, |state, cx| {
-            state.set_value(updated, window, cx);
-            state.set_cursor_position(Position::new(0, 0), window, cx);
-        });
+        if updated != uri {
+            self.draft.internal_uri_value = Some(updated.clone());
+            self.draft.uri_state.update(cx, |state, cx| state.set_value(updated, window, cx));
+        }
         self.parse_error = None;
         true
     }
 
-    pub(super) fn start_test(view: Entity<ConnectionManager>, cx: &mut App) {
-        let display_uri = view.read(cx).draft.uri_state.read(cx).value().to_string();
+    pub(super) fn start_test(view: Entity<ConnectionManager>, window: &mut Window, cx: &mut App) {
+        if matches!(view.read(cx).status, TestStatus::Testing)
+            || view.read(cx).pending_save.is_some()
+        {
+            return;
+        }
+        if !view.update(cx, |this, cx| this.update_uri_from_fields(window, cx)) {
+            return;
+        }
+        let fingerprint = view.read(cx).draft.fingerprint(cx);
         let real_uri = view.read(cx).real_uri(cx);
         let (ssh, proxy) = match view.read(cx).build_transport_settings(cx) {
             Ok(settings) => settings,
@@ -614,8 +752,8 @@ impl ConnectionManager {
                 view.update(cx, |this, cx| {
                     this.parse_error = Some(err.clone());
                     this.status = TestStatus::Error(err);
-                    this.last_tested_uri = None;
-                    this.pending_test_uri = None;
+                    this.last_tested_fingerprint = None;
+                    this.pending_test_fingerprint = None;
                     this.testing_step = None;
                     cx.notify();
                 });
@@ -627,8 +765,8 @@ impl ConnectionManager {
                 let message = err.to_string();
                 this.parse_error = Some(message.clone());
                 this.status = TestStatus::Error(message);
-                this.last_tested_uri = None;
-                this.pending_test_uri = None;
+                this.last_tested_fingerprint = None;
+                this.pending_test_fingerprint = None;
                 this.testing_step = None;
                 cx.notify();
             });
@@ -637,13 +775,15 @@ impl ConnectionManager {
 
         let manager = view.read(cx).state.read(cx).connection_manager();
 
-        view.update(cx, |this, cx| {
+        let generation = view.update(cx, |this, cx| {
             this.status = TestStatus::Testing;
-            this.pending_test_uri = Some(display_uri.clone());
-            this.last_tested_uri = None;
+            this.test_generation += 1;
+            this.pending_test_fingerprint = Some(fingerprint.clone());
+            this.last_tested_fingerprint = None;
             this.parse_error = None;
             this.testing_step = Some("Preparing transport settings".to_string());
             cx.notify();
+            this.test_generation
         });
 
         let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<String>();
@@ -677,7 +817,7 @@ impl ConnectionManager {
                             };
                             cx.update(|cx| {
                                 view.update(cx, |this, cx| {
-                                    if matches!(this.status, TestStatus::Testing) {
+                                    if this.test_generation == generation && matches!(this.status, TestStatus::Testing) {
                                         this.testing_step = Some(step.clone());
                                         cx.notify();
                                     }
@@ -688,30 +828,7 @@ impl ConnectionManager {
                             let result: Result<(), crate::error::Error> = result;
                             cx.update(|cx| {
                                 view.update(cx, |this, cx| {
-                                    let current_uri = this.draft.uri_state.read(cx).value().to_string();
-                                    let pending = this.pending_test_uri.clone();
-                                    if pending.as_deref() != Some(current_uri.trim()) {
-                                        this.status = TestStatus::Idle;
-                                        this.pending_test_uri = None;
-                                        this.last_tested_uri = None;
-                                        this.testing_step = None;
-                                        cx.notify();
-                                        return;
-                                    }
-
-                                    match result {
-                                        Ok(()) => {
-                                            this.status = TestStatus::Success;
-                                            this.last_tested_uri = Some(current_uri);
-                                        }
-                                        Err(err) => {
-                                            this.status = TestStatus::Error(err.to_string());
-                                            this.last_tested_uri = None;
-                                        }
-                                    }
-                                    this.pending_test_uri = None;
-                                    this.testing_step = None;
-                                    cx.notify();
+                                    this.finish_test(generation, result.map_err(|error| error.to_string()), cx);
                                 });
                             });
                             break;
@@ -723,11 +840,40 @@ impl ConnectionManager {
         .detach();
     }
 
+    pub(super) fn finish_test(
+        &mut self,
+        generation: u64,
+        result: Result<(), String>,
+        cx: &mut Context<Self>,
+    ) {
+        if self.test_generation != generation {
+            return;
+        }
+        let fingerprint = self.draft.fingerprint(cx);
+        if self.pending_test_fingerprint.as_ref() != Some(&fingerprint) {
+            self.status = TestStatus::Idle;
+            self.last_tested_fingerprint = None;
+        } else {
+            self.status = match result {
+                Ok(()) => TestStatus::Success,
+                Err(error) => TestStatus::Error(error),
+            };
+            self.last_tested_fingerprint = Some(fingerprint);
+        }
+        self.pending_test_fingerprint = None;
+        self.testing_step = None;
+        cx.notify();
+    }
+
     pub(super) fn save_connection(
         &mut self,
+        connect: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Uuid> {
+        if self.pending_save.is_some() || !self.state.read(cx).connection_secrets_ready() {
+            return None;
+        }
         if !self.update_uri_from_fields(window, cx) {
             if let Some(err) = self.parse_error.clone() {
                 self.status = TestStatus::Error(err);
@@ -812,7 +958,12 @@ impl ConnectionManager {
 
         if let Some(saved) = saved_connection {
             let saved_id = saved.id;
-            self.load_connection(Some(saved), window, cx);
+            self.pending_save = Some(super::PendingSave {
+                connection_id: saved_id,
+                fingerprint: self.draft.fingerprint(cx),
+                connect,
+            });
+            cx.notify();
             return Some(saved_id);
         }
         None
@@ -834,151 +985,6 @@ impl ConnectionManager {
                 request_remove_connection(state.clone(), connection_id, window, cx);
             },
         );
-    }
-
-    pub(super) fn import_uri_from_clipboard_or_dialog(
-        view: Entity<ConnectionManager>,
-        window: &mut Window,
-        cx: &mut App,
-    ) {
-        ConnectionManager::open_import_uri_dialog(view, window, cx);
-    }
-
-    pub(super) fn open_import_uri_dialog(
-        view: Entity<ConnectionManager>,
-        window: &mut Window,
-        cx: &mut App,
-    ) {
-        let input_state = cx.new(|cx| {
-            InputState::new(window, cx)
-                .placeholder("mongodb+srv://user:pass@cluster0.example.mongodb.net")
-        });
-
-        if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
-            let value = text.lines().next().unwrap_or("").trim().to_string();
-            if !value.is_empty() {
-                input_state.update(cx, |state, cx| {
-                    state.set_value(value, window, cx);
-                    state.set_cursor_position(Position::new(0, 0), window, cx);
-                });
-            }
-        }
-
-        window.open_dialog(cx, move |dialog: Dialog, window: &mut Window, cx: &mut App| {
-            input_state.update(cx, |state, cx| {
-                state.focus(window, cx);
-            });
-            dialog
-                .title("Import Connection URI")
-                .w(px(560.0))
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap(spacing::sm())
-                        .p(spacing::md())
-                        .child(
-                            Input::new(&input_state)
-                                .font_family(crate::theme::fonts::mono())
-                                .w_full(),
-                        )
-                        .child(
-                            div()
-                                .flex()
-                                .items_center()
-                                .gap(spacing::sm())
-                                .child(
-                                    Button::new("paste-uri")
-                                        .xsmall()
-                                        .label("Paste from Clipboard")
-                                        .on_click({
-                                            let input_state = input_state.clone();
-                                            move |_, window, cx| {
-                                                if let Some(text) = cx
-                                                    .read_from_clipboard()
-                                                    .and_then(|item| item.text())
-                                                {
-                                                    let value = text
-                                                        .lines()
-                                                        .next()
-                                                        .unwrap_or("")
-                                                        .trim()
-                                                        .to_string();
-                                                    if value.is_empty() {
-                                                        return;
-                                                    }
-                                                    input_state.update(cx, |state, cx| {
-                                                        state.set_value(value, window, cx);
-                                                        state.set_cursor_position(
-                                                            Position::new(0, 0),
-                                                            window,
-                                                            cx,
-                                                        );
-                                                    });
-                                                }
-                                            }
-                                        }),
-                                )
-                                .child(
-                                    Button::new("clear-uri")
-                                        .xsmall()
-                                        .ghost()
-                                        .label("Clear")
-                                        .on_click({
-                                            let input_state = input_state.clone();
-                                            move |_, window, cx| {
-                                                input_state.update(cx, |state, cx| {
-                                                    state.set_value(String::new(), window, cx);
-                                                });
-                                            }
-                                        }),
-                                ),
-                        )
-                        .child(
-                            div().text_xs().text_color(cx.theme().muted_foreground).child(
-                                "Paste a mongodb:// or mongodb+srv:// URI to import settings.",
-                            ),
-                        ),
-                )
-                .footer({
-                    let view = view.clone();
-                    let input_state = input_state.clone();
-
-                    let view = view.clone();
-                    let input_state = input_state.clone();
-                    gpui_kit::component::dialog::DialogFooter::new().children(vec![
-                        cancel_button("cancel-import-uri"),
-                        Button::new("confirm-import-uri")
-                            .primary()
-                            .label("Import")
-                            .on_click({
-                                let view = view.clone();
-                                let input_state = input_state.clone();
-                                move |_, window, cx| {
-                                    let raw = input_state.read(cx).value().to_string();
-                                    let value = raw.lines().next().unwrap_or("").trim().to_string();
-                                    if value.is_empty() {
-                                        window.close_dialog(cx);
-                                        return;
-                                    }
-                                    view.update(cx, |this, cx| {
-                                        this.draft.uri_state.update(cx, |state, cx| {
-                                            state.set_value(value.clone(), window, cx);
-                                            state.set_cursor_position(
-                                                Position::new(0, 0),
-                                                window,
-                                                cx,
-                                            );
-                                        });
-                                        this.import_from_uri(window, cx);
-                                    });
-                                    window.close_dialog(cx);
-                                }
-                            })
-                            .into_any_element(),
-                    ])
-                })
-        });
     }
 }
 

--- a/src/components/connection_manager/connection_list.rs
+++ b/src/components/connection_manager/connection_list.rs
@@ -1,245 +1,214 @@
-//! Connection list panel rendering.
-//!
-//! Renders the left-side panel showing all saved connections.
-
-use gpui_kit::component::ActiveTheme as _;
-use gpui_kit::component::Disableable as _;
-use gpui_kit::component::scroll::ScrollableElement;
-use gpui_kit::component::{Icon, IconName, Sizable as _};
-use gpui_kit::prelude::FluentBuilder as _;
+use gpui_kit::component::button::{Button, ButtonVariants as _};
+use gpui_kit::component::list::{List, ListDelegate, ListItem, ListState};
+use gpui_kit::component::menu::{DropdownMenu as _, PopupMenuItem};
+use gpui_kit::component::{ActiveTheme as _, Disableable as _, IndexPath, Sizable as _};
 use gpui_kit::*;
-use uuid::Uuid;
 
-use crate::components::{Button, ConnectionIdentity, connection_identity_badge};
+use crate::components::{ConnectionIdentity, connection_identity_badge};
 use crate::helpers::extract_host_from_uri;
 use crate::models::SavedConnection;
-use crate::theme::{borders, sizing, spacing};
+use crate::state::AppState;
+use crate::theme::{sizing, spacing};
 
 use super::ConnectionManager;
 use super::export_dialog::open_export_dialog;
 use super::import::open_import_flow;
 
-impl ConnectionManager {
-    /// Renders the connection list panel (left side of the manager).
-    pub(super) fn render_connection_list(
-        &mut self,
-        connections: Vec<SavedConnection>,
-        selected_id: Option<Uuid>,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
-        let view = cx.entity();
-        let header = self.render_list_header(cx);
-        let creating_new = self.creating_new;
+pub(super) struct ConnectionList {
+    pub(super) manager: WeakEntity<ConnectionManager>,
+    pub(super) state: Entity<AppState>,
+    pub(super) query: String,
+    pub(super) connections: Vec<SavedConnection>,
+    pub(super) selected: Option<IndexPath>,
+}
 
-        div()
-            .flex()
-            .flex_col()
-            .w(px(260.0))
-            .min_w(px(260.0))
-            .h_full()
-            .border_r_1()
-            .border_color(cx.theme().border)
-            .child(div().flex_shrink_0().child(header))
-            .child(
-                div().flex_1().min_h(px(0.0)).overflow_y_scrollbar().child(
-                    Self::render_list_content(view, connections, selected_id, creating_new, cx),
-                ),
-            )
-            .into_any_element()
-    }
-
-    /// Renders the header with title and action buttons.
-    fn render_list_header(&self, cx: &mut Context<Self>) -> AnyElement {
-        let view = cx.entity();
-        let selected_id = self.selected_id;
-        let state = self.state.clone();
-
-        div()
-            .flex()
-            .items_center()
-            .justify_between()
-            .px(spacing::md())
-            .h(sizing::header_height())
-            .border_b_1()
-            .border_color(cx.theme().border)
-            .child(div().text_xs().text_color(cx.theme().secondary_foreground).child("Connections"))
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .gap(spacing::xs())
-                    .child(
-                        Button::new("import-connections")
-                            .xsmall()
-                            .tooltip("Import Connections")
-                            .icon(Icon::new(crate::assets::AppIcon::Download).xsmall())
-                            .on_click({
-                                let state = state.clone();
-                                move |_, window, cx| {
-                                    open_import_flow(state.clone(), window, cx);
-                                }
-                            }),
-                    )
-                    .child(
-                        Button::new("export-connections")
-                            .xsmall()
-                            .tooltip("Export Connections")
-                            .icon(Icon::new(crate::assets::AppIcon::Upload).xsmall())
-                            .on_click({
-                                let state = state.clone();
-                                move |_, window, cx| {
-                                    open_export_dialog(state.clone(), window, cx);
-                                }
-                            }),
-                    )
-                    .child(
-                        Button::new("new-connection")
-                            .xsmall()
-                            .tooltip("New Connection")
-                            .icon(Icon::new(IconName::Plus).xsmall())
-                            .on_click({
-                                let view = view.clone();
-                                move |_, window, cx| {
-                                    ConnectionManager::request_load_connection(
-                                        view.clone(),
-                                        None,
-                                        window,
-                                        cx,
-                                    );
-                                }
-                            }),
-                    )
-                    .child(
-                        Button::new("remove-connection")
-                            .xsmall()
-                            .icon(Icon::new(IconName::Delete).xsmall())
-                            .disabled(selected_id.is_none())
-                            .on_click({
-                                let view = view.clone();
-                                move |_, window, cx| {
-                                    view.update(cx, |this, cx| {
-                                        this.remove_connection(window, cx);
-                                    });
-                                }
-                            }),
-                    ),
-            )
-            .into_any_element()
-    }
-
-    /// Renders the list of connections or an empty state.
-    fn render_list_content(
-        view: Entity<Self>,
-        connections: Vec<SavedConnection>,
-        selected_id: Option<Uuid>,
-        creating_new: bool,
-        cx: &App,
-    ) -> AnyElement {
-        div()
-            .flex()
-            .flex_col()
-            .gap(spacing::xs())
-            .p(spacing::xs())
-            .when(creating_new, |list| list.child(Self::render_new_connection_item(cx)))
-            .when(connections.is_empty() && !creating_new, |list| {
-                list.child(
-                    div()
-                        .p(spacing::sm())
-                        .text_sm()
-                        .text_color(cx.theme().muted_foreground)
-                        .child("No connections"),
-                )
+impl ConnectionList {
+    fn refresh(&mut self, cx: &App) {
+        self.connections = self
+            .state
+            .read(cx)
+            .connections
+            .iter()
+            .filter(|connection| {
+                connection.name.to_lowercase().contains(&self.query)
+                    || extract_host_from_uri(&connection.uri)
+                        .unwrap_or_default()
+                        .to_lowercase()
+                        .contains(&self.query)
             })
-            .children(
-                connections.into_iter().map(move |conn| {
-                    Self::render_connection_item(view.clone(), conn, selected_id, cx)
-                }),
-            )
-            .into_any_element()
+            .cloned()
+            .collect();
     }
+}
 
-    fn render_new_connection_item(cx: &App) -> AnyElement {
-        div()
-            .flex()
-            .items_center()
-            .gap(spacing::sm())
-            .px(spacing::sm())
-            .py(spacing::sm())
-            .rounded(borders::radius_sm())
-            .border_1()
-            .border_color(cx.theme().border)
-            .bg(cx.theme().list_hover)
-            .child(Icon::new(IconName::Plus).small().text_color(cx.theme().primary))
-            .child(
+impl ListDelegate for ConnectionList {
+    type Item = ListItem;
+    fn items_count(&self, _section: usize, _cx: &App) -> usize {
+        self.connections.len()
+    }
+    fn render_item(
+        &mut self,
+        ix: IndexPath,
+        _window: &mut Window,
+        cx: &mut Context<ListState<Self>>,
+    ) -> Option<ListItem> {
+        let connection = self.connections.get(ix.row)?;
+        let identity = ConnectionIdentity::from(connection);
+        let host = extract_host_from_uri(&connection.uri).unwrap_or_default();
+        let connected = self.state.read(cx).is_connected(connection.id);
+        Some(
+            ListItem::new(connection.id.to_string()).child(
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(2.0))
+                    .min_w(px(0.))
+                    .gap(px(2.))
+                    .child(connection_identity_badge(&identity, true, cx))
                     .child(
-                        div().text_sm().font_weight(FontWeight::SEMIBOLD).child("New Connection"),
+                        div()
+                            .text_xs()
+                            .text_color(cx.theme().muted_foreground)
+                            .truncate()
+                            .child(host),
                     )
                     .child(
                         div()
                             .text_xs()
                             .text_color(cx.theme().muted_foreground)
-                            .child("Unsaved draft"),
+                            .child(if connected { "Connected" } else { "Disconnected" }),
                     ),
-            )
-            .into_any_element()
+            ),
+        )
     }
+    fn set_selected_index(
+        &mut self,
+        ix: Option<IndexPath>,
+        _window: &mut Window,
+        _cx: &mut Context<ListState<Self>>,
+    ) {
+        self.selected = ix;
+    }
+    fn confirm(
+        &mut self,
+        _secondary: bool,
+        window: &mut Window,
+        cx: &mut Context<ListState<Self>>,
+    ) {
+        let Some(connection) = self.selected.and_then(|ix| self.connections.get(ix.row)).cloned()
+        else {
+            return;
+        };
+        let manager = self.manager.clone();
+        let handle = window.window_handle();
+        // End the list lease before the manager updates the confirmed selection.
+        cx.defer(move |cx| {
+            let Some(manager) = manager.upgrade() else {
+                return;
+            };
+            let _ = handle.update(cx, |_, window, cx| {
+                ConnectionManager::request_load_connection(
+                    manager.clone(),
+                    Some(connection),
+                    window,
+                    cx,
+                );
+                manager.update(cx, |manager, cx| manager.sync_connection_list(window, cx));
+            });
+        });
+    }
+    fn perform_search(
+        &mut self,
+        query: &str,
+        _window: &mut Window,
+        cx: &mut Context<ListState<Self>>,
+    ) -> Task<()> {
+        self.query = query.to_lowercase();
+        self.refresh(cx);
+        Task::ready(())
+    }
+    fn render_empty(
+        &mut self,
+        _window: &mut Window,
+        cx: &mut Context<ListState<Self>>,
+    ) -> impl IntoElement {
+        div().p(spacing::md()).text_sm().text_color(cx.theme().muted_foreground).child(
+            if self.query.is_empty() {
+                "No saved connections. Choose New to add one."
+            } else {
+                "No matching connections."
+            },
+        )
+    }
+}
 
-    /// Renders a single connection item in the list.
-    fn render_connection_item(
-        view: Entity<Self>,
-        conn: SavedConnection,
-        selected_id: Option<Uuid>,
-        cx: &App,
-    ) -> AnyElement {
-        let is_selected = Some(conn.id) == selected_id;
-        let host = extract_host_from_uri(&conn.uri).unwrap_or_else(|| "Unknown host".to_string());
-        let last_connected = conn
-            .last_connected
-            .map(|dt| dt.format("%Y-%m-%d").to_string())
-            .unwrap_or_else(|| "Never".to_string());
-        let identity = ConnectionIdentity::from(&conn);
-
+impl ConnectionManager {
+    pub(super) fn sync_connection_list(&self, window: &mut Window, cx: &mut Context<Self>) {
+        self.connection_list.update(cx, |list, cx| {
+            list.delegate_mut().refresh(cx);
+            let selected = list
+                .delegate()
+                .connections
+                .iter()
+                .position(|connection| Some(connection.id) == self.selected_id)
+                .map(IndexPath::new);
+            list.set_selected_index(selected, window, cx);
+            cx.notify();
+        });
+    }
+    pub(super) fn render_connection_list(&self, cx: &mut Context<Self>) -> AnyElement {
+        let state = self.state.clone();
+        let view = cx.entity();
         div()
             .flex()
             .flex_col()
-            .gap(px(2.0))
-            .px(spacing::sm())
-            .py(spacing::xs())
-            .cursor_pointer()
-            .rounded(borders::radius_sm())
-            .border_1()
-            .when(is_selected, |s| s.bg(cx.theme().list_hover).border_color(cx.theme().border))
-            .when(!is_selected, |s| s.border_color(gpui_kit::transparent_black()))
-            .hover(|s| s.bg(cx.theme().list_hover))
+            .w(px(224.))
+            .min_w(px(180.))
+            .max_w(px(224.))
+            .h_full()
+            .border_r_1()
+            .border_color(cx.theme().border)
             .child(
                 div()
                     .flex()
                     .items_center()
                     .justify_between()
-                    .child(connection_identity_badge(&identity, true, cx)),
+                    .px(spacing::sm())
+                    .h(sizing::header_height())
+                    .child(div().text_sm().child("Saved connections"))
+                    .child(
+                        Button::new("new-connection")
+                            .small()
+                            .ghost()
+                            .label("New")
+                            .disabled(self.pending_save.is_some())
+                            .on_click(move |_, window, cx| {
+                                Self::request_load_connection(view.clone(), None, window, cx)
+                            }),
+                    ),
             )
-            .child(div().text_xs().text_color(cx.theme().secondary_foreground).child(host))
+            .child(List::new(&self.connection_list).small().flex_1().min_h(px(0.)))
             .child(
-                div()
-                    .text_xs()
-                    .text_color(cx.theme().muted_foreground)
-                    .child(format!("Last: {last_connected}")),
+                div().p(spacing::sm()).child(
+                    Button::new("connection-list-more")
+                        .small()
+                        .ghost()
+                        .label("Import / Export")
+                        .dropdown_menu(move |menu, _, _| {
+                            menu.item(PopupMenuItem::new("Import connections…").on_click({
+                                let state = state.clone();
+                                move |_, window, cx| open_import_flow(state.clone(), window, cx)
+                            }))
+                            .item(
+                                PopupMenuItem::new("Export connections…").on_click({
+                                    let state = state.clone();
+                                    move |_, window, cx| {
+                                        open_export_dialog(state.clone(), window, cx)
+                                    }
+                                }),
+                            )
+                        }),
+                ),
             )
-            .on_mouse_down(MouseButton::Left, {
-                move |_, window, cx| {
-                    ConnectionManager::request_load_connection(
-                        view.clone(),
-                        Some(conn.clone()),
-                        window,
-                        cx,
-                    );
-                }
-            })
             .into_any_element()
     }
 }

--- a/src/components/connection_manager/mod.rs
+++ b/src/components/connection_manager/mod.rs
@@ -13,12 +13,17 @@ mod tabs;
 mod uri;
 mod view;
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ManagerTab {
     General,
+    Authentication,
     Tls,
     Network,
     Advanced,
+    Access,
 }
 
 #[derive(Clone, Debug)]
@@ -27,6 +32,13 @@ enum TestStatus {
     Testing,
     Success,
     Error(String),
+    Saved,
+}
+
+struct PendingSave {
+    connection_id: Uuid,
+    fingerprint: String,
+    connect: bool,
 }
 
 struct ConnectionDraft {
@@ -86,7 +98,9 @@ struct ConnectionDraft {
 
 pub struct ConnectionManager {
     state: Entity<AppState>,
+    connection_list: Entity<gpui_kit::component::list::ListState<connection_list::ConnectionList>>,
     selected_id: Option<Uuid>,
+    connecting_id: Option<Uuid>,
     draft: ConnectionDraft,
     testing_step: Option<String>,
     active_tab: ManagerTab,
@@ -94,8 +108,10 @@ pub struct ConnectionManager {
     new_connection_origin_id: Option<Uuid>,
     baseline_fingerprint: String,
     status: TestStatus,
-    last_tested_uri: Option<String>,
-    pending_test_uri: Option<String>,
+    last_tested_fingerprint: Option<String>,
+    pending_test_fingerprint: Option<String>,
+    test_generation: u64,
+    pending_save: Option<PendingSave>,
     parse_error: Option<String>,
     _subscriptions: Vec<Subscription>,
 }

--- a/src/components/connection_manager/state.rs
+++ b/src/components/connection_manager/state.rs
@@ -2,21 +2,30 @@ use gpui_kit::component::input::{InputEvent, InputState};
 use gpui_kit::{App, AppContext as _, Context, Entity, Window};
 use uuid::Uuid;
 
-use crate::state::AppState;
+use crate::state::{AppCommands, AppEvent, AppState};
 
 use super::{ConnectionDraft, ConnectionManager, ManagerTab, TestStatus};
 
 impl ManagerTab {
-    pub(super) fn all() -> [ManagerTab; 4] {
-        [ManagerTab::General, ManagerTab::Tls, ManagerTab::Network, ManagerTab::Advanced]
+    pub(super) fn all() -> [ManagerTab; 6] {
+        [
+            ManagerTab::General,
+            ManagerTab::Authentication,
+            ManagerTab::Tls,
+            ManagerTab::Network,
+            ManagerTab::Advanced,
+            ManagerTab::Access,
+        ]
     }
 
     pub(super) fn label(self) -> &'static str {
         match self {
-            ManagerTab::General => "General",
+            ManagerTab::General => "Connection",
+            ManagerTab::Authentication => "Auth",
             ManagerTab::Tls => "TLS",
             ManagerTab::Network => "Network",
             ManagerTab::Advanced => "Advanced",
+            ManagerTab::Access => "Access",
         }
     }
 
@@ -101,8 +110,8 @@ impl ConnectionDraft {
         }
     }
 
-    pub(super) fn fingerprint(&self, cx: &App) -> String {
-        let mut values = [
+    fn input_states(&self) -> [&Entity<InputState>; 33] {
+        [
             &self.name_state,
             &self.uri_state,
             &self.username_state,
@@ -137,9 +146,14 @@ impl ConnectionDraft {
             &self.proxy_username_state,
             &self.proxy_password_state,
         ]
-        .into_iter()
-        .map(|state| state.read(cx).value().to_string())
-        .collect::<Vec<_>>();
+    }
+
+    pub(super) fn fingerprint(&self, cx: &App) -> String {
+        let mut values = self
+            .input_states()
+            .into_iter()
+            .map(|state| state.read(cx).value().to_string())
+            .collect::<Vec<_>>();
         values.push(format!(
             "{:?}",
             (
@@ -165,7 +179,8 @@ impl ConnectionDraft {
                 self.proxy_enabled,
             )
         ));
-        values.join("\u{1f}")
+        values.push(serde_json::to_string(&self.uri_secrets).unwrap());
+        serde_json::to_string(&values).unwrap()
     }
 
     pub(super) fn reset(&mut self, window: &mut Window, cx: &mut Context<ConnectionManager>) {
@@ -247,7 +262,115 @@ impl ConnectionManager {
         cx: &mut Context<Self>,
     ) -> Self {
         let draft = ConnectionDraft::new(window, cx);
-        let mut subscriptions = vec![cx.observe(&state, |_, _, cx| cx.notify())];
+        let manager = cx.entity().downgrade();
+        let connection_list = cx.new(|cx| {
+            gpui_kit::component::list::ListState::new(
+                super::connection_list::ConnectionList {
+                    manager,
+                    state: state.clone(),
+                    query: String::new(),
+                    connections: state.read(cx).connections_snapshot(),
+                    selected: None,
+                },
+                window,
+                cx,
+            )
+            .searchable(true)
+        });
+        let mut subscriptions = vec![cx.observe_in(&state, window, |view, _, window, cx| {
+            view.sync_connection_list(window, cx);
+            cx.notify();
+        })];
+        subscriptions.push(cx.subscribe_in(&state, window, |view, state, event, window, cx| {
+            match event {
+                AppEvent::Connecting(id) if Some(*id) == view.selected_id => {
+                    view.connecting_id = Some(*id);
+                }
+                AppEvent::Connected(id) if view.connecting_id == Some(*id) => {
+                    view.connecting_id = None;
+                    view.status = TestStatus::Idle;
+                }
+                AppEvent::ConnectionFailed { connection_id, error }
+                    if view.connecting_id == Some(*connection_id)
+                        && view.selected_id == Some(*connection_id) =>
+                {
+                    view.connecting_id = None;
+                    view.status = TestStatus::Error(error.clone());
+                }
+                AppEvent::ConnectionRemoved
+                    if view
+                        .selected_id
+                        .is_some_and(|id| state.read(cx).connection_by_id(id).is_none()) =>
+                {
+                    view.selected_id = None;
+                    view.creating_new = true;
+                }
+                _ => {}
+            }
+            cx.notify();
+            let AppEvent::ConnectionSaveFinished { connection_id, result } = event else {
+                return;
+            };
+            if view
+                .pending_save
+                .as_ref()
+                .is_none_or(|pending| pending.connection_id != *connection_id)
+            {
+                return;
+            }
+            let pending = view.pending_save.take().unwrap();
+            match result {
+                Ok(()) => {
+                    let unchanged = view.draft.fingerprint(cx) == pending.fingerprint;
+                    view.selected_id = Some(*connection_id);
+                    view.creating_new = false;
+                    view.new_connection_origin_id = None;
+                    view.baseline_fingerprint = pending.fingerprint;
+                    if unchanged {
+                        let saved = state.read(cx).connection_by_id(*connection_id).cloned();
+                        view.load_connection(saved, window, cx);
+                    }
+                    view.status = TestStatus::Saved;
+                    if pending.connect {
+                        let state = state.clone();
+                        let connection_id = *connection_id;
+                        window.defer(cx, move |window, cx| {
+                            if state.read(cx).is_connected(connection_id) {
+                                let connect_state = state.clone();
+                                crate::components::request_unsaved_action(
+                                    state,
+                                    crate::state::UnsavedScope::Connection(connection_id),
+                                    window,
+                                    cx,
+                                    move |_, cx| {
+                                        AppCommands::connect(connect_state, connection_id, cx)
+                                    },
+                                );
+                            } else {
+                                AppCommands::connect(state, connection_id, cx);
+                            }
+                        });
+                    }
+                }
+                Err(error) => {
+                    view.status = TestStatus::Error(format!("Could not save connection: {error}"));
+                }
+            }
+            view.sync_connection_list(window, cx);
+            cx.notify();
+        }));
+
+        for input in draft.input_states() {
+            subscriptions.push(cx.subscribe(input, |view, _, event, cx| {
+                if matches!(event, InputEvent::Change) {
+                    if view.has_unsaved_changes(cx) && !matches!(view.status, TestStatus::Testing) {
+                        view.status = TestStatus::Idle;
+                        view.last_tested_fingerprint = None;
+                    }
+                    cx.notify();
+                }
+            }));
+        }
 
         let uri_state = draft.uri_state.clone();
         subscriptions.push(cx.subscribe_in(
@@ -256,11 +379,6 @@ impl ConnectionManager {
             move |view, _state, event, window, cx| {
                 if matches!(event, InputEvent::Change) {
                     view.capture_uri_secrets(window, cx);
-                    view.status = TestStatus::Idle;
-                    view.last_tested_uri = None;
-                    view.pending_test_uri = None;
-                    view.testing_step = None;
-                    view.parse_error = None;
                     cx.notify();
                 }
             },
@@ -268,7 +386,9 @@ impl ConnectionManager {
 
         let mut view = Self {
             state,
+            connection_list,
             selected_id,
+            connecting_id: None,
             draft,
             testing_step: None,
             active_tab: ManagerTab::General,
@@ -276,13 +396,16 @@ impl ConnectionManager {
             new_connection_origin_id: None,
             baseline_fingerprint: String::new(),
             status: TestStatus::Idle,
-            last_tested_uri: None,
-            pending_test_uri: None,
+            last_tested_fingerprint: None,
+            pending_test_fingerprint: None,
+            test_generation: 0,
+            pending_save: None,
             parse_error: None,
             _subscriptions: subscriptions,
         };
 
         if let Some(connection_id) = selected_id
+            .or_else(|| view.state.read(cx).connections.first().map(|connection| connection.id))
             && let Some(connection) = view
                 .state
                 .read(cx)

--- a/src/components/connection_manager/tabs.rs
+++ b/src/components/connection_manager/tabs.rs
@@ -4,9 +4,11 @@
 
 use gpui_kit::component::ActiveTheme as _;
 use gpui_kit::component::Disableable as _;
+use gpui_kit::component::Selectable as _;
 use gpui_kit::component::Sizable as _;
-use gpui_kit::component::button::ButtonVariants as _;
+use gpui_kit::component::button::{ButtonGroup, ButtonVariants as _};
 use gpui_kit::component::collapsible::Collapsible;
+use gpui_kit::component::form::{field, v_form};
 use gpui_kit::component::input::Input;
 use gpui_kit::component::switch::Switch;
 use gpui_kit::prelude::FluentBuilder as _;
@@ -19,7 +21,6 @@ use crate::theme::{colors, spacing};
 use super::ConnectionManager;
 
 impl ConnectionManager {
-    /// General tab: Name, URI, Read-only, Username/Password, App name, Auth fields.
     pub(super) fn render_general_tab(
         &mut self,
         parse_error: Option<String>,
@@ -28,8 +29,11 @@ impl ConnectionManager {
     ) -> AnyElement {
         let view = cx.entity();
         let selected_color = self.draft.color;
-        let mut no_color_button =
-            Button::new("connection-color-none").xsmall().label("None").on_click({
+        let no_color_button = Button::new("connection-color-none")
+            .xsmall()
+            .label("None")
+            .selected(selected_color.is_none())
+            .on_click({
                 let view = view.clone();
                 move |_, _window, cx| {
                     view.update(cx, |this, cx| {
@@ -38,15 +42,13 @@ impl ConnectionManager {
                     });
                 }
             });
-        if selected_color.is_none() {
-            no_color_button = no_color_button.primary();
-        }
         let color_buttons = ConnectionColor::ALL
             .into_iter()
             .map(|color| {
                 let accent = colors::connection_accent(color, cx);
                 let view = view.clone();
-                let mut button = Button::new(("connection-color", color as usize))
+                Button::new(("connection-color", color as usize))
+                    .selected(selected_color == Some(color))
                     .xsmall()
                     .child(div().size(px(12.0)).rounded_full().bg(accent))
                     .tooltip(color.label())
@@ -55,17 +57,119 @@ impl ConnectionManager {
                             this.draft.color = Some(color);
                             cx.notify();
                         });
-                    });
-                if selected_color == Some(color) {
-                    button = button.primary();
-                }
-                button.into_any_element()
+                    })
             })
             .collect::<Vec<_>>();
+
+        div().flex().flex_col().gap(spacing::lg())
+            .child(v_form()
+                .child(field().label("Connection URI")
+                    .description("Paste a MongoDB URI. Auth, TLS, and advanced options are filled automatically.")
+                    .child(Input::new(&self.draft.uri_state).font_family(crate::theme::fonts::mono())))
+                .child(field().label("Name")
+                    .description("Optional. Defaults to the server name.")
+                    .child(Input::new(&self.draft.name_state))))
+            .when_some(parse_error, |this, error| {
+                this.child(div().text_sm().text_color(cx.theme().danger).child(error))
+            })
+            // Connection color
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(spacing::xs())
+                    .child(
+                        div().text_sm().text_color(cx.theme().foreground).child("Connection color"),
+                    )
+                    .child(
+                        ButtonGroup::new("connection-colors").small().child(no_color_button)
+                            .children(color_buttons),
+                    )
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(cx.theme().muted_foreground)
+                            .child("Accents this connection in the sidebar and tabs."),
+                    ),
+            )
+
+            // Read-only switch
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(spacing::sm())
+                    .child(
+                        Switch::new("connection-read-only")
+                            .checked(self.draft.read_only)
+                            .small()
+                            .on_click({
+                                let view = view.clone();
+                                move |checked, _window, cx| {
+                                    view.update(cx, |this, cx| {
+                                        this.draft.read_only = *checked;
+                                        cx.notify();
+                                    });
+                                }
+                            }),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap(px(2.0))
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(cx.theme().foreground)
+                                    .child("Read-only (safe mode)"),
+                            )
+                            .child(
+                                div().text_xs().text_color(cx.theme().secondary_foreground).child(
+                                    "Block inserts, updates, deletes, drops, and index changes",
+                                ),
+                            ),
+                    ),
+            )
+
+            .into_any_element()
+    }
+
+    pub(super) fn render_authentication_tab(&self) -> AnyElement {
+        v_form()
+            .child(field().label("Username").child(Input::new(&self.draft.username_state)))
+            .child(
+                field()
+                    .label("Password")
+                    .child(Input::new(&self.draft.password_state).mask_toggle()),
+            )
+            .child(
+                field()
+                    .label("Authentication database")
+                    .description("Leave empty to use the URI database or MongoDB default.")
+                    .child(Input::new(&self.draft.auth_source_state)),
+            )
+            .child(
+                field()
+                    .label("Authentication mechanism")
+                    .description("Optional. MongoDB negotiates the mechanism when empty.")
+                    .child(Input::new(&self.draft.auth_mechanism_state)),
+            )
+            .child(
+                field()
+                    .label("Mechanism properties")
+                    .child(Input::new(&self.draft.auth_mechanism_props_state)),
+            )
+            .into_any_element()
+    }
+
+    pub(super) fn render_access_tab(&mut self, cx: &mut Context<Self>) -> AnyElement {
+        let view = cx.entity();
         let selected_environment = self.draft.environment;
-        let mut no_environment_button = Button::new("connection-environment-none")
+        let no_environment_button = Button::new("connection-environment-none")
+            .selected(selected_environment.is_none())
             .xsmall()
-            .label(if selected_environment.is_none() { "✓ Not set" } else { "Not set" })
+            .label("Not set")
             .on_click({
                 let view = view.clone();
                 move |_, _window, cx| {
@@ -75,20 +179,14 @@ impl ConnectionManager {
                     });
                 }
             });
-        if selected_environment.is_none() {
-            no_environment_button = no_environment_button.primary();
-        }
         let environment_buttons = ConnectionEnvironment::ALL
             .into_iter()
             .map(|environment| {
                 let view = view.clone();
-                let mut button = Button::new(("connection-environment", environment as usize))
+                Button::new(("connection-environment", environment as usize))
+                    .selected(selected_environment == Some(environment))
                     .xsmall()
-                    .label(if selected_environment == Some(environment) {
-                        format!("✓ {}", environment.label())
-                    } else {
-                        environment.label().to_string()
-                    })
+                    .label(environment.label())
                     .on_click(move |_, _window, cx| {
                         view.update(cx, |this, cx| {
                             if environment == ConnectionEnvironment::Production
@@ -100,52 +198,11 @@ impl ConnectionManager {
                             this.draft.environment = Some(environment);
                             cx.notify();
                         });
-                    });
-                if selected_environment == Some(environment) {
-                    button = button.primary();
-                }
-                button.into_any_element()
+                    })
             })
             .collect::<Vec<_>>();
 
-        div()
-            .flex()
-            .flex_col()
-            .gap(spacing::lg())
-            // Name
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(div().text_sm().text_color(cx.theme().foreground).child("Name"))
-                    .child(Input::new(&self.draft.name_state)),
-            )
-            // Connection color
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(
-                        div().text_sm().text_color(cx.theme().foreground).child("Connection color"),
-                    )
-                    .child(
-                        div()
-                            .flex()
-                            .flex_wrap()
-                            .items_center()
-                            .gap(spacing::xs())
-                            .child(no_color_button)
-                            .children(color_buttons),
-                    )
-                    .child(
-                        div()
-                            .text_xs()
-                            .text_color(cx.theme().muted_foreground)
-                            .child("Accents this connection in the sidebar and tabs."),
-                    ),
-            )
+        div().flex().flex_col().gap(spacing::lg())
             // Environment identity
             .child(
                 div()
@@ -154,12 +211,7 @@ impl ConnectionManager {
                     .gap(spacing::xs())
                     .child(div().text_sm().text_color(cx.theme().foreground).child("Environment"))
                     .child(
-                        div()
-                            .flex()
-                            .flex_wrap()
-                            .items_center()
-                            .gap(spacing::xs())
-                            .child(no_environment_button)
+                        ButtonGroup::new("connection-environments").small().child(no_environment_button)
                             .children(environment_buttons),
                     )
                     .child(
@@ -358,171 +410,7 @@ impl ConnectionManager {
                         },
                     ),
             )
-            // URI
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(div().text_sm().text_color(cx.theme().foreground).child("URI"))
-                    .child(
-                        Input::new(&self.draft.uri_state)
-                            .font_family(crate::theme::fonts::mono())
-                            .w_full(),
-                    )
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap(spacing::sm())
-                            .child(
-                                Button::new("import-uri")
-                                    .xsmall()
-                                    .label("Import from URI")
-                                    .on_click({
-                                        let view = view.clone();
-                                        move |_, window, cx| {
-                                            ConnectionManager::import_uri_from_clipboard_or_dialog(
-                                                view.clone(),
-                                                window,
-                                                cx,
-                                            );
-                                        }
-                                    }),
-                            )
-                            .child(
-                                Button::new("apply-uri").xsmall().label("Update URI").on_click({
-                                    let view = view.clone();
-                                    move |_, window, cx| {
-                                        view.update(cx, |this, cx| {
-                                            this.update_uri_from_fields(window, cx);
-                                        });
-                                    }
-                                }),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .text_xs()
-                            .text_color(cx.theme().muted_foreground)
-                            .child("Keep URI as the source of truth; fields below sync on update."),
-                    )
-                    .child(if let Some(err) = parse_error {
-                        div()
-                            .text_xs()
-                            .text_color(cx.theme().danger_foreground)
-                            .child(err)
-                            .into_any_element()
-                    } else {
-                        div().into_any_element()
-                    }),
-            )
-            // Read-only switch
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .gap(spacing::sm())
-                    .child(
-                        Switch::new("connection-read-only")
-                            .checked(self.draft.read_only)
-                            .small()
-                            .on_click({
-                                let view = view.clone();
-                                move |checked, _window, cx| {
-                                    view.update(cx, |this, cx| {
-                                        this.draft.read_only = *checked;
-                                        cx.notify();
-                                    });
-                                }
-                            }),
-                    )
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap(px(2.0))
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(cx.theme().foreground)
-                                    .child("Read-only (safe mode)"),
-                            )
-                            .child(
-                                div().text_xs().text_color(cx.theme().secondary_foreground).child(
-                                    "Block inserts, updates, deletes, drops, and index changes",
-                                ),
-                            ),
-                    ),
-            )
-            // Username / Password
-            .child(
-                div()
-                    .grid()
-                    .grid_cols(2)
-                    .gap(spacing::md())
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap(spacing::xs())
-                            .child(
-                                div().text_sm().text_color(cx.theme().foreground).child("Username"),
-                            )
-                            .child(Input::new(&self.draft.username_state)),
-                    )
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap(spacing::xs())
-                            .child(
-                                div().text_sm().text_color(cx.theme().foreground).child("Password"),
-                            )
-                            .child(Input::new(&self.draft.password_state).mask_toggle()),
-                    ),
-            )
-            // App name
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(div().text_sm().text_color(cx.theme().foreground).child("App name"))
-                    .child(Input::new(&self.draft.app_name_state)),
-            )
-            // Auth fields
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(div().text_sm().text_color(cx.theme().foreground).child("Auth source"))
-                    .child(Input::new(&self.draft.auth_source_state)),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(
-                        div().text_sm().text_color(cx.theme().foreground).child("Auth mechanism"),
-                    )
-                    .child(Input::new(&self.draft.auth_mechanism_state)),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(
-                        div()
-                            .text_sm()
-                            .text_color(cx.theme().foreground)
-                            .child("Auth mechanism properties"),
-                    )
-                    .child(Input::new(&self.draft.auth_mechanism_props_state)),
-            )
+
             .into_any_element()
     }
 
@@ -573,39 +461,22 @@ impl ConnectionManager {
                     )
                     .child(div().text_sm().text_color(cx.theme().foreground).child("TLS insecure")),
             )
+            .child(v_form().child(
+                field().label("TLS CA file").child(Input::new(&self.draft.tls_ca_file_state)),
+            ))
             .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(div().text_sm().text_color(cx.theme().foreground).child("TLS CA file"))
-                    .child(Input::new(&self.draft.tls_ca_file_state)),
+                v_form().child(
+                    field()
+                        .label("TLS certificate key file")
+                        .child(Input::new(&self.draft.tls_cert_key_file_state)),
+                ),
             )
             .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(
-                        div()
-                            .text_sm()
-                            .text_color(cx.theme().foreground)
-                            .child("TLS certificate key file"),
-                    )
-                    .child(Input::new(&self.draft.tls_cert_key_file_state)),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::xs())
-                    .child(
-                        div()
-                            .text_sm()
-                            .text_color(cx.theme().foreground)
-                            .child("TLS certificate key password"),
-                    )
-                    .child(Input::new(&self.draft.tls_cert_key_password_state).mask_toggle()),
+                v_form().child(
+                    field()
+                        .label("TLS certificate key password")
+                        .child(Input::new(&self.draft.tls_cert_key_password_state).mask_toggle()),
+                ),
             )
             .into_any_element()
     }
@@ -618,47 +489,32 @@ impl ConnectionManager {
     ) -> AnyElement {
         let view = cx.entity();
 
-        let ssh_auth_block = if self.draft.ssh_use_identity_file {
-            div()
-                .grid()
-                .grid_cols(2)
-                .gap(spacing::md())
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap(spacing::xs())
-                        .child(
-                            div()
-                                .text_sm()
-                                .text_color(cx.theme().foreground)
-                                .child("Identity file"),
-                        )
-                        .child(Input::new(&self.draft.ssh_identity_file_state)),
-                )
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap(spacing::xs())
-                        .child(
-                            div()
-                                .text_sm()
-                                .text_color(cx.theme().foreground)
-                                .child("Identity passphrase"),
-                        )
-                        .child(Input::new(&self.draft.ssh_identity_passphrase_state).mask_toggle()),
-                )
-                .into_any_element()
-        } else {
-            div()
-                .flex()
-                .flex_col()
-                .gap(spacing::xs())
-                .child(div().text_sm().text_color(cx.theme().foreground).child("SSH password"))
-                .child(Input::new(&self.draft.ssh_password_state).mask_toggle())
-                .into_any_element()
-        };
+        let ssh_auth_block =
+            if self.draft.ssh_use_identity_file {
+                div()
+                    .grid()
+                    .grid_cols(2)
+                    .gap(spacing::md())
+                    .child(
+                        v_form().child(
+                            field()
+                                .label("Identity file")
+                                .child(Input::new(&self.draft.ssh_identity_file_state)),
+                        ),
+                    )
+                    .child(v_form().child(field().label("Identity passphrase").child(
+                        Input::new(&self.draft.ssh_identity_passphrase_state).mask_toggle(),
+                    )))
+                    .into_any_element()
+            } else {
+                v_form()
+                    .child(
+                        field()
+                            .label("SSH password")
+                            .child(Input::new(&self.draft.ssh_password_state).mask_toggle()),
+                    )
+                    .into_any_element()
+            };
 
         let both_enabled = self.draft.ssh_enabled && self.draft.proxy_enabled;
 
@@ -724,57 +580,25 @@ impl ConnectionManager {
                             .grid()
                             .grid_cols(2)
                             .gap(spacing::md())
+                            .child(v_form().child(
+                                field().label("Host").child(Input::new(&self.draft.ssh_host_state)),
+                            ))
+                            .child(v_form().child(
+                                field().label("Port").child(Input::new(&self.draft.ssh_port_state)),
+                            ))
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Host"),
-                                    )
-                                    .child(Input::new(&self.draft.ssh_host_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Username")
+                                        .child(Input::new(&self.draft.ssh_username_state)),
+                                ),
                             )
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Port"),
-                                    )
-                                    .child(Input::new(&self.draft.ssh_port_state)),
-                            )
-                            .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Username"),
-                                    )
-                                    .child(Input::new(&self.draft.ssh_username_state)),
-                            )
-                            .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Local bind host"),
-                                    )
-                                    .child(Input::new(&self.draft.ssh_local_bind_host_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Local bind host")
+                                        .child(Input::new(&self.draft.ssh_local_bind_host_state)),
+                                ),
                             ),
                     )
                     .child(
@@ -881,59 +705,29 @@ impl ConnectionManager {
                             .grid_cols(2)
                             .gap(spacing::md())
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Proxy host"),
-                                    )
-                                    .child(Input::new(&self.draft.proxy_host_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Proxy host")
+                                        .child(Input::new(&self.draft.proxy_host_state)),
+                                ),
                             )
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Proxy port"),
-                                    )
-                                    .child(Input::new(&self.draft.proxy_port_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Proxy port")
+                                        .child(Input::new(&self.draft.proxy_port_state)),
+                                ),
                             )
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Proxy username"),
-                                    )
-                                    .child(Input::new(&self.draft.proxy_username_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Proxy username")
+                                        .child(Input::new(&self.draft.proxy_username_state)),
+                                ),
                             )
-                            .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Proxy password"),
-                                    )
-                                    .child(
-                                        Input::new(&self.draft.proxy_password_state).mask_toggle(),
-                                    ),
-                            ),
+                            .child(v_form().child(field().label("Proxy password").child(
+                                Input::new(&self.draft.proxy_password_state).mask_toggle(),
+                            ))),
                     )
                     .child(
                         div()
@@ -959,6 +753,9 @@ impl ConnectionManager {
             .flex()
             .flex_col()
             .gap(spacing::lg())
+            .child(v_form().child(
+                field().label("Application name").child(Input::new(&self.draft.app_name_state)),
+            ))
             // Direct connection switch
             .child(
                 div()
@@ -993,57 +790,29 @@ impl ConnectionManager {
                     .grid_cols(2)
                     .gap(spacing::md())
                     .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap(spacing::xs())
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(cx.theme().foreground)
-                                    .child("Read preference"),
-                            )
-                            .child(Input::new(&self.draft.read_preference_state)),
+                        v_form().child(
+                            field()
+                                .label("Read preference")
+                                .child(Input::new(&self.draft.read_preference_state)),
+                        ),
                     )
                     .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap(spacing::xs())
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(cx.theme().foreground)
-                                    .child("Read concern level"),
-                            )
-                            .child(Input::new(&self.draft.read_concern_state)),
+                        v_form().child(
+                            field()
+                                .label("Read concern level")
+                                .child(Input::new(&self.draft.read_concern_state)),
+                        ),
                     )
                     .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap(spacing::xs())
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(cx.theme().foreground)
-                                    .child("Write concern (w)"),
-                            )
-                            .child(Input::new(&self.draft.write_concern_state)),
+                        v_form().child(
+                            field()
+                                .label("Write concern (w)")
+                                .child(Input::new(&self.draft.write_concern_state)),
+                        ),
                     )
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap(spacing::xs())
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(cx.theme().foreground)
-                                    .child("wTimeoutMS"),
-                            )
-                            .child(Input::new(&self.draft.w_timeout_state)),
-                    ),
+                    .child(v_form().child(
+                        field().label("wTimeoutMS").child(Input::new(&self.draft.w_timeout_state)),
+                    )),
             )
             // Pool & Timeouts collapsible
             .child(
@@ -1076,69 +845,39 @@ impl ConnectionManager {
                             .gap(spacing::md())
                             .mt(spacing::sm())
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Connect timeout (ms)"),
-                                    )
-                                    .child(Input::new(&self.draft.connect_timeout_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Connect timeout (ms)")
+                                        .child(Input::new(&self.draft.connect_timeout_state)),
+                                ),
                             )
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Server selection timeout (ms)"),
-                                    )
-                                    .child(Input::new(&self.draft.server_selection_timeout_state)),
+                                v_form().child(
+                                    field().label("Server selection timeout (ms)").child(
+                                        Input::new(&self.draft.server_selection_timeout_state),
+                                    ),
+                                ),
                             )
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Max pool size"),
-                                    )
-                                    .child(Input::new(&self.draft.max_pool_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Max pool size")
+                                        .child(Input::new(&self.draft.max_pool_state)),
+                                ),
                             )
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Min pool size"),
-                                    )
-                                    .child(Input::new(&self.draft.min_pool_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Min pool size")
+                                        .child(Input::new(&self.draft.min_pool_state)),
+                                ),
                             )
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Heartbeat frequency (ms)"),
-                                    )
-                                    .child(Input::new(&self.draft.heartbeat_frequency_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Heartbeat frequency (ms)")
+                                        .child(Input::new(&self.draft.heartbeat_frequency_state)),
+                                ),
                             ),
                     ),
             )
@@ -1174,30 +913,18 @@ impl ConnectionManager {
                             .gap(spacing::lg())
                             .mt(spacing::sm())
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Compressors"),
-                                    )
-                                    .child(Input::new(&self.draft.compressors_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Compressors")
+                                        .child(Input::new(&self.draft.compressors_state)),
+                                ),
                             )
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(spacing::xs())
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(cx.theme().foreground)
-                                            .child("Zlib compression level"),
-                                    )
-                                    .child(Input::new(&self.draft.zlib_level_state)),
+                                v_form().child(
+                                    field()
+                                        .label("Zlib compression level")
+                                        .child(Input::new(&self.draft.zlib_level_state)),
+                                ),
                             ),
                     ),
             )

--- a/src/components/connection_manager/tests.rs
+++ b/src/components/connection_manager/tests.rs
@@ -1,0 +1,265 @@
+use gpui_kit::ClipboardItem;
+use std::sync::Arc;
+
+use gpui_kit::component::Root;
+use gpui_kit::component::list::ListDelegate as _;
+use gpui_kit::{
+    AppContext as _, Entity, Focusable as _, TestAppContext, VisualTestContext, px, size,
+};
+
+use super::{ConnectionManager, ManagerTab, TestStatus};
+use crate::models::{ActiveConnection, SavedConnection};
+use crate::state::{AppState, ConfigManager};
+
+fn setup(
+    cx: &mut TestAppContext,
+    config: ConfigManager,
+    connections: Vec<SavedConnection>,
+) -> (Entity<AppState>, Entity<ConnectionManager>, &mut VisualTestContext) {
+    cx.update(|cx| {
+        gpui_kit::init(cx);
+        crate::theme::apply_design_tokens(cx);
+    });
+    let state = cx.new(|_| {
+        let mut state =
+            AppState::with_config(Arc::new(crate::connection::ConnectionManager::new()), config);
+        state.connections = connections;
+        state
+    });
+    let mut manager = None;
+    let (_, cx) = cx.add_window_view(|window, cx| {
+        let view = cx.new(|cx| ConnectionManager::new(state.clone(), None, window, cx));
+        manager = Some(view.clone());
+        Root::new(view, window, cx).bordered(false)
+    });
+    draw(cx);
+    (state, manager.unwrap(), cx)
+}
+
+fn draw(cx: &mut VisualTestContext) {
+    cx.run_until_parked();
+    cx.update(|window, cx| window.draw(cx).clear(cx));
+    cx.run_until_parked();
+}
+
+fn paste_uri(manager: &Entity<ConnectionManager>, uri: &str, cx: &mut VisualTestContext) {
+    cx.update(|window, cx| {
+        window.focus(&manager.read(cx).draft.uri_state.read(cx).focus_handle(cx), cx);
+        cx.write_to_clipboard(ClipboardItem::new_string(uri.to_string()));
+    });
+    cx.simulate_keystrokes("cmd-a cmd-v");
+    draw(cx);
+}
+
+#[gpui_kit::test]
+fn connection_editor_preserves_credentials_and_tls_alias_while_editing(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let (_, manager, cx) = setup(cx, ConfigManager::with_config_dir(dir.path().into()), vec![]);
+    paste_uri(&manager, "mongodb://user:secret@", cx);
+    manager.read_with(cx, |view, cx| {
+        assert!(view.parse_error.is_some());
+        assert!(!view.draft.uri_state.read(cx).value().contains("secret"));
+        assert_eq!(view.draft.password_state.read(cx).value().as_ref(), "secret");
+    });
+    paste_uri(
+        &manager,
+        "mongodb://?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:temporary-token",
+        cx,
+    );
+    manager.read_with(cx, |view, cx| {
+        assert!(view.parse_error.is_some());
+        assert!(!view.draft.uri_state.read(cx).value().contains("temporary-token"));
+        assert_eq!(view.draft.uri_secrets.aws_session_token.as_deref(), Some("temporary-token"));
+    });
+    paste_uri(&manager, "mongodb+srv://%20user%20:p%40ss@cluster.example/?ssl=false", cx);
+    cx.update(|window, cx| {
+        manager.update(cx, |view, cx| {
+            assert!(!view.draft.tls);
+            assert!(view.update_uri_from_fields(window, cx));
+            let uri = view.real_uri(cx);
+            assert!(uri.contains("%20user%20:p%40ss@"));
+            assert!(uri.contains("ssl=false"));
+            assert!(!uri.contains("tls="));
+            view.draft.tls = true;
+            assert!(view.update_uri_from_fields(window, cx));
+            assert!(view.real_uri(cx).contains("ssl=true"));
+        })
+    });
+}
+
+#[gpui_kit::test]
+fn connection_editor_pastes_options_and_saves_without_connecting(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, manager, cx) = setup(cx, ConfigManager::with_config_dir(dir.path().into()), vec![]);
+    cx.update(|window, cx| {
+        window.focus(&manager.read(cx).draft.uri_state.read(cx).focus_handle(cx), cx)
+    });
+    cx.simulate_keystrokes("cmd-a");
+    cx.simulate_input("mongodb+srv://user:p%40ss@cluster.example/app?authSource=admin&appName=Imported%20App&retryWrites=false&tls=false");
+    draw(cx);
+    manager.read_with(cx, |view, cx| {
+        assert_eq!(view.draft.password_state.read(cx).value().as_ref(), "p@ss");
+        assert_eq!(
+            view.draft.app_name_state.read(cx).value().as_ref(),
+            "Imported App",
+            "URI after paste: {}",
+            view.draft.uri_state.read(cx).value()
+        );
+        assert_eq!(view.draft.auth_source_state.read(cx).value().as_ref(), "admin");
+        assert!(!view.draft.tls);
+        assert!(!view.draft.uri_state.read(cx).value().contains("p%40ss"));
+    });
+    cx.update(|window, cx| {
+        manager.update(cx, |view, cx| {
+            view.draft
+                .password_state
+                .update(cx, |input, cx| input.set_value(" p@ss:/?& ", window, cx));
+            assert!(view.save_connection(false, window, cx).is_some());
+            assert!(view.pending_save.is_some());
+            assert!(view.has_unsaved_changes(cx));
+        })
+    });
+    draw(cx);
+    state.read_with(cx, |state, _| {
+        assert_eq!(state.connections.len(), 1);
+        let saved = &state.connections[0];
+        assert!(!state.is_connected(saved.id));
+        assert!(saved.uri.contains("retryWrites=false"));
+        assert!(saved.uri.contains("appName=Imported%20App"));
+        assert!(saved.uri.contains("tls=false"));
+        assert!(saved.uri.contains("%20p%40ss%3A%2F%3F%26%20"));
+    });
+    manager.read_with(cx, |view, cx| {
+        assert!(view.pending_save.is_none());
+        assert!(!view.has_unsaved_changes(cx));
+        assert!(!view.creating_new);
+    });
+    let saved = std::fs::read_to_string(dir.path().join("connections.json")).unwrap();
+    assert!(!saved.contains("p%40ss"));
+}
+
+#[gpui_kit::test]
+fn connection_editor_failed_save_keeps_draft_and_active_session(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let mut saved = SavedConnection::new("Existing".into(), "mongodb://localhost:27017".into());
+    saved.secret_id = Some(uuid::Uuid::new_v4());
+    let (state, manager, cx) =
+        setup(cx, ConfigManager::with_config_dir(dir.path().into()), vec![saved.clone()]);
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let client = runtime.block_on(async {
+        mongodb::Client::with_options(mongodb::options::ClientOptions::default()).unwrap()
+    });
+    state.update(cx, |state, _| {
+        state.insert_active_connection(
+            saved.id,
+            ActiveConnection {
+                config: saved.clone(),
+                client,
+                databases: vec!["keep_this_session".into()],
+                collections: Default::default(),
+                runtime_meta: Default::default(),
+            },
+        )
+    });
+    // Make the final atomic rename fail without changing the test process permissions.
+    std::fs::create_dir(dir.path().join("connections.json")).unwrap();
+    cx.update(|window, cx| {
+        manager.update(cx, |view, cx| {
+            view.draft
+                .uri_state
+                .update(cx, |input, cx| input.set_value("mongodb://different.example", window, cx));
+        })
+    });
+    draw(cx);
+    cx.update(|window, cx| {
+        manager.update(cx, |view, cx| {
+            assert!(view.save_connection(true, window, cx).is_some());
+        })
+    });
+    draw(cx);
+    manager.read_with(cx, |view, cx| {
+        assert!(view.pending_save.is_none());
+        assert!(view.has_unsaved_changes(cx));
+        assert!(view.draft.uri_state.read(cx).value().contains("different.example"));
+        assert!(matches!(view.status, TestStatus::Error(_)));
+    });
+    state.read_with(cx, |state, _| {
+        assert_eq!(state.connections[0].uri, saved.uri);
+        let active = state.active_connection_by_id(saved.id).unwrap();
+        assert_eq!(active.config.uri, saved.uri);
+        assert_eq!(active.databases, ["keep_this_session"]);
+    });
+    std::fs::remove_dir(dir.path().join("connections.json")).unwrap();
+    cx.update(|window, cx| {
+        manager.update(cx, |view, cx| {
+            assert!(view.save_connection(false, window, cx).is_some());
+        })
+    });
+    draw(cx);
+    state.read_with(cx, |state, _| {
+        assert!(state.connections[0].uri.contains("different.example"));
+        assert_eq!(state.active_connection_by_id(saved.id).unwrap().config.uri, saved.uri);
+        assert!(state.connection_needs_reconnect(saved.id));
+    });
+}
+
+#[gpui_kit::test]
+fn connection_editor_discards_stale_test_results_and_renders_every_tab(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let (_, manager, cx) = setup(cx, ConfigManager::with_config_dir(dir.path().into()), vec![]);
+    cx.update(|window, cx| {
+        manager.update(cx, |view, cx| {
+            view.test_generation = 4;
+            view.status = TestStatus::Testing;
+            view.pending_test_fingerprint = Some(view.draft.fingerprint(cx));
+            view.draft
+                .ssh_password_state
+                .update(cx, |input, cx| input.set_value("changed", window, cx));
+            view.finish_test(4, Ok(()), cx);
+            assert!(matches!(view.status, TestStatus::Idle));
+            view.pending_test_fingerprint = Some(view.draft.fingerprint(cx));
+            view.status = TestStatus::Testing;
+            view.finish_test(3, Ok(()), cx);
+            assert!(matches!(view.status, TestStatus::Testing));
+            view.finish_test(4, Ok(()), cx);
+            assert!(matches!(view.status, TestStatus::Success));
+        })
+    });
+    for tab in ManagerTab::all() {
+        manager.update(cx, |view, cx| {
+            view.active_tab = tab;
+            cx.notify();
+        });
+        draw(cx);
+    }
+    cx.simulate_resize(size(px(640.), px(480.)));
+    for tab in ManagerTab::all() {
+        manager.update(cx, |view, cx| {
+            view.active_tab = tab;
+            cx.notify();
+        });
+        draw(cx);
+    }
+}
+
+#[gpui_kit::test]
+fn connection_editor_native_search_confirms_the_matching_connection(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let first = SavedConnection::new("Alpha".into(), "mongodb://alpha.example".into());
+    let second = SavedConnection::new("Beta".into(), "mongodb://beta.example".into());
+    let second_id = second.id;
+    let (_, manager, cx) =
+        setup(cx, ConfigManager::with_config_dir(dir.path().into()), vec![first, second]);
+    let list = manager.read_with(cx, |view, _| view.connection_list.clone());
+    cx.update(|window, cx| {
+        list.update(cx, |list, cx| {
+            list.set_query("beta", window, cx);
+            assert_eq!(list.delegate().items_count(0, cx), 1);
+        });
+        window.focus(&list.read(cx).focus_handle(cx), cx);
+    });
+    draw(cx);
+    cx.simulate_keystrokes("enter");
+    draw(cx);
+    assert_eq!(manager.read_with(cx, |view, _| view.selected_id), Some(second_id));
+}

--- a/src/components/connection_manager/uri.rs
+++ b/src/components/connection_manager/uri.rs
@@ -2,6 +2,7 @@ use gpui_kit::component::input::InputState;
 use gpui_kit::{Context, Entity};
 
 use super::ConnectionManager;
+use crate::helpers::validate::{percent_decode, percent_encode};
 
 #[derive(Clone, Debug)]
 pub(super) struct UriParts {
@@ -18,24 +19,27 @@ impl UriParts {
         self.query
             .iter()
             .find(|(k, _)| k.eq_ignore_ascii_case(key))
-            .map(|(_, v)| v.clone())
+            .map(|(_, v)| percent_decode(v))
             .unwrap_or_default()
     }
 
     pub(super) fn set_query(&mut self, key: &str, value: Option<String>) {
+        if self.get_query(key) == value.as_deref().unwrap_or_default() {
+            return;
+        }
         self.query.retain(|(k, _)| !k.eq_ignore_ascii_case(key));
         if let Some(value) = value {
-            self.query.push((key.to_string(), value));
+            self.query.push((key.to_string(), percent_encode(&value)));
         }
     }
 
     pub(super) fn set_userinfo(&mut self, user: Option<String>, password: Option<String>) {
-        self.user = user;
-        self.password = password;
+        self.user = user.map(|value| percent_encode(&value));
+        self.password = password.map(|value| percent_encode(&value));
     }
 
     pub(super) fn userinfo(&self) -> (Option<String>, Option<String>) {
-        (self.user.clone(), self.password.clone())
+        (self.user.as_deref().map(percent_decode), self.password.as_deref().map(percent_decode))
     }
 
     pub(super) fn to_uri(&self) -> String {
@@ -75,6 +79,9 @@ pub(super) fn parse_uri(input: &str) -> Result<UriParts, String> {
     let (scheme, rest) = raw
         .split_once("://")
         .ok_or_else(|| "URI must include a scheme (mongodb:// or mongodb+srv://)".to_string())?;
+    if !matches!(scheme, "mongodb" | "mongodb+srv") {
+        return Err("Use a mongodb:// or mongodb+srv:// URI".into());
+    }
     if rest.is_empty() {
         return Err("URI is missing host".to_string());
     }

--- a/src/components/connection_manager/view.rs
+++ b/src/components/connection_manager/view.rs
@@ -1,49 +1,32 @@
-//! Main render implementation for ConnectionManager.
-//!
-//! This file contains the core `Render` impl that composes the connection list
-//! and editor panels. Tab-specific rendering is in `tabs.rs` and
-//! connection list rendering is in `connection_list.rs`.
-
-use gpui_kit::component::ActiveTheme as _;
-use gpui_kit::component::Disableable as _;
-use gpui_kit::component::Sizable as _;
-use gpui_kit::component::WindowExt as _;
-use gpui_kit::component::button::ButtonVariants as _;
+use gpui_kit::component::button::{Button, ButtonVariants as _};
 use gpui_kit::component::dialog::Dialog;
 use gpui_kit::component::scroll::ScrollableElement;
 use gpui_kit::component::tab::{Tab, TabBar};
+use gpui_kit::component::{ActiveTheme as _, Disableable as _, Sizable as _, WindowExt as _};
 use gpui_kit::prelude::FluentBuilder as _;
 use gpui_kit::*;
 
-use crate::components::{Button, request_unsaved_action};
-use crate::state::UnsavedScope;
-use crate::theme::{islands, sizing, spacing};
-
 use super::{ConnectionManager, ManagerTab, TestStatus};
+use crate::theme::{islands, spacing};
 
 impl Render for ConnectionManager {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let connections = self.state.read(cx).connections_snapshot();
-        let selected_exists =
-            self.selected_id.is_some_and(|id| connections.iter().any(|conn| conn.id == id));
-        if !selected_exists && !connections.is_empty() && !self.creating_new {
-            let next = connections.first().cloned();
-            self.load_connection(next, window, cx);
+        if self
+            .last_tested_fingerprint
+            .as_ref()
+            .is_some_and(|tested| tested != &self.draft.fingerprint(cx))
+        {
+            self.status = TestStatus::Idle;
+            self.last_tested_fingerprint = None;
         }
-
-        let selected_id = self.selected_id;
-        let is_active_selection =
-            selected_id.is_some_and(|id| self.state.read(cx).is_connected(id));
-
-        let list = self.render_connection_list(connections, selected_id, window, cx);
-        let editor = self.render_editor_panel(is_active_selection, window, cx);
-
+        let is_active = self.selected_id.is_some_and(|id| self.state.read(cx).is_connected(id));
+        let list = self.render_connection_list(cx);
+        let editor = self.render_editor_panel(is_active, window, cx);
         div()
             .flex()
-            .flex_row()
             .size_full()
-            .min_w(px(0.0))
-            .min_h(px(0.0))
+            .min_w(px(0.))
+            .min_h(px(0.))
             .overflow_hidden()
             .child(list)
             .child(editor)
@@ -51,285 +34,239 @@ impl Render for ConnectionManager {
 }
 
 impl ConnectionManager {
-    /// Renders the right-side editor panel with tabs and form fields.
     fn render_editor_panel(
         &mut self,
-        is_active_selection: bool,
+        is_active: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let appearance = self.state.read(cx).settings.appearance.clone();
-        let active_tab = self.active_tab;
-        let creating_new = self.creating_new;
-        let editor_title = if creating_new {
-            "New Connection".to_string()
+        let title = if self.creating_new {
+            "New connection".to_string()
         } else {
             let name = self.draft.name_state.read(cx).value().trim().to_string();
             if name.is_empty() { "Connection".to_string() } else { name }
         };
-        let parse_error = self.parse_error.clone();
-        let global_parse_error =
-            if active_tab == ManagerTab::General { None } else { parse_error.clone() };
-        let parse_error_border = cx.theme().danger.opacity(0.5);
-        let parse_error_bg = cx.theme().danger.opacity(0.08);
-        let parse_error_fg = cx.theme().danger_foreground;
-
-        let tab_bar = self.render_tab_bar(cx);
-        let status_bar = self.render_status_bar(is_active_selection, creating_new, cx);
-
+        let dirty = self.has_unsaved_changes(cx);
+        let view = cx.entity();
+        let tabs = islands::tab_bar(TabBar::new("connection-manager-tabs"), &appearance)
+            .small()
+            .min_w(px(0.))
+            .selected_index(self.active_tab.index())
+            .on_click({
+                let view = view.clone();
+                move |index, window, cx| {
+                    view.update(cx, |this, cx| {
+                        // Publish structured edits before returning to the URI.
+                        if this.active_tab != ManagerTab::General && this.has_unsaved_changes(cx) {
+                            this.update_uri_from_fields(window, cx);
+                        }
+                        this.active_tab = ManagerTab::from_index(*index);
+                        cx.notify();
+                    });
+                }
+            })
+            .children(ManagerTab::all().into_iter().map(|tab| Tab::new().label(tab.label())));
+        let content = match self.active_tab {
+            ManagerTab::General => self.render_general_tab(None, window, cx),
+            ManagerTab::Authentication => self.render_authentication_tab(),
+            ManagerTab::Tls => self.render_tls_tab(window, cx),
+            ManagerTab::Network => self.render_network_tab(window, cx),
+            ManagerTab::Advanced => self.render_advanced_tab(window, cx),
+            ManagerTab::Access => self.render_access_tab(cx),
+        };
         div()
             .flex()
             .flex_col()
             .flex_1()
+            .min_w(px(0.))
+            .min_h(px(0.))
             .h_full()
-            .min_h(px(0.0))
-            .min_w(px(0.0))
-            // Tab bar — sticky top
             .child(
                 div()
-                    .flex_shrink_0()
                     .flex()
                     .items_center()
+                    .gap(spacing::sm())
                     .px(spacing::md())
-                    .h(sizing::header_height())
-                    .gap(spacing::md())
-                    .bg(islands::tool_bg(&appearance, cx))
+                    .py(spacing::sm())
                     .child(
                         div()
-                            .w(px(180.0))
-                            .min_w(px(120.0))
-                            .truncate()
+                            .flex_1()
+                            .min_w(px(0.))
                             .text_sm()
                             .font_weight(FontWeight::SEMIBOLD)
-                            .child(editor_title),
+                            .truncate()
+                            .child(title),
                     )
-                    .child(div().flex_1().min_w(px(0.0)).child(tab_bar)),
-            )
-            // Tab content — scrollable
-            .child(
-                div()
-                    .flex_1()
-                    .min_h(px(0.0))
-                    .overflow_y_scrollbar()
-                    .p(spacing::md())
-                    .when_some(global_parse_error, |this, err| {
+                    .when(dirty, |this| {
                         this.child(
                             div()
-                                .mb(spacing::md())
-                                .rounded(crate::theme::borders::radius_sm())
-                                .border_1()
-                                .border_color(parse_error_border)
-                                .bg(parse_error_bg)
-                                .px(spacing::sm())
-                                .py(spacing::xs())
                                 .text_xs()
-                                .text_color(parse_error_fg)
-                                .child(err),
+                                .text_color(cx.theme().muted_foreground)
+                                .child("Unsaved changes"),
                         )
                     })
-                    .child(match active_tab {
-                        ManagerTab::General => self.render_general_tab(parse_error, window, cx),
-                        ManagerTab::Tls => self.render_tls_tab(window, cx),
-                        ManagerTab::Network => self.render_network_tab(window, cx),
-                        ManagerTab::Advanced => self.render_advanced_tab(window, cx),
+                    .when(self.selected_id.is_some(), |this| {
+                        this.child(
+                            Button::new("remove-connection")
+                                .small()
+                                .ghost()
+                                .label("Remove…")
+                                .disabled(self.pending_save.is_some())
+                                .on_click(move |_, window, cx| {
+                                    view.update(cx, |this, cx| this.remove_connection(window, cx))
+                                }),
+                        )
                     }),
             )
-            // Status bar — sticky bottom
-            .child(div().flex_shrink_0().child(status_bar))
-            .into_any_element()
-    }
-
-    /// Renders the tab bar for switching between configuration sections.
-    fn render_tab_bar(&self, cx: &mut Context<Self>) -> AnyElement {
-        let view = cx.entity();
-        let active_tab = self.active_tab;
-        let appearance = self.state.read(cx).settings.appearance.clone();
-
-        islands::tab_bar(TabBar::new("connection-manager-tabs"), &appearance)
-            .small()
-            .min_w(px(0.0))
-            .menu(false)
-            .selected_index(active_tab.index())
-            .on_click(move |index, _window, cx| {
-                let index = *index;
-                view.update(cx, |this, cx| {
-                    this.active_tab = ManagerTab::from_index(index);
-                    cx.notify();
-                });
-            })
-            .children(ManagerTab::all().into_iter().map(|tab| Tab::new().label(tab.label())))
-            .into_any_element()
-    }
-
-    /// Renders the status bar with test status and action buttons.
-    fn render_status_bar(
-        &self,
-        is_active_selection: bool,
-        creating_new: bool,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
-        let view = cx.entity();
-        let state = self.state.clone();
-        let appearance = self.state.read(cx).settings.appearance.clone();
-        let status = self.status.clone();
-        let testing_step = self.testing_step.clone();
-        let is_testing = matches!(status, TestStatus::Testing);
-        let error_details = match &status {
-            TestStatus::Error(err) => Some(err.clone()),
-            _ => None,
-        };
-
-        let (status_text, status_color) = Self::format_status(&status, testing_step.as_deref(), cx);
-        let actions = Self::render_action_buttons(
-            view,
-            state,
-            is_testing,
-            is_active_selection,
-            creating_new,
-            error_details,
-        );
-
-        div()
-            .flex()
-            .items_center()
-            .justify_between()
-            .gap(spacing::sm())
-            .px(spacing::md())
-            .h(sizing::header_height())
-            .border_t_1()
-            .border_color(islands::panel_border(&appearance, cx))
-            .bg(islands::tool_bg(&appearance, cx))
+            .child(div().px(spacing::md()).child(tabs))
             .child(
                 div()
                     .flex_1()
-                    .min_w(px(0.0))
-                    .text_xs()
-                    .text_color(status_color)
-                    .truncate()
-                    .child(status_text),
+                    .min_h(px(0.))
+                    .overflow_y_scrollbar()
+                    .p(spacing::md())
+                    .child(div().w_full().max_w(px(720.)).child(content)),
             )
-            .child(actions)
+            .child(self.render_status_bar(is_active, cx))
             .into_any_element()
     }
 
-    /// Formats the test status into a display string and color.
-    fn format_status(status: &TestStatus, testing_step: Option<&str>, cx: &App) -> (String, Hsla) {
-        let text = match status {
-            TestStatus::Idle => "Test connection to verify settings".to_string(),
-            TestStatus::Testing => testing_step
-                .map(|step| format!("Testing: {step}"))
-                .unwrap_or_else(|| "Testing connection...".to_string()),
-            TestStatus::Success => "Connection OK".to_string(),
-            TestStatus::Error(_) => "Connection failed. Open Details for diagnostics.".to_string(),
+    fn render_status_bar(&self, is_active: bool, cx: &mut Context<Self>) -> AnyElement {
+        let view = cx.entity();
+        let saving = self.pending_save.is_some();
+        let testing = matches!(self.status, TestStatus::Testing);
+        let connecting = self.connecting_id.is_some() && self.connecting_id == self.selected_id;
+        let busy =
+            saving || testing || connecting || !self.state.read(cx).connection_secrets_ready();
+        let dirty = self.has_unsaved_changes(cx);
+        let needs_reconnect =
+            self.selected_id.is_some_and(|id| self.state.read(cx).connection_needs_reconnect(id));
+        let message = if saving {
+            "Saving connection…".to_string()
+        } else if connecting {
+            "Connecting…".to_string()
+        } else if let Some(error) = &self.parse_error {
+            error.clone()
+        } else {
+            match &self.status {
+                TestStatus::Idle => if needs_reconnect {
+                    "Connected using previous settings. Reconnect to apply saved changes."
+                } else if is_active {
+                    "Connected"
+                } else if self.creating_new {
+                    "Test is optional. Save keeps this connection for later."
+                } else {
+                    "Disconnected"
+                }
+                .to_string(),
+                TestStatus::Testing => {
+                    self.testing_step.clone().unwrap_or_else(|| "Testing connection…".into())
+                }
+                TestStatus::Success => "Test succeeded".into(),
+                TestStatus::Error(error) => error.clone(),
+                TestStatus::Saved => if needs_reconnect {
+                    "Connection saved. Reconnect to apply changes."
+                } else {
+                    "Connection saved"
+                }
+                .into(),
+            }
         };
-        let color = match status {
-            TestStatus::Success => cx.theme().primary,
-            TestStatus::Error(_) => cx.theme().danger,
-            _ => cx.theme().muted_foreground,
-        };
-        (text, color)
-    }
-
-    /// Renders the action buttons (Test and Save).
-    fn render_action_buttons(
-        view: Entity<Self>,
-        state: Entity<crate::state::AppState>,
-        is_testing: bool,
-        is_active_selection: bool,
-        creating_new: bool,
-        error_details: Option<String>,
-    ) -> AnyElement {
-        let row = div()
+        let error = matches!(self.status, TestStatus::Error(_)) || self.parse_error.is_some();
+        let mut actions = div()
             .flex()
+            .flex_wrap()
             .items_center()
             .gap(spacing::sm())
-            .flex_shrink_0()
-            .when(creating_new, |row| {
-                row.child(Button::new("cancel-new-connection").xsmall().label("Cancel").on_click({
-                    let view = view.clone();
-                    move |_, window, cx| {
-                        ConnectionManager::request_cancel_new(view.clone(), window, cx);
-                    }
-                }))
+            .when(self.creating_new, |row| {
+                row.child(
+                    Button::new("cancel-new-connection")
+                        .small()
+                        .ghost()
+                        .label("Cancel")
+                        .disabled(saving)
+                        .on_click({
+                            let view = view.clone();
+                            move |_, window, cx| Self::request_cancel_new(view.clone(), window, cx)
+                        }),
+                )
             })
             .child(
                 Button::new("test-connection")
-                    .xsmall()
-                    .label(if is_testing { "Testing..." } else { "Test" })
-                    .disabled(is_testing)
+                    .small()
+                    .label("Test")
+                    .loading(testing)
+                    .disabled(busy)
                     .on_click({
                         let view = view.clone();
-                        move |_, _window, cx| {
-                            ConnectionManager::start_test(view.clone(), cx);
-                        }
+                        move |_, window, cx| Self::start_test(view.clone(), window, cx)
                     }),
             )
+            .map(|row| {
+                row.child(
+                    Button::new("save-connection")
+                        .small()
+                        .label("Save")
+                        .disabled(busy || (!dirty && !self.creating_new))
+                        .on_click({
+                            let view = view.clone();
+                            move |_, window, cx| Self::request_save(view.clone(), false, window, cx)
+                        }),
+                )
+            })
             .child(
-                Button::new("save-connection")
-                    .xsmall()
+                Button::new("save-connect")
+                    .small()
                     .primary()
-                    .label(if is_active_selection { "Save & Reconnect" } else { "Save & Connect" })
+                    .loading(connecting)
+                    .disabled(busy)
+                    .label(if is_active {
+                        if dirty { "Save & Reconnect" } else { "Reconnect" }
+                    } else if self.creating_new || dirty {
+                        "Save & Connect"
+                    } else {
+                        "Connect"
+                    })
                     .on_click({
                         let view = view.clone();
-                        let state = state.clone();
-                        move |_, window, cx| {
-                            let selected_id = view.read(cx).selected_id;
-                            let save_view = view.clone();
-                            let save_state = state.clone();
-                            let save = move |window: &mut Window, cx: &mut App| {
-                                let mut saved_id = None;
-                                save_view.update(cx, |this, cx| {
-                                    saved_id = this.save_connection(window, cx);
-                                });
-                                if let Some(connection_id) = saved_id {
-                                    save_state.update(cx, |state, cx| {
-                                        state.connect_when_secrets_ready(connection_id, cx);
-                                    });
-                                }
-                            };
-                            if let Some(connection_id) = selected_id {
-                                request_unsaved_action(
-                                    state.clone(),
-                                    UnsavedScope::Connection(connection_id),
-                                    window,
-                                    cx,
-                                    save,
-                                );
-                            } else {
-                                save(window, cx);
-                            }
-                        }
+                        move |_, window, cx| Self::request_save(view.clone(), true, window, cx)
                     }),
             );
-
-        let row = if let Some(error_details) = error_details {
-            row.child(Button::new("test-details").xsmall().label("Details").on_click(
-                move |_, window, cx| {
-                    let details = error_details.clone();
-                    window.open_dialog(cx, move |dialog: Dialog, _window, _cx| {
-                        dialog
-                            .title("Connection Test Details")
-                            .w(px(780.0))
-                            .margin_top(px(20.0))
-                            .min_h(px(420.0))
-                            .child(
+        if let TestStatus::Error(details) = &self.status {
+            let details = details.clone();
+            actions = actions.child(
+                Button::new("connection-error-details").small().ghost().label("Details").on_click(
+                    move |_, window, cx| {
+                        let details = details.clone();
+                        window.open_dialog(cx, move |dialog: Dialog, _, _| {
+                            dialog.title("Connection details").child(
                                 div()
-                                    .flex()
-                                    .flex_col()
-                                    .h_full()
+                                    .max_h(px(360.))
                                     .overflow_y_scrollbar()
-                                    .p(spacing::md())
-                                    .text_xs()
-                                    .font_family(crate::theme::fonts::mono())
+                                    .text_sm()
                                     .child(details.clone()),
                             )
-                    });
-                },
-            ))
-        } else {
-            row
-        };
-
-        row.into_any_element()
+                        });
+                    },
+                ),
+            );
+        }
+        div()
+            .flex()
+            .flex_col()
+            .gap(spacing::sm())
+            .px(spacing::md())
+            .py(spacing::sm())
+            .border_t_1()
+            .border_color(cx.theme().border)
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(if error { cx.theme().danger } else { cx.theme().muted_foreground })
+                    .child(message),
+            )
+            .child(actions)
+            .into_any_element()
     }
 }

--- a/src/components/content/connection_manager_tests.rs
+++ b/src/components/content/connection_manager_tests.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use gpui_kit::component::input::AnyInputState;
+use gpui_kit::component::{Root, WindowExt as _};
+use gpui_kit::{AppContext as _, TestAppContext, VisualTestContext};
+
+use super::ContentArea;
+use crate::components::ConnectionManager;
+use crate::models::SavedConnection;
+use crate::state::{AppState, ConfigManager};
+
+fn draw(cx: &mut VisualTestContext) {
+    cx.run_until_parked();
+    cx.update(|window, cx| window.draw(cx).clear(cx));
+    cx.run_until_parked();
+}
+
+#[gpui_kit::test]
+fn connection_open_requests_create_reuse_and_protect_the_manager(cx: &mut TestAppContext) {
+    let config = tempfile::tempdir().unwrap();
+    cx.update(|cx| {
+        gpui_kit::init(cx);
+        crate::theme::apply_design_tokens(cx);
+    });
+    let saved = SavedConnection::new("Saved connection".into(), "mongodb://localhost:27017".into());
+    let saved_id = saved.id;
+    let state = cx.new(|_| {
+        let mut state = AppState::with_config(
+            Arc::new(crate::connection::ConnectionManager::new()),
+            ConfigManager::with_config_dir(config.path().to_owned()),
+        );
+        state.connections.push(saved);
+        state
+    });
+    let mut content = None;
+    let (_, cx) = cx.add_window_view(|window, cx| {
+        let view = cx.new(|cx| ContentArea::new(state.clone(), cx));
+        content = Some(view.clone());
+        // This is the shared action invoked by the sidebar '+' and New Connection command.
+        ConnectionManager::open_new(state.clone(), window, cx);
+        Root::new(view, window, cx).bordered(false)
+    });
+    draw(cx);
+    let content = content.unwrap();
+    let manager =
+        content.read_with(cx, |content, _| content.connection_manager_view.clone().unwrap());
+    assert!(!manager.read_with(cx, |manager, cx| manager.has_unsaved_changes(cx)));
+
+    // Exercise the existing-manager branch as well as construction.
+    cx.update(|window, cx| ConnectionManager::open_selected(state.clone(), saved_id, window, cx));
+    draw(cx);
+    assert!(!cx.update(|window, cx| window.has_active_dialog(cx)));
+    cx.update(|window, cx| ConnectionManager::open_new(state.clone(), window, cx));
+    draw(cx);
+    assert_eq!(
+        content.read_with(cx, |content, _| content
+            .connection_manager_view
+            .as_ref()
+            .unwrap()
+            .entity_id()),
+        manager.entity_id()
+    );
+    let name = cx.update(|window, cx| {
+        match window.focused_input(cx).expect("new connection name is focused") {
+            AnyInputState::Input(input) => input,
+            _ => panic!("expected connection name input"),
+        }
+    });
+    cx.update(|window, cx| {
+        name.update(cx, |input, cx| input.set_value("Unsaved draft", window, cx))
+    });
+    draw(cx);
+    cx.update(|window, cx| ConnectionManager::open_new(state.clone(), window, cx));
+    draw(cx);
+    assert!(
+        cx.update(|window, cx| window.has_active_dialog(cx)),
+        "opening a new connection must protect the current draft"
+    );
+    cx.update(|window, cx| window.close_dialog(cx));
+    draw(cx);
+    assert_eq!(name.read_with(cx, |input, _| input.value().to_string()), "Unsaved draft");
+    assert!(manager.read_with(cx, |manager, cx| manager.has_unsaved_changes(cx)));
+}

--- a/src/components/content/mod.rs
+++ b/src/components/content/mod.rs
@@ -11,6 +11,9 @@ mod empty;
 mod shell;
 mod tabs;
 
+#[cfg(test)]
+mod connection_manager_tests;
+
 use empty::render_empty_state;
 use shell::render_shell;
 pub(crate) use tabs::OpenTabsBar;
@@ -239,18 +242,23 @@ impl ContentArea {
             return;
         }
 
-        if let Some(view) = self.connection_manager_view.clone() {
-            view.update(cx, |view, cx| {
-                view.apply_open_request(request.selected_id, request.creating_new, window, cx);
-            });
+        let view = if let Some(view) = self.connection_manager_view.clone() {
+            view
         } else {
             let state = self.state.clone();
-            self.connection_manager_view = Some(cx.new(|cx| {
-                let mut view = ConnectionManagerView::new(state, None, window, cx);
-                view.apply_open_request(request.selected_id, request.creating_new, window, cx);
-                view
-            }));
-        }
+            let view = cx.new(|cx| ConnectionManagerView::new(state, None, window, cx));
+            self.connection_manager_view = Some(view.clone());
+            view
+        };
+        // Opening can read/update the manager or show a discard dialog. Its
+        // entity must be fully created and free of an existing update lease.
+        ConnectionManagerView::apply_open_request(
+            view,
+            request.selected_id,
+            request.creating_new,
+            window,
+            cx,
+        );
 
         self.connection_manager_request_generation = request.generation;
     }

--- a/src/helpers/validate.rs
+++ b/src/helpers/validate.rs
@@ -202,7 +202,7 @@ fn strip_auth_mechanism_secret(value: &str) -> Option<String> {
     (!kept.is_empty()).then(|| percent_encode(&kept.join(",")))
 }
 
-fn percent_decode(value: &str) -> String {
+pub(crate) fn percent_decode(value: &str) -> String {
     let bytes = value.as_bytes();
     let mut decoded = Vec::with_capacity(bytes.len());
     let mut index = 0;
@@ -231,7 +231,7 @@ fn hex_value(value: u8) -> Option<u8> {
     }
 }
 
-fn percent_encode(value: &str) -> String {
+pub(crate) fn percent_encode(value: &str) -> String {
     use std::fmt::Write as _;
 
     let mut encoded = String::with_capacity(value.len());

--- a/src/state/app_state/connection.rs
+++ b/src/state/app_state/connection.rs
@@ -115,6 +115,12 @@ impl AppState {
         self.conn.active.get(&connection_id)
     }
 
+    pub(crate) fn connection_needs_reconnect(&self, connection_id: Uuid) -> bool {
+        self.active_connection_by_id(connection_id)
+            .zip(self.connection_by_id(connection_id))
+            .is_some_and(|(active, saved)| connection_transport_changed(&active.config, saved))
+    }
+
     pub(crate) fn active_connection_mut(
         &mut self,
         connection_id: Uuid,
@@ -602,10 +608,8 @@ impl AppState {
 
     fn finish_update_connection(&mut self, connection: SavedConnection, cx: &mut Context<Self>) {
         let mut updated = false;
-        let mut transport_changed = false;
         for existing in &mut self.connections {
             if existing.id == connection.id {
-                transport_changed = connection_transport_changed(existing, &connection);
                 *existing = connection.clone();
                 updated = true;
                 break;
@@ -617,22 +621,6 @@ impl AppState {
             cx.emit(AppEvent::ConnectionAdded);
             cx.notify();
             return;
-        }
-
-        if let Some(active) = self.conn.active.get_mut(&connection.id) {
-            active.config = connection.clone();
-            if transport_changed {
-                self.connection_manager().disconnect(connection.id);
-                self.conn.active.remove(&connection.id);
-                self.reset_connection_runtime_state(connection.id, cx);
-                if self.conn.selected_connection == Some(connection.id) {
-                    self.current_view = View::Welcome;
-                    cx.emit(AppEvent::ViewChanged);
-                }
-                let event = AppEvent::Disconnected(connection.id);
-                self.update_status_from_event(&event);
-                cx.emit(event);
-            }
         }
 
         let event = AppEvent::ConnectionUpdated;
@@ -688,10 +676,30 @@ impl AppState {
                     Ok(()) => match state.config.save_connections(&state.connections) {
                         Ok(()) => {
                             state.connection_secret_sync_pending = false;
+                            for (connection_id, _) in &candidate_bundles {
+                                if let Some(connection) =
+                                    state.connection_by_id(*connection_id).cloned()
+                                    && let Some(active) = state.conn.active.get_mut(connection_id)
+                                    && !connection_transport_changed(&active.config, &connection)
+                                {
+                                    active.config = connection;
+                                }
+                                cx.emit(AppEvent::ConnectionSaveFinished {
+                                    connection_id: *connection_id,
+                                    result: Ok(()),
+                                });
+                            }
+                            cx.notify();
                             state.cleanup_secret_bundles(stale_bundles, cx);
                             state.take_connections_waiting_for_secrets()
                         }
                         Err(error) => {
+                            for (connection_id, _) in &candidate_bundles {
+                                cx.emit(AppEvent::ConnectionSaveFinished {
+                                    connection_id: *connection_id,
+                                    result: Err(error.to_string()),
+                                });
+                            }
                             state.connection_secret_sync_pending = false;
                             state.connections_waiting_for_secret_sync.clear();
                             state.restore_connections_after_secret_failure(
@@ -705,6 +713,12 @@ impl AppState {
                         }
                     },
                     Err(error) => {
+                        for (connection_id, _) in &candidate_bundles {
+                            cx.emit(AppEvent::ConnectionSaveFinished {
+                                connection_id: *connection_id,
+                                result: Err(error.to_string()),
+                            });
+                        }
                         state.connection_secret_sync_pending = false;
                         state.connections_waiting_for_secret_sync.clear();
                         state.restore_connections_after_secret_failure(
@@ -731,8 +745,14 @@ impl AppState {
         candidate_bundles: &[(Uuid, Uuid)],
         cx: &mut Context<Self>,
     ) {
-        for (connection_id, _) in candidate_bundles {
-            if self.conn.active.remove(connection_id).is_some() {
+        for (connection_id, secret_id) in candidate_bundles {
+            if self
+                .conn
+                .active
+                .get(connection_id)
+                .is_some_and(|active| active.config.secret_id == Some(*secret_id))
+            {
+                self.conn.active.remove(connection_id);
                 self.connection_manager().disconnect(*connection_id);
                 self.reset_connection_runtime_state(*connection_id, cx);
                 cx.emit(AppEvent::Disconnected(*connection_id));

--- a/src/state/app_state/status.rs
+++ b/src/state/app_state/status.rs
@@ -20,7 +20,7 @@ impl AppState {
             AppEvent::Disconnected(_) => {
                 self.set_status_message(Some(StatusMessage::info("Disconnected")));
             }
-            AppEvent::ConnectionFailed(error) => {
+            AppEvent::ConnectionFailed { error, .. } => {
                 self.set_status_message(Some(StatusMessage::error(format!(
                     "Connection failed: {error}"
                 ))));

--- a/src/state/commands/connections.rs
+++ b/src/state/commands/connections.rs
@@ -14,7 +14,7 @@ impl AppCommands {
             state.update(cx, |state, cx| {
                 let message = "Connection credentials are still loading or require recovery.";
                 state.set_status_message(Some(StatusMessage::error(message)));
-                cx.emit(AppEvent::ConnectionFailed(message.to_string()));
+                cx.emit(AppEvent::ConnectionFailed { connection_id, error: message.to_string() });
                 cx.notify();
             });
             return;
@@ -29,10 +29,17 @@ impl AppCommands {
 
         let Some(saved) = saved else {
             state.update(cx, |_, cx| {
-                cx.emit(AppEvent::ConnectionFailed("Connection not found".to_string()));
+                cx.emit(AppEvent::ConnectionFailed {
+                    connection_id,
+                    error: "Connection not found".to_string(),
+                });
             });
             return;
         };
+
+        if state.read(cx).is_connected(connection_id) {
+            Self::disconnect(state.clone(), connection_id, cx);
+        }
 
         // Emit connecting event
         state.update(cx, |state, cx| {
@@ -79,7 +86,12 @@ impl AppCommands {
                                     runtime_meta,
                                 },
                             );
-                            state.update_connection(saved.clone(), cx);
+                            // A connection attempt uses a snapshot; retain settings edited while it ran.
+                            if let Some(mut latest) = state.connection_by_id(connection_id).cloned()
+                            {
+                                latest.last_connected = saved.last_connected;
+                                state.update_connection(latest, cx);
+                            }
                             state.select_connection(Some(connection_id), cx);
                             state.update_workspace_from_state();
                             let connected = AppEvent::Connected(connection_id);
@@ -104,7 +116,8 @@ impl AppCommands {
                     Err(e) => {
                         log::error!("Failed to connect: {}", e);
                         state.update(cx, |state, cx| {
-                            let event = AppEvent::ConnectionFailed(e.to_string());
+                            let event =
+                                AppEvent::ConnectionFailed { connection_id, error: e.to_string() };
                             state.update_status_from_event(&event);
                             cx.emit(event);
                         });

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -13,13 +13,20 @@ pub enum AppEvent {
     // Connection lifecycle
     ConnectionAdded,
     ConnectionUpdated,
+    ConnectionSaveFinished {
+        connection_id: Uuid,
+        result: Result<(), String>,
+    },
     ConnectionRemoved,
 
     // Connection state changes
     Connecting(Uuid),
     Connected(Uuid),
     Disconnected(Uuid),
-    ConnectionFailed(String),
+    ConnectionFailed {
+        connection_id: Uuid,
+        error: String,
+    },
 
     // Data loaded
     DatabasesLoaded(Vec<String>),


### PR DESCRIPTION
Opening New Connection could panic, saved connections disappeared from the sidebar when disconnected, and saving cleared the editor before persistence completed. This change fixes the manager's entity access, keeps saved connections visible, and puts Connect/Edit actions on the connection they affect.

The editor uses GPUI Kit's searchable list, forms, tabs, and button groups. URI and name come first; Test, Save, and Connect have separate actions. Failed saves retain drafts and active sessions, saved connection settings require an explicit reconnect, and stale test results cannot overwrite newer settings. URI editing preserves options and credentials, including incomplete input and TLS aliases.

Validation:
- `just fmt-check`
- `just lint`
- `RUST_TEST_THREADS=1 just test` with the local Docker socket configured
- GPUI headless checks cover New/Edit, draft cancellation, keyboard list confirmation, save success/failure, stale test results, and all editor tabs at normal and narrow widths. Desktop visual review remains manual.

Research and implementation details: [connection workflow notes](docs/CONNECTION_WORKFLOW_RESEARCH.md).
