### PR TITLE
Redesign Documents browsing and editing

### DIFF
--- a/docs/DOCUMENTS_WORKFLOW.md
+++ b/docs/DOCUMENTS_WORKFLOW.md
@@ -1,0 +1,59 @@
+# Documents workflow
+
+Implemented on `redesign/documents-workflow`. The existing filter builder and query controls keep their layout and behavior.
+
+## Views and actions
+
+- Tree, Table, and JSON have labeled controls. Tree/Table retain the selection; JSON focuses one document and supports previous/next document navigation.
+- JSON uses the existing editor and shared editor sessions inside Documents. “Open in window” carries the same buffer into a detached window. Pending edits and save callbacks survive collection-tab changes.
+- The toolbar names its scope: selected documents, current page, matching results, or the entire collection. Save and Discard appear when selected documents have drafts.
+- Right-clicking an unselected row selects that row. Right-clicking an already selected document preserves a multi-selection; field actions target the clicked field.
+- Pagination uses GPUI Kit. Up to 100 pages, it shows page numbers. Larger results use compact navigation and a First/Last page menu because Kit 0.6 eagerly creates every page in an ellipsis dropdown.
+
+## Component ownership
+
+The implementation uses components from the published `gpui-kit = 0.6.0` dependency.
+
+| Surface | Kit components | Application responsibility |
+| --- | --- | --- |
+| Tree | Kit `base::Tree`, `TreeState`, `TreeItem`, Component `ListItem` | BSON columns, document multi-selection, field edit presentation, context actions |
+| JSON | `Editor`, `EditorState`, built-in JSON Tree-sitter grammar | BSON serialization, draft ownership, save/conflict handling |
+| Table | `DataTable`, `TableState`, `TableDelegate` | BSON cells, stable document identities, multi-selection, persisted column preferences |
+| Controls | `Button`, `Checkbox`, `Input`, `NumberInput`, `Switch`, `TabBar`, `PopupMenu`, `Popover`, `Pagination` | Action scopes and command dispatch |
+
+The tree's extra rounded selection background and accent stripe were removed. Browsing selections use Kit's `ListItem` styling; editing rows use only a compact input frame. Kit's base Tree supplies the same tree state, keyboard behavior, and virtualization while allowing this distinction—the styled Tree reapplies selection unconditionally. Tree items remain enabled even when a field is immutable. Row click handling consumes the whole `ListItem` so single clicks select without invoking the default expansion handler. The table column picker uses labeled Kit checkboxes and buttons.
+
+The document editor selects the JSON grammar rather than JavaScript, so keys, strings, numbers, booleans, and punctuation use the active syntax theme. No custom highlighter or dependency is required.
+
+References: [Kit Tree](https://gpui-kit.com/component/tree/), [Kit Editor](https://gpui-kit.com/component/editor/), [Kit DataTable](https://gpui-kit.com/component/data-table/). API usage was checked against the pinned registry source; rendering remains subject to manual verification.
+
+## Editing and clipboard
+
+- Inline edits and single-document field dialogs stage local changes. Save commits selected drafts with an atomic comparison against the original document; conflicts retain the draft. Bulk operations retain their explicit database-write confirmation.
+- Inline editing uses compact controls with one thin border, no focus halo, and a bounded width. “Done” or Enter keeps the field change in the local draft; Cancel or Escape restores the value from before that edit and preserves other staged fields.
+- Moving to another row finishes a valid edit. Invalid edits stay open, show an explanation below the tree, and disable Done. Buttons and switches retain their native keyboard actions; tabbing to Cancel and pressing Enter cancels. Focus loss alone does not commit or close the editor.
+- Field dialogs support type-preserving Extended JSON for specialized BSON values. String whitespace, Int64 values, nested BSON types, literal dotted keys, and nested `_id` fields are preserved. The root `_id` and its contents remain immutable.
+- “Paste value” (or the existing Cmd/Ctrl+Shift+V action with a field selected) stages a value of the current BSON type. In an editor, normal paste remains a native text operation.
+- Document JSON and JSONL clipboard output use canonical Extended JSON. “Copy field and value as JSON” copies a complete object with an escaped field name. Multiple documents follow displayed order.
+- “Duplicate as new document” opens a prefilled insert editor. Pasting documents confirms the destination and the use of new `_id` values before inserting.
+- Read-only JSON remains selectable and copyable. Projected results open a full-document JSON editor before replacement; field edits direct the user to JSON or to clear the projection.
+- Page changes and refresh use the existing Save/Discard/Cancel prompt. Invalid inline values cannot be hidden by view/subtab switches or overwritten by a new query. Repeated saves and discards are blocked while a document save is pending.
+
+## Validation
+
+App launches, compilation, lint, and test execution were intentionally left to the user. Formatting and source/API review are not runtime verification.
+
+Focused regression checks were added for BSON clipboard round trips, whitespace and type preservation, immutable root IDs, staged field edits, draft baselines, editor clean-state tracking, and page bounds.
+
+Manual checks:
+
+1. Edit a field, switch Tree/Table, then open JSON. Confirm the same draft appears. Save, reopen, and verify the BSON type and value.
+2. Enter invalid JSON or an invalid numeric field. Try Save, refresh, pagination, and subtab shortcuts. Confirm the buffer remains available and errors are visible.
+3. Right-click a different row, then copy, edit, duplicate, and discard. Repeat with several selected rows and with a nested field.
+4. Copy/paste strings with leading/trailing whitespace, Int64 values above JavaScript's safe integer range, Decimal128, arrays, and a field containing a dot or quote.
+5. Edit in JSON, switch collection tabs, and return. Repeat while a save is pending, and after moving the editor to a separate window.
+6. Use a projection, edit in JSON, and verify fields excluded by the projection remain on the server. Modify the document externally before saving and verify conflict handling.
+7. Check empty results, a one-page collection, more than 100 pages, page-size changes, narrow windows, and read-only connections.
+8. While editing, verify there is one input border and no row-wide selection outline. Try Cancel by mouse, Escape, and Tab-to-Cancel followed by Enter. Confirm that prior edits to other fields survive cancellation and that Done keeps changes local until document Save.
+
+Primary-source background: [Documents workflow research](DOCUMENTS_WORKFLOW_RESEARCH.md).

--- a/docs/DOCUMENTS_WORKFLOW_RESEARCH.md
+++ b/docs/DOCUMENTS_WORKFLOW_RESEARCH.md
@@ -1,0 +1,143 @@
+# Documents workflow research
+
+Reviewed 2026-09-10 against current primary MongoDB and Apple documentation.
+Scope: Collection → Documents, tree/JSON views, edits, clipboard actions, pagination, menus, toolbar, and subtabs.
+The recommendations below are OpenMango design implications, not assertions that Compass implements every proposed behavior.
+Preserve the completed Filter Builder and existing native GPUI Kit visual system; no product code was changed for this research.
+
+## Core direction
+
+Treat Documents as one task surface with several representations of the same result set and staged document drafts.
+Keep collection-level subtabs separate from the Tree/JSON representation switch inside Documents.
+The toolbar should expose query execution/refresh, insertion, representation, and clearly scoped document actions.
+Put selected-document commands near the selection; page navigation and result counts belong with the result set.
+Changing representation must not execute a write, rerun a query unnecessarily, or discard a draft.
+
+Compass offers List, JSON, and Table representations: JSON displays Extended JSON for BSON types, while List expands nested objects/arrays.
+Its clipboard actions distinguish a whole document from a selected field/value pair.
+That is a useful precedent for consistent scope across OpenMango's existing representations.
+[Compass: View Documents](https://www.mongodb.com/docs/compass/documents/view/)
+
+## Make every action's scope explicit
+
+| Command | Target | Required behavior |
+| --- | --- | --- |
+| Copy field name / path | Selected field | Preserve the actual key/path; distinguish a literal key containing `.` from a nested path |
+| Copy value | Selected BSON value | Serialize its complete typed value, not an ellipsized preview |
+| Copy field & value | Selected field | Produce a one-field Extended JSON object with the original key |
+| Copy document | Selected document | Produce one complete document; never silently copy the page |
+| Copy selected documents | Explicit selected IDs | Produce a document array and show the count |
+| Copy current page | Loaded page | Name that bounded scope; do not call it “all documents” |
+| Export all matching documents | Current executed query | Separate operation using the filter, not just the loaded page |
+| Delete field / element / document | The named object | These are different mutations and need different labels |
+
+When a query projects fields away, distinguish the displayed result from the full stored document.
+Whole-document editing/replacement needs a full source document and stable identity; do not reconstruct it from a projected or truncated row.
+If identity is unavailable, do not guess the target. Keep `_id`/document identity separate from field selection and display formatting.
+These are implications of MongoDB's full-replacement semantics, not cosmetic preferences.
+[MongoDB: findOneAndReplace](https://www.mongodb.com/docs/manual/reference/method/db.collection.findOneAndReplace/)
+
+## Preserve BSON through text and clipboard
+
+Use **Canonical Extended JSON v2** for the authoritative copy/edit round trip; offer Relaxed JSON only as an explicitly readable representation.
+MongoDB documents that Canonical generally preserves BSON type information, whereas Relaxed can lose it.
+Canonical wrappers distinguish Int32, Int64, Double, Decimal128, Date, Timestamp, ObjectId, binary, and regex values.
+Do not flatten those values through an ordinary JSON-number or plain-string conversion before copying or saving.
+Examples: Int64 `{"$numberLong":"9007199254740993"}`, Decimal128 `{"$numberDecimal":"1.10"}`, and Date `{"$date":{"$numberLong":"0"}}`.
+The JSON display can be friendlier than the stored editing representation, but display strings are not the data model.
+[MongoDB: Extended JSON v2](https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/)
+
+Preserve empty strings, significant string whitespace, null, empty arrays/objects, numeric types, regex options, and binary subtypes.
+Missing field is distinct from a field whose value is null. A type change must be explicit rather than inferred from the edited text alone.
+Copy from BSON-backed state or an explicitly parsed draft; never copy a shortened tree-cell label.
+
+Canonical Extended JSON is not a universal lossless envelope: MongoDB documents ambiguity when user field names collide with `$`-prefixed type wrappers.
+Treat such documents as a known format boundary; do not silently reinterpret an ordinary object as a BSON scalar wrapper.
+Literal dotted field names also require special handling: ordinary dot notation means traversal, not an escaped field name.
+[MongoDB: dollar and period field-name considerations](https://www.mongodb.com/docs/manual/core/dot-dollar-considerations/)
+
+## Paste and insert
+
+Native Paste inside a focused text editor should remain text editing; it must not unexpectedly insert database documents.
+An explicit **Insert document…** or **Paste documents…** action opens a staged editor and validates before writing.
+For multi-document paste, show the parsed document count and use **Insert N documents**; retain failures with their document index and draft.
+Reject unsupported top-level values with a specific error instead of accepting a scalar as a document.
+Do not change `_id` during ordinary copy. A separate Duplicate document command may intentionally prepare a new draft with a new/omitted ID.
+
+Current Compass documents three insertion modes: Shell Syntax, Field-by-Field, and JSON.
+Shell Syntax allows constructors such as `ObjectId()`; JSON expects Extended JSON; both text modes accept arrays of documents.
+Field-by-Field supports one document with explicit value types. If `_id` is omitted, Compass generates one.
+Do not call arbitrary shell syntax “JSON,” and do not evaluate pasted source merely to make an Extended JSON parser accept it.
+[Compass: Insert Documents](https://www.mongodb.com/docs/compass/documents/insert/)
+
+## Staged edits and save semantics
+
+Maintain an original BSON snapshot, the editable draft, and its dirty state for each document being edited.
+Field editing should expose the field's type and distinguish rename, replace value, remove field, and remove array element.
+Show changed fields and offer a local revert; provide explicit Save changes and Discard for the document.
+Invalid JSON remains visible and recoverable. Switching to Tree must not replace an unparseable draft with server data or `{}`.
+On write failure, retain the draft and selection, show the error beside the document, and allow correction/retry.
+On success, clear only the draft revision that was actually saved; later keystrokes must remain dirty.
+
+Compass List/Table editing updates only changed fields using `findOneAndUpdate`; its JSON editing uses `findOneAndReplace`.
+It highlights changes, supports field-level reversion, and has explicit Update/Cancel actions.
+It also reports detected external changes rather than silently overwriting them.
+OpenMango should likewise distinguish a patch from whole-document replacement; a full JSON replacement from incomplete source is unsafe.
+[Compass: Modify Single Document](https://www.mongodb.com/docs/compass/documents/modify/)
+
+MongoDB single-document writes are atomic, but `_id`-only writes can still overwrite another client's edits.
+Use an expected original value/version in the write predicate where appropriate; a separate read-then-write check alone leaves a race.
+A failed conditional match should produce a conflict/missing-document state and keep the local draft, not silently upsert or claim success.
+Whole-document replacement needs a guard appropriate to the whole snapshot, not just one unchanged field.
+[MongoDB: Atomicity and Transactions](https://www.mongodb.com/docs/manual/core/write-operations-atomicity/)
+
+Removing an array element is not equivalent to removing an object field.
+MongoDB documents that positional `$unset` leaves a null array element rather than shrinking the array.
+Keep typed path segments and implement the intended array mutation; a displayed dotted path is insufficient for every BSON key shape.
+[MongoDB: $unset](https://www.mongodb.com/docs/manual/reference/operator/update/unset/)
+
+## Pagination, refresh, and pending edits
+
+Next/Previous, page-size changes, query execution, refresh, collection changes, and subtab changes need one consistent pending-edit policy.
+Either retain drafts by document identity across navigation or ask Save / Discard / Cancel before replacing their source data; do not mix policies between Tree and JSON.
+If Save is asynchronous, perform navigation only after acknowledged success. Failure or Cancel leaves the current page and draft intact.
+Recheck dirty state at the destructive transition, not only before an asynchronous prompt/save started.
+An old page request must not overwrite a newer query/page or reset the current selection; bind responses to the executed query and page generation.
+Display the actual visible range and distinguish loaded count, matching count, and collection count. Avoid claiming an exact total before it is known.
+
+For offset pagination, MongoDB recommends a sort containing a unique value, commonly `_id`, for consistent ordering among equal sort values.
+`skip()` becomes slower at large offsets; indexed range pagination can avoid scanning skipped records, but is not a universal replacement for arbitrary sort/page-number behavior.
+Stable ordering does not make independently fetched pages a frozen database snapshot while writes continue.
+[MongoDB: cursor.skip](https://www.mongodb.com/docs/manual/reference/method/cursor.skip/)
+
+Bulk actions must be named separately from page actions.
+Compass bulk update uses the Query Bar's filter and previews the result; an empty filter targets the collection.
+For OpenMango, **Update all matching…** must preserve that query scope and show it before committing, never inherit only the current selection/page by accident.
+[Compass: Modify Multiple Documents](https://www.mongodb.com/docs/compass/documents/modify-multiple/)
+
+## Context menus, toolbar, and keyboard ownership
+
+Right-click should target the clicked document/field; visible selection and command target must agree.
+For an existing multi-selection, clearly state the selected count when an action affects the whole selection.
+Keep field menus short: edit/revert, copy variants, then applicable remove commands. Keep whole-document and query-wide commands out of a field menu unless explicitly labeled.
+Expose essential edit/copy/insert commands through ordinary controls or the menu bar as well; the context menu is an accelerator, not the only discovery path.
+Apple recommends relevant, compact context menus, consistent availability, and main-interface equivalents; a scope title is useful when it clarifies a multi-item action.
+[Apple: Context menus](https://developer.apple.com/design/human-interface-guidelines/context-menus/)
+
+While a native Input/Editor is focused, Copy/Paste/Select All/Undo belong to that editor.
+Document-level save/delete/page shortcuts must not intercept text edits, popup confirmation, or IME composition.
+Focus should return to the edited field/document after Save or Discard; changing view mode should retain document identity and useful expansion/scroll state.
+Preserve the existing filter controls and native Kit components; this task needs clearer command/state ownership, not a second visual language.
+
+## Focused acceptance checks
+
+- Round-trip representative BSON types through copy → paste → edit → save; include large Int64, Decimal128, regex flags, binary subtype, dates, and mixed arrays.
+- Verify selected field, document, selected documents, current page, and all-matching actions never cross scopes.
+- Edit a projected document without losing omitted fields; reject whole-document replacement when full source/identity is unavailable.
+- Preserve malformed drafts and server-error drafts across retry, view-mode changes, and cancelled pagination.
+- Simulate a concurrent server edit and a late save/page response; keep newer local work and report conflicts accurately.
+- Exercise nested object keys containing periods, empty strings/null/missing fields, and array removal semantics.
+- Verify Copy/Paste and Enter/Escape with field editors, JSON editor, menus, and dirty prompts focused.
+
+This is source-backed design research, not a claim about current OpenMango behavior or completed runtime verification.
+No builds, tests, application launches, or product edits were performed.

--- a/src/app/sidebar/mod.rs
+++ b/src/app/sidebar/mod.rs
@@ -160,6 +160,7 @@ impl Sidebar {
                 | AppEvent::DocumentInsertFailed { .. }
                 | AppEvent::DocumentsInserted { .. }
                 | AppEvent::DocumentsInsertFailed { .. }
+                | AppEvent::DocumentDraftChanged { .. }
                 | AppEvent::DocumentSaved { .. }
                 | AppEvent::DocumentSaveFailed { .. }
                 | AppEvent::DocumentDeleted { .. }

--- a/src/bson/formatter.rs
+++ b/src/bson/formatter.rs
@@ -2,6 +2,41 @@
 
 use mongodb::bson::Bson;
 
+/// Strict, type-preserving Extended JSON for document editing and clipboard round trips.
+pub fn document_to_json_string(document: &mongodb::bson::Document) -> String {
+    serde_json::to_string_pretty(&Bson::Document(document.clone()).into_canonical_extjson())
+        .expect("Extended JSON is serializable")
+}
+
+/// Copy scalar text naturally; use Extended JSON for structured and specialized BSON values.
+pub fn format_bson_for_clipboard(value: &Bson) -> String {
+    match value {
+        Bson::String(_)
+        | Bson::ObjectId(_)
+        | Bson::DateTime(_)
+        | Bson::Int32(_)
+        | Bson::Int64(_)
+        | Bson::Double(_)
+        | Bson::Boolean(_)
+        | Bson::Null => bson_value_for_edit(value),
+        _ => serde_json::to_string_pretty(&value.clone().into_canonical_extjson())
+            .expect("Extended JSON is serializable"),
+    }
+}
+
+#[cfg(test)]
+mod json_tests {
+    use super::*;
+    use mongodb::bson::{Decimal128, doc};
+    #[test]
+    fn document_json_preserves_numeric_types_and_string_whitespace() {
+        let document = doc! { "small_long": Bson::Int64(1), "large_long": Bson::Int64(i64::MAX), "decimal": Bson::Decimal128("12.30".parse::<Decimal128>().unwrap()), "text": "  value  " };
+        let text = document_to_json_string(&document);
+        assert!(serde_json::from_str::<serde_json::Value>(&text).is_ok());
+        assert_eq!(crate::bson::parse_document_from_json(&text).unwrap(), document);
+    }
+}
+
 /// Get a human-readable type label for a BSON value.
 pub fn bson_type_label(value: &Bson) -> &'static str {
     match value {

--- a/src/bson/parser.rs
+++ b/src/bson/parser.rs
@@ -527,8 +527,8 @@ fn format_relaxed_object_compact(map: &serde_json::Map<String, Value>) -> String
 /// Parse an edited string value back into BSON, matching the original type.
 pub fn parse_edited_value(original: &Bson, input: &str) -> Result<Bson, String> {
     let trimmed = input.trim();
-    match original {
-        Bson::String(_) => Ok(Bson::String(trimmed.to_string())),
+    let result = match original {
+        Bson::String(_) => Ok(Bson::String(input.to_string())),
         Bson::Int32(_) => {
             trimmed.parse::<i32>().map(Bson::Int32).map_err(|_| "Expected int32".to_string())
         }
@@ -556,7 +556,50 @@ pub fn parse_edited_value(original: &Bson, input: &str) -> Result<Bson, String> 
         Bson::DateTime(_) => DateTime::parse_rfc3339_str(trimmed)
             .map(Bson::DateTime)
             .map_err(|_| "Expected RFC3339 date".to_string()),
-        _ => Err("Unsupported type".to_string()),
+        _ => Err("Expected this field's BSON type in Extended JSON".to_string()),
+    };
+    result.or_else(|error| {
+        let value = parse_bson_from_relaxed_json(trimmed).map_err(|_| error.clone())?;
+        if value.element_type() == original.element_type() { Ok(value) } else { Err(error) }
+    })
+}
+
+#[cfg(test)]
+mod field_edit_tests {
+    use super::*;
+    #[test]
+    fn field_input_preserves_whitespace_and_bson_type() {
+        assert!(!crate::bson::is_editable_value(
+            &Bson::Int32(1),
+            &[
+                crate::bson::PathSegment::Key("_id".into()),
+                crate::bson::PathSegment::Key("part".into())
+            ]
+        ));
+        assert!(crate::bson::is_editable_value(
+            &Bson::Int32(1),
+            &[
+                crate::bson::PathSegment::Key("nested".into()),
+                crate::bson::PathSegment::Key("_id".into())
+            ]
+        ));
+        assert_eq!(
+            parse_edited_value(&Bson::String(String::new()), "  text\n ").unwrap(),
+            Bson::String("  text\n ".into())
+        );
+        assert_eq!(
+            parse_edited_value(&Bson::Int64(0), "{\"$numberLong\":\"9223372036854775807\"}")
+                .unwrap(),
+            Bson::Int64(i64::MAX)
+        );
+        assert!(
+            parse_edited_value(&Bson::Int32(0), "{\"$numberLong\":\"9223372036854775807\"}")
+                .is_err()
+        );
+        assert_eq!(
+            parse_edited_value(&Bson::Array(vec![]), "[1,2]").unwrap(),
+            Bson::Array(vec![Bson::Int32(1), Bson::Int32(2)])
+        );
     }
 }
 

--- a/src/bson/path.rs
+++ b/src/bson/path.rs
@@ -39,7 +39,7 @@ pub fn escape_key(key: &str) -> String {
 /// Check if a BSON value at the given path is editable inline.
 pub fn is_editable_value(value: &Bson, path: &[PathSegment]) -> bool {
     // _id field is not editable
-    if matches!(path.last(), Some(PathSegment::Key(key)) if key == "_id") {
+    if matches!(path.first(), Some(PathSegment::Key(key)) if key == "_id") {
         return false;
     }
 

--- a/src/components/unsaved_guard.rs
+++ b/src/components/unsaved_guard.rs
@@ -28,7 +28,11 @@ type Continuation = Box<dyn FnOnce(&mut Window, &mut App)>;
 
 fn has_in_flight_editor_save(inventory: &UnsavedInventory) -> bool {
     inventory.changes.iter().any(|change| {
-        matches!(change, UnsavedChange::DetachedEditor(EditorSession { save_in_flight: true, .. }))
+        matches!(
+            change,
+            UnsavedChange::DetachedEditor(EditorSession { save_in_flight: true, .. })
+                | UnsavedChange::InlineDocument { save_in_flight: true, .. }
+        )
     })
 }
 
@@ -725,6 +729,7 @@ fn apply_saved_change(
                 }
                 if unchanged {
                     session.view.drafts.remove(&doc_key);
+                    session.view.draft_baselines.remove(&doc_key);
                     session.view.dirty.remove(&doc_key);
                 }
             }

--- a/src/components/unsaved_guard.rs
+++ b/src/components/unsaved_guard.rs
@@ -662,7 +662,7 @@ fn execute_save(
             else {
                 unreachable!();
             };
-            let original_id = original_id.as_ref().ok_or_else(|| {
+            let original_id = original_id.as_deref().ok_or_else(|| {
                 Error::Parse("Could not resolve the edited document's _id.".to_string())
             })?;
             let baseline_document = baseline_document.as_ref().ok_or_else(|| {

--- a/src/state/app_state/sessions/document_ops.rs
+++ b/src/state/app_state/sessions/document_ops.rs
@@ -150,6 +150,13 @@ impl AppState {
 
     pub fn set_draft(&mut self, session_key: &SessionKey, doc_key: DocumentKey, doc: Document) {
         if let Some(session) = self.session_mut(session_key) {
+            if let Some(original) = session.data.items.iter().find(|item| item.key == doc_key) {
+                session
+                    .view
+                    .draft_baselines
+                    .entry(doc_key.clone())
+                    .or_insert_with(|| original.doc.clone());
+            }
             session.view.drafts.insert(doc_key.clone(), doc);
             session.view.dirty.insert(doc_key);
         }
@@ -158,6 +165,7 @@ impl AppState {
     pub fn clear_draft(&mut self, session_key: &SessionKey, doc_key: &DocumentKey) {
         if let Some(session) = self.session_mut(session_key) {
             session.view.drafts.remove(doc_key);
+            session.view.draft_baselines.remove(doc_key);
             session.view.dirty.remove(doc_key);
         }
     }
@@ -165,6 +173,7 @@ impl AppState {
     pub fn clear_all_drafts(&mut self, session_key: &SessionKey) {
         if let Some(session) = self.session_mut(session_key) {
             session.view.drafts.clear();
+            session.view.draft_baselines.clear();
             session.view.dirty.clear();
         }
     }
@@ -181,11 +190,14 @@ impl AppState {
             return false;
         };
 
+        let baseline =
+            session.view.draft_baselines.entry(doc_key.clone()).or_insert_with(|| original.clone());
         let draft = session.view.drafts.entry(doc_key.clone()).or_insert_with(|| original.clone());
 
         if set_bson_at_path(draft, path, new_value) {
-            if draft == original {
+            if draft == baseline {
                 session.view.drafts.remove(doc_key);
+                session.view.draft_baselines.remove(doc_key);
                 session.view.dirty.remove(doc_key);
             } else {
                 session.view.dirty.insert(doc_key.clone());
@@ -193,6 +205,32 @@ impl AppState {
             return true;
         }
         false
+    }
+
+    pub fn document_edit_baseline(
+        &self,
+        key: &SessionKey,
+        document: &DocumentKey,
+    ) -> Option<Document> {
+        self.session(key)
+            .and_then(|session| session.view.draft_baselines.get(document).cloned())
+            .or_else(|| self.document_for_key(key, document))
+    }
+
+    pub fn document_field_edit_restriction(&self, key: &SessionKey) -> Option<&'static str> {
+        if self.connection_read_only(key.connection_id) {
+            Some("Connection is read-only.")
+        } else if self.session_view(key).is_some_and(|view| !view.saving_documents.is_empty()) {
+            Some("Wait for the document save to finish before editing.")
+        } else if self.session_data(key).is_some_and(|data| data.is_loading) {
+            Some("Wait for the current page to finish loading before editing.")
+        } else if self.session_data(key).is_some_and(|data| data.projection.is_some()) {
+            Some(
+                "Open JSON to edit the full document, or clear the projection to edit fields here.",
+            )
+        } else {
+            None
+        }
     }
 }
 
@@ -223,6 +261,16 @@ mod tests {
         assert!(updated);
         let session = state.session(&session_key).unwrap();
         assert!(session.view.dirty.contains(&doc_key));
+        assert_eq!(state.document_edit_baseline(&session_key, &doc_key), Some(original.clone()));
+        let refreshed = doc! { "_id": "doc1", "name": "server update" };
+        state.update_draft_value(
+            &session_key,
+            &doc_key,
+            &refreshed,
+            &path,
+            Bson::String("gamma".into()),
+        );
+        assert_eq!(state.document_edit_baseline(&session_key, &doc_key), Some(original.clone()));
 
         let cleared = state.update_draft_value(
             &session_key,

--- a/src/state/app_state/sessions/pagination.rs
+++ b/src/state/app_state/sessions/pagination.rs
@@ -4,6 +4,13 @@ use crate::state::AppState;
 use crate::state::app_state::types::SessionKey;
 
 impl AppState {
+    pub fn set_document_page(&mut self, session_key: &SessionKey, page: u64) {
+        if let Some(session) = self.session_mut(session_key) {
+            let pages = session.data.total.div_ceil(session.data.per_page.max(1) as u64).max(1);
+            session.data.page = page.min(pages - 1);
+        }
+    }
+
     pub fn prev_page(&mut self, session_key: &SessionKey) -> bool {
         if let Some(session) = self.session_mut(session_key)
             && session.data.page > 0
@@ -26,7 +33,7 @@ impl AppState {
 
     pub fn set_per_page(&mut self, session_key: &SessionKey, per_page: i64) {
         if let Some(session) = self.session_mut(session_key) {
-            session.data.per_page = per_page;
+            session.data.per_page = per_page.max(1);
             session.data.page = 0;
         }
     }
@@ -45,5 +52,12 @@ mod tests {
         assert!(!state.prev_page(&session_key));
         assert!(state.next_page(&session_key, 2));
         assert!(state.prev_page(&session_key));
+        state.session_mut(&session_key).unwrap().data.total = 101;
+        state.set_per_page(&session_key, 25);
+        state.set_document_page(&session_key, 200);
+        assert_eq!(state.session_data(&session_key).unwrap().page, 4);
+        state.set_per_page(&session_key, 0);
+        assert_eq!(state.session_data(&session_key).unwrap().per_page, 1);
+        assert_eq!(state.session_data(&session_key).unwrap().page, 0);
     }
 }

--- a/src/state/app_state/types.rs
+++ b/src/state/app_state/types.rs
@@ -37,6 +37,7 @@ pub enum DocumentViewMode {
     #[default]
     Tree,
     Table,
+    Json,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -1194,6 +1195,8 @@ pub struct SessionViewState {
     pub selected_docs: HashSet<DocumentKey>,
     pub expanded_nodes: HashSet<String>,
     pub drafts: HashMap<DocumentKey, Document>,
+    pub draft_baselines: HashMap<DocumentKey, Document>,
+    pub saving_documents: HashSet<DocumentKey>,
     pub dirty: HashSet<DocumentKey>,
     pub subview: CollectionSubview,
     pub view_mode: DocumentViewMode,

--- a/src/state/app_state/unsaved.rs
+++ b/src/state/app_state/unsaved.rs
@@ -22,7 +22,7 @@ pub enum UnsavedChange {
     InlineDocument {
         session_key: SessionKey,
         doc_key: DocumentKey,
-        original_id: Option<Bson>,
+        original_id: Option<Box<Bson>>,
         baseline_document: Option<Document>,
         document: Document,
         save_in_flight: bool,
@@ -99,7 +99,8 @@ impl AppState {
                     let original_id = baseline_document
                         .as_ref()
                         .and_then(|document| document.get("_id").cloned())
-                        .or_else(|| parse_bson_from_relaxed_json(doc_key.as_str()).ok());
+                        .or_else(|| parse_bson_from_relaxed_json(doc_key.as_str()).ok())
+                        .map(Box::new);
                     changes.push(UnsavedChange::InlineDocument {
                         session_key: session_key.clone(),
                         doc_key: doc_key.clone(),

--- a/src/state/app_state/unsaved.rs
+++ b/src/state/app_state/unsaved.rs
@@ -3,7 +3,7 @@ use mongodb::bson::{Bson, Document};
 use uuid::Uuid;
 
 use crate::bson::{DocumentKey, parse_bson_from_relaxed_json};
-use crate::state::{EditorSession, EditorSessionId, EditorSessionTarget, SessionKey, TabKey};
+use crate::state::{EditorSession, EditorSessionId, SessionKey, TabKey};
 
 use super::AppState;
 
@@ -25,6 +25,7 @@ pub enum UnsavedChange {
         original_id: Option<Bson>,
         baseline_document: Option<Document>,
         document: Document,
+        save_in_flight: bool,
     },
     InvalidInlineEdit {
         session_key: SessionKey,
@@ -48,6 +49,10 @@ impl UnsavedInventory {
 }
 
 impl AppState {
+    pub fn session_has_invalid_edit(&self, key: &SessionKey) -> bool {
+        self.invalid_inline_edits.contains(key)
+    }
+
     pub fn set_invalid_inline_edit(&mut self, session_key: SessionKey, invalid: bool) {
         if invalid {
             self.invalid_inline_edits.insert(session_key);
@@ -90,7 +95,7 @@ impl AppState {
                     let Some(document) = session.view.drafts.get(doc_key).cloned() else {
                         continue;
                     };
-                    let baseline_document = self.document_for_key(session_key, doc_key);
+                    let baseline_document = self.document_edit_baseline(session_key, doc_key);
                     let original_id = baseline_document
                         .as_ref()
                         .and_then(|document| document.get("_id").cloned())
@@ -101,6 +106,7 @@ impl AppState {
                         original_id,
                         baseline_document,
                         document,
+                        save_in_flight: session.view.saving_documents.contains(doc_key),
                     });
                 }
             }

--- a/src/state/commands/documents/delete.rs
+++ b/src/state/commands/documents/delete.rs
@@ -61,6 +61,7 @@ impl AppCommands {
                                     session.data.total = session.data.total.saturating_sub(1);
                                 }
                                 session.view.drafts.remove(&doc_key);
+                                session.view.draft_baselines.remove(&doc_key);
                                 session.view.dirty.remove(&doc_key);
                                 session.view.selected_docs.remove(&doc_key);
                                 if session.view.selected_doc.as_ref() == Some(&doc_key) {

--- a/src/state/commands/documents/query.rs
+++ b/src/state/commands/documents/query.rs
@@ -80,6 +80,15 @@ impl AppCommands {
         session_key: SessionKey,
         cx: &mut App,
     ) {
+        if state.read(cx).session_has_invalid_edit(&session_key) {
+            state.update(cx, |state, cx| {
+                state.set_status_message(Some(StatusMessage::error(
+                    "Finish or cancel the invalid field edit before loading documents.",
+                )));
+                cx.notify();
+            });
+            return;
+        }
         let Some(client) = Self::client_for_session(&state, &session_key, cx) else {
             return;
         };

--- a/src/state/commands/documents/update.rs
+++ b/src/state/commands/documents/update.rs
@@ -2,9 +2,7 @@ use gpui_kit::{App, AppContext as _, Entity};
 use mongodb::bson::{Document, doc};
 
 use crate::bson::{DocumentKey, parse_bson_from_relaxed_json};
-use crate::connection::ops::documents::{
-    replace_document_async, replace_document_if_current_async,
-};
+use crate::connection::ops::documents::replace_document_if_current_async;
 use crate::state::{AppEvent, AppState, EditorSessionId, SessionKey, StatusMessage};
 
 use crate::state::AppCommands;
@@ -18,7 +16,8 @@ impl AppCommands {
         updated: Document,
         cx: &mut App,
     ) {
-        Self::save_document_internal(state, session_key, doc_key, updated, None, None, cx);
+        let baseline = state.read(cx).document_edit_baseline(&session_key, &doc_key);
+        Self::save_document_internal(state, session_key, doc_key, updated, baseline, None, cx);
     }
 
     pub fn save_document_for_editor(
@@ -50,13 +49,44 @@ impl AppCommands {
         editor: Option<EditorSessionId>,
         cx: &mut App,
     ) {
+        let reject = |message: &str, cx: &mut App| {
+            state.update(cx, |state, cx| {
+                let event = AppEvent::DocumentSaveFailed {
+                    session: session_key.clone(),
+                    document: doc_key.clone(),
+                    editor,
+                    error: message.to_string(),
+                };
+                state.update_status_from_event(&event);
+                cx.emit(event);
+                cx.notify();
+            });
+        };
+        if state
+            .read(cx)
+            .session_view(&session_key)
+            .is_some_and(|view| view.saving_documents.contains(&doc_key))
+        {
+            reject("A save is already in progress for this document.", cx);
+            return;
+        }
         if !Self::ensure_writable(&state, Some(session_key.connection_id), cx) {
+            reject("Document could not be saved. Check connection write permissions.", cx);
+            return;
+        }
+        let Some(baseline_document) = baseline_document else {
+            reject("Original document is unavailable. Reload before saving.", cx);
+            return;
+        };
+        if updated.get("_id") != baseline_document.get("_id") {
+            reject("The document _id cannot be changed.", cx);
             return;
         }
         let Some(client) = Self::client_for_session(&state, &session_key, cx) else {
+            reject("Connection is no longer active.", cx);
             return;
         };
-        let (database, collection, original_id, doc_index, should_reload_after_save) = {
+        let (database, collection, original_id, should_reload_after_save) = {
             let state_ref = state.read(cx);
             let doc_index = state_ref.document_index(&session_key, &doc_key).or_else(|| {
                 state_ref.session(&session_key).and_then(|session| {
@@ -69,12 +99,7 @@ impl AppCommands {
                 .or_else(|| parse_bson_from_relaxed_json(doc_key.as_str()).ok());
 
             let Some(original_id) = original_id else {
-                state.update(cx, |state, cx| {
-                    state.set_status_message(Some(StatusMessage::error(
-                        "Could not resolve original document ID for save.",
-                    )));
-                    cx.notify();
-                });
+                reject("Could not resolve original document ID for save.", cx);
                 return;
             };
 
@@ -82,12 +107,12 @@ impl AppCommands {
                 session_key.database.clone(),
                 session_key.collection.clone(),
                 original_id,
-                doc_index,
                 doc_index.is_none(),
             )
         };
         let runtime = state.read(cx).connection_manager().runtime_handle();
         state.update(cx, |state, cx| {
+            state.ensure_session(session_key.clone()).view.saving_documents.insert(doc_key.clone());
             state.set_status_message(Some(StatusMessage::info("Saving document…")));
             cx.notify();
         });
@@ -97,26 +122,15 @@ impl AppCommands {
             let database = database.clone();
             let collection = collection.clone();
             async move {
-                if let Some(baseline_document) = baseline_document {
-                    replace_document_if_current_async(
-                        &client,
-                        &database,
-                        &collection,
-                        original_id,
-                        baseline_document,
-                        updated_for_task,
-                    )
-                    .await
-                } else {
-                    replace_document_async(
-                        &client,
-                        &database,
-                        &collection,
-                        original_id,
-                        updated_for_task,
-                    )
-                    .await
-                }
+                replace_document_if_current_async(
+                    &client,
+                    &database,
+                    &collection,
+                    original_id,
+                    baseline_document,
+                    updated_for_task,
+                )
+                .await
             }
         });
 
@@ -137,20 +151,28 @@ impl AppCommands {
                 cx.update(|cx| match result {
                     Ok(()) => {
                         state.update(cx, |state, cx| {
+                            if let Some(editor) = editor {
+                                state
+                                    .editor_sessions()
+                                    .refresh_document_baseline(editor, updated.clone());
+                            }
                             if let Some(session) = state.session_mut(&session_key) {
+                                session.view.saving_documents.remove(&doc_key);
                                 let draft_unchanged =
                                     session.view.drafts.get(&doc_key) == Some(&updated);
-                                let index = doc_index.or_else(|| {
-                                    session.data.items.iter().position(|item| item.key == doc_key)
-                                });
+                                let index =
+                                    session.data.items.iter().position(|item| item.key == doc_key);
                                 if let Some(index) = index
                                     && let Some(existing) = session.data.items.get_mut(index)
                                 {
-                                    existing.doc = updated;
+                                    existing.doc = updated.clone();
                                 }
                                 if draft_unchanged {
                                     session.view.drafts.remove(&doc_key);
+                                    session.view.draft_baselines.remove(&doc_key);
                                     session.view.dirty.remove(&doc_key);
+                                } else if session.view.drafts.contains_key(&doc_key) {
+                                    session.view.draft_baselines.insert(doc_key.clone(), updated);
                                 }
                                 session.generation = session.generation.wrapping_add(1);
                             }
@@ -174,6 +196,9 @@ impl AppCommands {
                     Err(e) => {
                         log::error!("Failed to save document");
                         state.update(cx, |state, cx| {
+                            if let Some(session) = state.session_mut(&session_key) {
+                                session.view.saving_documents.remove(&doc_key);
+                            }
                             let event = AppEvent::DocumentSaveFailed {
                                 session: session_key.clone(),
                                 document: doc_key.clone(),

--- a/src/state/editor_sessions.rs
+++ b/src/state/editor_sessions.rs
@@ -7,7 +7,7 @@ use gpui_kit::AnyWindowHandle;
 use mongodb::bson::{Bson, Document};
 use uuid::Uuid;
 
-use crate::bson::{DocumentKey, document_to_shell_string};
+use crate::bson::{DocumentKey, document_to_json_string};
 use crate::state::app_state::SessionKey;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -185,7 +185,13 @@ impl EditorSessionStore {
             else {
                 return false;
             };
-            session.baseline_content = document_to_shell_string(&baseline_document);
+            session.baseline_content = if crate::bson::parse_document_from_json(&session.content)
+                .is_ok_and(|document| document == baseline_document)
+            {
+                session.content.clone()
+            } else {
+                document_to_json_string(&baseline_document)
+            };
             **current = baseline_document;
             true
         })
@@ -343,6 +349,12 @@ mod tests {
             panic!("expected document target");
         };
         assert_eq!(baseline_document.get_str("name").ok(), Some("after"));
+        let content = "{ \"_id\": 1, \"name\": \"after\" }".to_string();
+        store.update_content(session_id, content.clone());
+        store.refresh_document_baseline(session_id, doc! { "_id": 1, "name": "after" });
+        let snapshot = store.snapshot(session_id).unwrap();
+        assert_eq!(snapshot.content, content);
+        assert!(!snapshot.is_dirty());
     }
 
     #[test]

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -56,6 +56,9 @@ pub enum AppEvent {
         count: usize,
         error: String,
     },
+    DocumentDraftChanged {
+        session: SessionKey,
+    },
     DocumentSaved {
         session: SessionKey,
         document: DocumentKey,

--- a/src/views/documents/actions.rs
+++ b/src/views/documents/actions.rs
@@ -2,8 +2,7 @@ use gpui_kit::*;
 use mongodb::bson::{Bson, Document, doc, oid::ObjectId};
 
 use crate::bson::{
-    PathSegment, bson_value_for_edit, document_to_shell_string, format_relaxed_json_value,
-    get_bson_at_path,
+    PathSegment, document_to_json_string, format_bson_for_clipboard, get_bson_at_path,
 };
 use crate::components::{WriteConfirmation, open_confirm_dialog, request_connection_write};
 use crate::keyboard::{
@@ -89,7 +88,8 @@ impl CollectionView {
             IndexCreateDialog::open(this.state.clone(), session_key, window, cx);
         }))
         .on_action(cx.listener(|this, _: &EditDocumentJson, window, cx| {
-            let Some((session_key, doc_key)) = this.selected_doc_key_for_current_session(cx) else {
+            let Some((session_key, _doc_key)) = this.selected_doc_key_for_current_session(cx)
+            else {
                 return;
             };
             let selected_count = this
@@ -101,16 +101,9 @@ impl CollectionView {
             if selected_count > 1 {
                 return;
             }
-            CollectionView::open_document_json_editor(
-                cx.entity(),
-                this.state.clone(),
-                session_key,
-                doc_key,
-                window,
-                cx,
-            );
+            this.change_document_view(session_key, DocumentViewMode::Json, window, cx);
         }))
-        .on_action(cx.listener(|this, _: &DuplicateDocument, window, cx| {
+        .on_action(cx.listener(|this, _: &DuplicateDocument, _window, cx| {
             let Some((session_key, _doc_key, doc)) = this.selected_document_for_current_session(cx)
             else {
                 return;
@@ -126,22 +119,11 @@ impl CollectionView {
             }
             let mut new_doc = doc.clone();
             new_doc.insert("_id", ObjectId::new());
-            let state = this.state.clone();
-            let state_for_write = state.clone();
-            let target = session_key.namespace();
-            request_connection_write(
-                state,
-                crate::components::WriteRequest::new(
-                    session_key.connection_id,
-                    target,
-                    "Insert a duplicated document",
-                    None,
-                ),
-                window,
+            crate::views::json_editor_detached::open_insert_json_editor_with_content(
+                this.state.clone(),
+                session_key,
+                document_to_json_string(&new_doc),
                 cx,
-                move |_window, cx| {
-                    AppCommands::insert_document(state_for_write, session_key, new_doc, cx);
-                },
             );
         }))
         .on_action(cx.listener(|this, _: &DeleteDocument, window, cx| {
@@ -153,7 +135,13 @@ impl CollectionView {
                 let Some(session) = state_ref.session(&session_key) else {
                     return;
                 };
-                session.view.selected_docs.iter().cloned().collect()
+                session
+                    .data
+                    .items
+                    .iter()
+                    .filter(|item| session.view.selected_docs.contains(&item.key))
+                    .map(|item| item.key.clone())
+                    .collect()
             };
             if selected_docs.is_empty() {
                 return;
@@ -264,6 +252,50 @@ impl CollectionView {
             );
         }))
         .on_action(cx.listener(|this, _: &PasteDocuments, window, cx| {
+            if let Some((session_key, meta)) = this.selected_property_context(cx) {
+                if !this.finish_document_edit(cx) {
+                    return;
+                }
+                let result = (|| {
+                    if let Some(reason) =
+                        this.state.read(cx).document_field_edit_restriction(&session_key)
+                    {
+                        return Err(reason.to_string());
+                    }
+                    if matches!(meta.path.first(), Some(PathSegment::Key(key)) if key == "_id") {
+                        return Err("The document _id cannot be changed.".into());
+                    }
+                    let text = cx
+                        .read_from_clipboard()
+                        .and_then(|item| item.text())
+                        .ok_or("Clipboard has no text.")?;
+                    let document = this
+                        .resolve_document(&session_key, &meta.doc_key, cx)
+                        .ok_or("Document is no longer available.")?;
+                    let original = get_bson_at_path(&document, &meta.path)
+                        .ok_or("Field is no longer available.")?;
+                    crate::bson::parse_edited_value(original, &text)
+                })();
+                match result {
+                    Ok(value) => {
+                        this.view_model.update_draft_value(
+                            &this.state,
+                            &meta.doc_key,
+                            &meta.path,
+                            value,
+                            cx,
+                        );
+                        this.view_model.rebuild_tree(&this.state, cx);
+                        this.view_model.invalidate_table();
+                        cx.notify();
+                    }
+                    Err(error) => this.state.update(cx, |state, cx| {
+                        state.set_status_message(Some(StatusMessage::error(error)));
+                        cx.notify();
+                    }),
+                }
+                return;
+            }
             let Some(session_key) = this.view_model.current_session() else {
                 return;
             };
@@ -278,7 +310,13 @@ impl CollectionView {
                 let Some(session) = state_ref.session(&session_key) else {
                     return;
                 };
-                session.view.selected_docs.iter().cloned().collect()
+                session
+                    .data
+                    .items
+                    .iter()
+                    .filter(|item| session.view.selected_docs.contains(&item.key))
+                    .map(|item| item.key.clone())
+                    .collect()
             };
             if selected_docs.is_empty() {
                 return;
@@ -286,7 +324,7 @@ impl CollectionView {
             if selected_docs.len() == 1 {
                 let doc_key = &selected_docs[0];
                 if let Some(doc) = this.resolve_document(&session_key, doc_key, cx) {
-                    let json = document_to_shell_string(&doc);
+                    let json = document_to_json_string(&doc);
                     cx.write_to_clipboard(ClipboardItem::new_string(json));
                 }
             } else {
@@ -301,7 +339,7 @@ impl CollectionView {
                         .collect()
                 };
                 let task = cx.background_spawn(async move {
-                    let parts: Vec<String> = docs.iter().map(document_to_shell_string).collect();
+                    let parts: Vec<String> = docs.iter().map(document_to_json_string).collect();
                     format!("[{}]", parts.join(",\n"))
                 });
                 cx.spawn(async move |_this, cx: &mut gpui_kit::AsyncApp| {
@@ -312,61 +350,7 @@ impl CollectionView {
             }
         }))
         .on_action(cx.listener(|this, _: &SaveDocument, window, cx| {
-            this.view_model.commit_inline_edit(&this.state, cx);
-            let Some(session_key) = this.view_model.current_session() else {
-                return;
-            };
-            let dirty_selected: Vec<_> = {
-                let state_ref = this.state.read(cx);
-                let Some(session) = state_ref.session(&session_key) else {
-                    return;
-                };
-                session
-                    .view
-                    .selected_docs
-                    .iter()
-                    .filter(|dk| session.view.dirty.contains(*dk))
-                    .cloned()
-                    .collect()
-            };
-            let documents = dirty_selected
-                .into_iter()
-                .filter_map(|doc_key| {
-                    this.state
-                        .read(cx)
-                        .session_draft(&session_key, &doc_key)
-                        .map(|document| (doc_key, document))
-                })
-                .collect::<Vec<_>>();
-            if documents.is_empty() {
-                return;
-            }
-            let state = this.state.clone();
-            let state_for_write = state.clone();
-            let write_count = documents.len();
-            request_connection_write(
-                state,
-                crate::components::WriteRequest::new(
-                    session_key.connection_id,
-                    session_key.namespace(),
-                    format!("Save {write_count} document change(s)"),
-                    None,
-                )
-                .for_writes(write_count),
-                window,
-                cx,
-                move |_window, cx| {
-                    for (doc_key, document) in documents {
-                        AppCommands::save_document(
-                            state_for_write.clone(),
-                            session_key.clone(),
-                            doc_key,
-                            document,
-                            cx,
-                        );
-                    }
-                },
-            );
+            this.save_selected_documents(window, cx);
         }))
         .on_action(cx.listener(|this, _: &EditValueType, window, cx| {
             let Some((session_key, meta)) = this.selected_property_context(cx) else {
@@ -495,7 +479,13 @@ impl CollectionView {
                 let Some(session) = state_ref.session(&session_key) else {
                     return;
                 };
-                session.view.selected_docs.iter().cloned().collect()
+                session
+                    .data
+                    .items
+                    .iter()
+                    .filter(|item| session.view.selected_docs.contains(&item.key))
+                    .map(|item| item.key.clone())
+                    .collect()
             };
             if selected_docs.is_empty() {
                 return;
@@ -503,7 +493,7 @@ impl CollectionView {
             if selected_docs.len() == 1 {
                 let doc_key = &selected_docs[0];
                 if let Some(doc) = this.resolve_document(&session_key, doc_key, cx) {
-                    let json = document_to_shell_string(&doc);
+                    let json = document_to_json_string(&doc);
                     cx.write_to_clipboard(ClipboardItem::new_string(json));
                 }
             } else {
@@ -518,7 +508,7 @@ impl CollectionView {
                         .collect()
                 };
                 let task = cx.background_spawn(async move {
-                    let parts: Vec<String> = docs.iter().map(document_to_shell_string).collect();
+                    let parts: Vec<String> = docs.iter().map(document_to_json_string).collect();
                     format!("[{}]", parts.join(",\n"))
                 });
                 cx.spawn(async move |_this, cx: &mut gpui_kit::AsyncApp| {
@@ -546,7 +536,7 @@ impl CollectionView {
             };
 
             match view_mode {
-                DocumentViewMode::Tree => {
+                DocumentViewMode::Tree | DocumentViewMode::Json => {
                     let property_ctx = this.selected_property_context(cx);
                     match tree_copy_target(
                         property_ctx.as_ref().map(|(_, meta)| meta.path.as_slice()),
@@ -566,7 +556,7 @@ impl CollectionView {
                             if let Some((sk, meta)) = property_ctx
                                 && let Some(doc) = this.resolve_document(&sk, &meta.doc_key, cx)
                             {
-                                let text = document_to_shell_string(&doc);
+                                let text = document_to_json_string(&doc);
                                 cx.write_to_clipboard(ClipboardItem::new_string(text));
                             }
                         }
@@ -613,38 +603,13 @@ impl CollectionView {
             };
             cx.write_to_clipboard(ClipboardItem::new_string(meta.key_label));
         }))
-        .on_action(cx.listener(|this, _: &DiscardDocumentChanges, _window, cx| {
-            let Some(session_key) = this.view_model.current_session() else {
-                return;
-            };
-            let dirty_selected: Vec<_> = {
-                let state_ref = this.state.read(cx);
-                let Some(session) = state_ref.session(&session_key) else {
-                    return;
-                };
-                session
-                    .view
-                    .selected_docs
-                    .iter()
-                    .filter(|dk| session.view.dirty.contains(*dk))
-                    .cloned()
-                    .collect()
-            };
-            if dirty_selected.is_empty() {
-                return;
-            }
-            this.state.update(cx, |state, cx| {
-                for doc_key in &dirty_selected {
-                    state.clear_draft(&session_key, doc_key);
-                }
-                cx.notify();
-            });
-            this.view_model.clear_inline_edit();
-            this.view_model.rebuild_tree(&this.state, cx);
-            this.view_model.sync_dirty_state(&this.state, cx);
-            cx.notify();
+        .on_action(cx.listener(|this, _: &DiscardDocumentChanges, window, cx| {
+            this.discard_selected_documents(window, cx);
         }))
         .on_action(cx.listener(|this, _: &ShowDocumentsSubview, _window, cx| {
+            if !this.finish_document_edit(cx) {
+                return;
+            }
             let Some(session_key) = this.view_model.current_session() else {
                 return;
             };
@@ -654,6 +619,9 @@ impl CollectionView {
             });
         }))
         .on_action(cx.listener(|this, _: &ShowIndexesSubview, _window, cx| {
+            if !this.finish_document_edit(cx) {
+                return;
+            }
             let Some(session_key) = this.view_model.current_session() else {
                 return;
             };
@@ -664,6 +632,9 @@ impl CollectionView {
             AppCommands::load_collection_indexes(this.state.clone(), session_key, false, cx);
         }))
         .on_action(cx.listener(|this, _: &ShowStatsSubview, _window, cx| {
+            if !this.finish_document_edit(cx) {
+                return;
+            }
             let Some(session_key) = this.view_model.current_session() else {
                 return;
             };
@@ -678,6 +649,9 @@ impl CollectionView {
             }
         }))
         .on_action(cx.listener(|this, _: &ShowAggregationSubview, _window, cx| {
+            if !this.finish_document_edit(cx) {
+                return;
+            }
             let Some(session_key) = this.view_model.current_session() else {
                 return;
             };
@@ -687,6 +661,9 @@ impl CollectionView {
             });
         }))
         .on_action(cx.listener(|this, _: &ShowHistorySubview, _window, cx| {
+            if !this.finish_document_edit(cx) {
+                return;
+            }
             let Some(session_key) = this.view_model.current_session() else {
                 return;
             };
@@ -704,6 +681,9 @@ impl CollectionView {
             AppCommands::load_collection_history(this.state.clone(), session_key, cx);
         }))
         .on_action(cx.listener(|this, _: &ShowSchemaSubview, _window, cx| {
+            if !this.finish_document_edit(cx) {
+                return;
+            }
             let Some(session_key) = this.view_model.current_session() else {
                 return;
             };
@@ -1044,8 +1024,16 @@ pub(in crate::views::documents) fn copy_documents_as(
         let snapshot = ViewExportSnapshot::from_session_state(
             &session.data.items,
             &session.view.selected_docs,
-            &session.view.table_column_order,
-            &session.view.table_hidden_columns,
+            if session.view.view_mode == DocumentViewMode::Table {
+                &session.view.table_column_order
+            } else {
+                &[]
+            },
+            &if session.view.view_mode == DocumentViewMode::Table {
+                session.view.table_hidden_columns.clone()
+            } else {
+                Default::default()
+            },
             &session.view.table_pinned_columns,
             &session.view.drafts,
             session_key.collection.clone(),
@@ -1153,7 +1141,7 @@ fn property_flags(meta: &NodeMeta) -> PropertyFlags {
     let is_array_element = matches!(meta.path.last(), Some(PathSegment::Index(_)));
     let has_index = meta.path.iter().any(|segment| matches!(segment, PathSegment::Index(_)));
     let allow_bulk = !has_index;
-    let is_id = matches!(meta.path.last(), Some(PathSegment::Key(key)) if key == "_id");
+    let is_id = matches!(meta.path.first(), Some(PathSegment::Key(key)) if key == "_id");
     let is_array = matches!(meta.value, Some(Bson::Array(_)));
     let can_edit_value = !is_id;
     let can_rename_field = !is_id && !is_array_element;
@@ -1170,17 +1158,6 @@ fn property_flags(meta: &NodeMeta) -> PropertyFlags {
         can_add_field,
         is_array,
         is_array_element,
-    }
-}
-
-fn format_bson_for_clipboard(value: &Bson) -> String {
-    match value {
-        Bson::Document(doc) => document_to_shell_string(doc),
-        Bson::Array(arr) => {
-            let value = Bson::Array(arr.clone()).into_relaxed_extjson();
-            format_relaxed_json_value(&value)
-        }
-        _ => bson_value_for_edit(value),
     }
 }
 

--- a/src/views/documents/dialogs/json_dialogs.rs
+++ b/src/views/documents/dialogs/json_dialogs.rs
@@ -2,23 +2,39 @@ use gpui_kit::*;
 
 use crate::bson::DocumentKey;
 use crate::state::{AppState, SessionKey};
-use crate::views::json_editor_detached::{
-    open_document_json_editor_window, open_insert_json_editor_window,
-};
+use crate::views::json_editor_detached::open_insert_json_editor_window;
 
 use super::super::CollectionView;
 use super::index_create::IndexCreateDialog;
 
 impl CollectionView {
     pub(crate) fn open_document_json_editor(
-        _view: Entity<CollectionView>,
+        view: Entity<CollectionView>,
         state: Entity<AppState>,
         session_key: SessionKey,
         doc_key: DocumentKey,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut App,
     ) {
-        open_document_json_editor_window(state, session_key, doc_key, cx);
+        view.update(cx, |this, cx| {
+            if !this.finish_document_edit(cx) {
+                return;
+            }
+            state.update(cx, |state, cx| {
+                state.select_single_doc(
+                    &session_key,
+                    doc_key.clone(),
+                    crate::bson::doc_root_id(&doc_key),
+                );
+                cx.notify();
+            });
+            this.change_document_view(
+                session_key,
+                crate::state::DocumentViewMode::Json,
+                window,
+                cx,
+            );
+        });
     }
 
     pub(crate) fn open_insert_document_json_editor(

--- a/src/views/documents/dialogs/property_dialog.rs
+++ b/src/views/documents/dialogs/property_dialog.rs
@@ -26,6 +26,7 @@ pub struct PropertyActionDialog {
     session_key: SessionKey,
     doc_key: DocumentKey,
     action: PropertyActionKind,
+    path: Vec<PathSegment>,
     path_dot: String,
     parent_dot: String,
     array_dot: String,
@@ -195,6 +196,9 @@ impl PropertyActionDialog {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        let allow_bulk = allow_bulk && !meta.path.iter().any(|segment| {
+            matches!(segment, PathSegment::Key(key) if key.contains('.') || key.starts_with('$'))
+        });
         let mut parent_path = parent_path(&meta.path);
         if action == PropertyActionKind::AddField && matches!(meta.value, Some(Bson::Document(_))) {
             parent_path = meta.path.clone();
@@ -274,7 +278,12 @@ impl PropertyActionDialog {
         }
 
         if should_prefill_value && let Some(value) = meta.value.as_ref() {
-            let raw = format_bson_for_input(value);
+            let raw = if value_type == ValueType::ExtendedJson {
+                serde_json::to_string_pretty(&value.clone().into_canonical_extjson())
+                    .expect("Extended JSON is serializable")
+            } else {
+                format_bson_for_input(value)
+            };
             value_state.update(cx, |state, cx| {
                 state.set_value(raw, window, cx);
             });
@@ -285,6 +294,7 @@ impl PropertyActionDialog {
             session_key,
             doc_key: meta.doc_key.clone(),
             action,
+            path: meta.path.clone(),
             path_dot,
             parent_dot,
             array_dot,
@@ -356,6 +366,7 @@ impl PropertyActionDialog {
         let trimmed = raw.trim();
 
         match self.value_type {
+            ValueType::ExtendedJson => crate::bson::parse_bson_from_relaxed_json(trimmed),
             ValueType::String => Ok(Bson::String(raw)),
             ValueType::Bool => parse_bool(trimmed),
             ValueType::Int32 => parse_i32(trimmed),
@@ -391,6 +402,15 @@ impl PropertyActionDialog {
         }
 
         self.error_message = None;
+        if self.effective_scope() == UpdateScope::CurrentDocument {
+            if let Err(error) = self.stage_property_edit(cx) {
+                self.error_message = Some(error);
+                cx.notify();
+            } else {
+                window.close_dialog(cx);
+            }
+            return;
+        }
         let update_doc = match self.build_update_doc(cx) {
             Ok(doc) => doc,
             Err(err) => {
@@ -401,38 +421,7 @@ impl PropertyActionDialog {
         };
 
         match self.effective_scope() {
-            UpdateScope::CurrentDocument => {
-                let state = self.state.clone();
-                let state_for_write = state.clone();
-                let session_key = self.session_key.clone();
-                let session_for_write = session_key.clone();
-                let doc_key = self.doc_key.clone();
-                let view = cx.entity();
-                request_connection_write(
-                    state,
-                    crate::components::WriteRequest::new(
-                        session_key.connection_id,
-                        session_key.namespace(),
-                        "Update a document property",
-                        None,
-                    ),
-                    window,
-                    cx,
-                    move |_window, cx| {
-                        view.update(cx, |view, cx| {
-                            view.updating = true;
-                            cx.notify();
-                            AppCommands::update_document_by_key(
-                                state_for_write,
-                                session_for_write,
-                                doc_key,
-                                update_doc,
-                                cx,
-                            );
-                        });
-                    },
-                );
-            }
+            UpdateScope::CurrentDocument => unreachable!("single-document edits are staged above"),
             UpdateScope::MatchQuery => {
                 self.confirm_bulk_update(self.current_filter(cx), update_doc, window, cx);
             }
@@ -440,6 +429,52 @@ impl PropertyActionDialog {
                 self.confirm_bulk_update(Document::new(), update_doc, window, cx);
             }
         }
+    }
+
+    fn stage_property_edit(&self, cx: &mut Context<Self>) -> Result<(), String> {
+        let state = self.state.read(cx);
+        if let Some(reason) = state.document_field_edit_restriction(&self.session_key) {
+            return Err(reason.into());
+        }
+        let baseline = state
+            .document_edit_baseline(&self.session_key, &self.doc_key)
+            .ok_or("Document is no longer available.")?;
+        let mut document = state
+            .session_draft_or_document(&self.session_key, &self.doc_key)
+            .ok_or("Document is no longer available.")?;
+        let value = if matches!(
+            self.action,
+            PropertyActionKind::RenameField | PropertyActionKind::RemoveField
+        ) {
+            Bson::Null
+        } else {
+            self.parse_value(cx)?
+        };
+        let field = self.field_state.read(cx).value().to_string();
+        super::property_dialog_support::apply_property_edit(
+            &mut document,
+            &self.path,
+            self.action,
+            field.trim(),
+            value,
+        )?;
+        self.state.update(cx, |state, cx| {
+            if document == baseline {
+                state.clear_draft(&self.session_key, &self.doc_key);
+            } else {
+                state.set_draft(&self.session_key, self.doc_key.clone(), document);
+            }
+            let session = state.ensure_session(self.session_key.clone());
+            session.generation = session.generation.wrapping_add(1);
+            state.set_collection_dirty(
+                self.session_key.clone(),
+                !state.session_view(&self.session_key).is_none_or(|view| view.dirty.is_empty()),
+                cx,
+            );
+            cx.emit(AppEvent::DocumentDraftChanged { session: self.session_key.clone() });
+            cx.notify();
+        });
+        Ok(())
     }
 
     fn confirm_bulk_update(
@@ -655,6 +690,7 @@ impl PropertyActionDialog {
                         ValueType::Double,
                         ValueType::Date,
                         ValueType::Null,
+                        ValueType::ExtendedJson,
                     ] {
                         menu = menu.item(PopupMenuItem::new(kind.label()).on_click({
                             let view = view.clone();
@@ -696,16 +732,24 @@ impl Render for PropertyActionDialog {
                 | PropertyActionKind::RemoveMatchingValues
         );
 
-        let action_label = match self.action {
-            PropertyActionKind::EditValue => "Set Value",
-            PropertyActionKind::AddField => "Add Field",
-            PropertyActionKind::RenameField => "Rename",
-            PropertyActionKind::RemoveField => "Remove",
-            PropertyActionKind::AddElement => "Add Element",
-            PropertyActionKind::RemoveMatchingValues => "Remove",
+        let action_label = if self.effective_scope() == UpdateScope::CurrentDocument {
+            "Stage change"
+        } else {
+            match self.action {
+                PropertyActionKind::EditValue => "Set Value",
+                PropertyActionKind::AddField => "Add Field",
+                PropertyActionKind::RenameField => "Rename",
+                PropertyActionKind::RemoveField => "Remove",
+                PropertyActionKind::AddElement => "Add Element",
+                PropertyActionKind::RemoveMatchingValues => "Remove",
+            }
         };
 
-        let default_label = if !self.allow_bulk { "Scope locked to current document." } else { "" };
+        let default_label = if self.effective_scope() == UpdateScope::CurrentDocument {
+            "Staged locally. Save the document to apply changes."
+        } else {
+            "Updates matching documents in the collection."
+        };
         let status = status_text(
             self.error_message.as_ref(),
             self.updating,

--- a/src/views/documents/dialogs/property_dialog_support.rs
+++ b/src/views/documents/dialogs/property_dialog_support.rs
@@ -1,8 +1,6 @@
 use mongodb::bson::{Bson, DateTime};
 
-use crate::bson::{
-    PathSegment, bson_value_for_edit, document_to_shell_string, format_relaxed_json_value,
-};
+use crate::bson::{PathSegment, bson_value_for_edit, document_to_json_string};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum PropertyActionKind {
@@ -12,6 +10,144 @@ pub(super) enum PropertyActionKind {
     RemoveField,
     AddElement,
     RemoveMatchingValues,
+}
+
+/// Apply one field edit using typed path segments, including literal dotted keys.
+pub(super) fn apply_property_edit(
+    document: &mut mongodb::bson::Document,
+    path: &[PathSegment],
+    action: PropertyActionKind,
+    field: &str,
+    value: Bson,
+) -> Result<(), String> {
+    use crate::bson::{get_bson_at_path, set_bson_at_path};
+    if matches!(path.first(), Some(PathSegment::Key(key)) if key == "_id") {
+        return Err("The document _id cannot be changed.".into());
+    }
+    let mut target = path.to_vec();
+    let replacement = match action {
+        PropertyActionKind::EditValue => value,
+        PropertyActionKind::AddElement | PropertyActionKind::RemoveMatchingValues => {
+            if matches!(target.last(), Some(PathSegment::Index(_))) {
+                target.pop();
+            }
+            let Some(Bson::Array(mut values)) = get_bson_at_path(document, &target).cloned() else {
+                return Err("Array is no longer available.".into());
+            };
+            if action == PropertyActionKind::AddElement {
+                values.push(value);
+            } else {
+                values.retain(|item| item != &value);
+            }
+            Bson::Array(values)
+        }
+        PropertyActionKind::AddField
+        | PropertyActionKind::RenameField
+        | PropertyActionKind::RemoveField => {
+            let old_key = match target.last() {
+                Some(PathSegment::Key(key)) => Some(key.clone()),
+                _ => None,
+            };
+            if action != PropertyActionKind::AddField
+                || !matches!(get_bson_at_path(document, &target), Some(Bson::Document(_)))
+            {
+                target.pop();
+            }
+            let mut parent = if target.is_empty() {
+                document.clone()
+            } else if let Some(Bson::Document(parent)) = get_bson_at_path(document, &target) {
+                parent.clone()
+            } else {
+                return Err("Parent document is no longer available.".into());
+            };
+            if action != PropertyActionKind::RemoveField {
+                if field.is_empty() {
+                    return Err("Field name is required.".into());
+                }
+                if target.is_empty() && field == "_id" {
+                    return Err("The document _id cannot be changed.".into());
+                }
+                if parent.contains_key(field)
+                    && (action == PropertyActionKind::AddField || old_key.as_deref() != Some(field))
+                {
+                    return Err("A field with this name already exists.".into());
+                }
+            }
+            match action {
+                PropertyActionKind::AddField => {
+                    parent.insert(field, value);
+                }
+                PropertyActionKind::RenameField => {
+                    let value = parent
+                        .remove(old_key.as_deref().ok_or("Select a field to rename.")?)
+                        .ok_or("Field is no longer available.")?;
+                    parent.insert(field, value);
+                }
+                PropertyActionKind::RemoveField => {
+                    parent.remove(old_key.as_deref().ok_or("Select a field to remove.")?);
+                }
+                _ => unreachable!(),
+            }
+            Bson::Document(parent)
+        }
+    };
+    if target.is_empty() {
+        if let Bson::Document(updated) = replacement {
+            *document = updated;
+            return Ok(());
+        }
+    } else if set_bson_at_path(document, &target, replacement) {
+        return Ok(());
+    }
+    Err("Field is no longer available.".into())
+}
+
+#[cfg(test)]
+mod staged_edit_tests {
+    use super::*;
+    use mongodb::bson::doc;
+
+    #[test]
+    fn edits_preserve_literal_keys_types_and_existing_fields() {
+        let mut document = doc! { "_id": 1, "a.b": { "count": Bson::Int64(i64::MAX) }, "a": { "b": 8 }, "values": [1, 2, 1] };
+        let path = [PathSegment::Key("a.b".into()), PathSegment::Key("count".into())];
+        apply_property_edit(
+            &mut document,
+            &path,
+            PropertyActionKind::RenameField,
+            "total",
+            Bson::Null,
+        )
+        .unwrap();
+        assert_eq!(
+            document.get_document("a.b").unwrap().get("total"),
+            Some(&Bson::Int64(i64::MAX))
+        );
+        assert_eq!(document.get_document("a").unwrap().get_i32("b").unwrap(), 8);
+        assert!(
+            apply_property_edit(&mut document, &[], PropertyActionKind::AddField, "a", Bson::Null)
+                .is_err()
+        );
+        assert!(
+            apply_property_edit(
+                &mut document,
+                &[PathSegment::Key("_id".into())],
+                PropertyActionKind::EditValue,
+                "",
+                Bson::Int32(2)
+            )
+            .is_err()
+        );
+        apply_property_edit(
+            &mut document,
+            &[PathSegment::Key("values".into())],
+            PropertyActionKind::RemoveMatchingValues,
+            "",
+            Bson::Int32(1),
+        )
+        .unwrap();
+        assert_eq!(document.get_array("values").unwrap(), &vec![Bson::Int32(2)]);
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -33,6 +169,7 @@ impl UpdateScope {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum ValueType {
+    ExtendedJson,
     Document,
     Array,
     ObjectId,
@@ -48,6 +185,7 @@ pub(super) enum ValueType {
 impl ValueType {
     pub(super) fn label(self) -> &'static str {
         match self {
+            ValueType::ExtendedJson => "Extended JSON",
             ValueType::Document => "Document",
             ValueType::Array => "Array",
             ValueType::ObjectId => "ObjectId",
@@ -63,6 +201,7 @@ impl ValueType {
 
     pub(super) fn placeholder(self) -> &'static str {
         match self {
+            ValueType::ExtendedJson => "BSON value in Extended JSON",
             ValueType::Document => "{ }",
             ValueType::Array => "[ ]",
             ValueType::ObjectId => "ObjectId hex",
@@ -88,7 +227,7 @@ impl ValueType {
             Bson::Double(_) => ValueType::Double,
             Bson::DateTime(_) => ValueType::Date,
             Bson::Null => ValueType::Null,
-            _ => ValueType::String,
+            _ => ValueType::ExtendedJson,
         }
     }
 }
@@ -151,10 +290,10 @@ pub(super) fn dot_path(path: &[PathSegment]) -> String {
 
 pub(super) fn format_bson_for_input(value: &Bson) -> String {
     match value {
-        Bson::Document(doc) => document_to_shell_string(doc),
+        Bson::Document(doc) => document_to_json_string(doc),
         Bson::Array(arr) => {
-            let value = Bson::Array(arr.clone()).into_relaxed_extjson();
-            format_relaxed_json_value(&value)
+            let value = Bson::Array(arr.clone()).into_canonical_extjson();
+            serde_json::to_string_pretty(&value).expect("Extended JSON is serializable")
         }
         _ => bson_value_for_edit(value),
     }

--- a/src/views/documents/export/formats.rs
+++ b/src/views/documents/export/formats.rs
@@ -20,7 +20,7 @@ fn filter_doc_to_columns(
     let mut map = serde_json::Map::new();
     for col in &snapshot.columns {
         if let Some(val) = doc.get(&col.key) {
-            map.insert(col.key.clone(), val.clone().into_relaxed_extjson());
+            map.insert(col.key.clone(), val.clone().into_canonical_extjson());
         }
     }
     serde_json::Value::Object(map)

--- a/src/views/documents/header/actions.rs
+++ b/src/views/documents/header/actions.rs
@@ -10,6 +10,7 @@ use gpui_kit::component::menu::{DropdownMenu as _, PopupMenu, PopupMenuItem};
 use gpui_kit::component::popover::Popover;
 use gpui_kit::component::scroll::ScrollableElement as _;
 use gpui_kit::component::{Disableable as _, Icon, IconName, Sizable as _, Size};
+use gpui_kit::prelude::FluentBuilder as _;
 use gpui_kit::*;
 use mongodb::bson::Document;
 
@@ -88,10 +89,15 @@ fn render_delete_menu(
     let button = MenuButton::new("delete-menu")
         .xsmall()
         .rounded(borders::radius_sm())
-        .disabled(session_key.is_none())
+        .disabled(
+            session_key
+                .as_ref()
+                .is_none_or(|key| state.read(cx).connection_read_only(key.connection_id)),
+        )
         .with_size(Size::Small)
         .custom(clean_delete_variant)
         .icon(Icon::new(IconName::Delete).xsmall())
+        .label("Delete")
         .tooltip("Delete options");
 
     let anchor = Anchor::BottomLeft;
@@ -253,6 +259,7 @@ fn render_delete_menu(
 fn render_copy_as_dropdown(
     view: Entity<CollectionView>,
     view_mode: DocumentViewMode,
+    selected_count: usize,
     cx: &App,
 ) -> impl IntoElement {
     use crate::views::documents::actions::copy_documents_as;
@@ -266,7 +273,7 @@ fn render_copy_as_dropdown(
         .shadow(false);
 
     let formats = match view_mode {
-        DocumentViewMode::Tree => CopyFormat::tree_formats(),
+        DocumentViewMode::Tree | DocumentViewMode::Json => CopyFormat::tree_formats(),
         DocumentViewMode::Table => CopyFormat::table_formats(),
     };
     let formats: Vec<CopyFormat> = formats.to_vec();
@@ -276,9 +283,9 @@ fn render_copy_as_dropdown(
         .rounded(borders::radius_sm())
         .with_size(Size::Small)
         .custom(clean_variant)
-        .label("Copy Page As")
+        .label(if selected_count > 0 { "Copy selected" } else { "Copy page" })
         .icon(Icon::new(IconName::Copy).xsmall())
-        .tooltip("Copy the current page")
+        .tooltip("Copy documents in a selected format")
         .dropdown_menu_with_anchor(Anchor::TopLeft, move |menu: PopupMenu, _window, _cx| {
             let mut menu = menu;
             for &fmt in &formats {
@@ -286,7 +293,16 @@ fn render_copy_as_dropdown(
                 let item = PopupMenuItem::new(fmt.label()).icon(fmt.icon()).on_click(
                     move |_, _window, cx| {
                         view_click.update(cx, |this, cx| {
-                            copy_documents_as(this, fmt, ExportScope::CurrentPage, cx);
+                            copy_documents_as(
+                                this,
+                                fmt,
+                                if selected_count > 0 {
+                                    ExportScope::Selected
+                                } else {
+                                    ExportScope::CurrentPage
+                                },
+                                cx,
+                            );
                         });
                     },
                 );
@@ -356,14 +372,16 @@ fn render_documents_actions_clean(
     cx: &mut Context<CollectionView>,
 ) -> Div {
     let state_for_refresh = state.clone();
-    let state_for_apply = state.clone();
     let state_for_dialog = state.clone();
     let state_for_insert = state.clone();
     let state_for_delete = state.clone();
     let state_for_transfer = state.clone();
+    let writable = session_key
+        .as_ref()
+        .is_some_and(|key| !state.read(cx).connection_read_only(key.connection_id));
 
     let insert_button = clean_toolbar_icon_button(
-        Button::new("insert-document-clean").xsmall().disabled(session_key.is_none()).on_click({
+        Button::new("insert-document-clean").xsmall().disabled(!writable || is_loading).on_click({
             let session_key = session_key.clone();
             let state_for_insert = state_for_insert.clone();
             move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
@@ -380,7 +398,8 @@ fn render_documents_actions_clean(
         }),
         IconName::Plus,
         "Insert document",
-    );
+    )
+    .label("Insert");
 
     let edit_button = clean_toolbar_icon_button(
         Button::new("edit-json-clean")
@@ -410,115 +429,37 @@ fn render_documents_actions_clean(
             }),
         crate::assets::AppIcon::Braces,
         "Edit JSON",
-    );
+    )
+    .label("Edit");
 
-    let discard_button = clean_toolbar_icon_button(
-        Button::new("discard-clean").xsmall().disabled(!any_selected_dirty).on_click({
+    let saving = session_key
+        .as_ref()
+        .and_then(|key| state.read(cx).session_view(key))
+        .is_some_and(|view| !view.saving_documents.is_empty());
+    let discard_button = Button::new("discard-clean")
+        .ghost()
+        .xsmall()
+        .label("Discard")
+        .disabled(!any_selected_dirty || saving)
+        .on_click({
             let view = view.clone();
-            move |_: &ClickEvent, _window: &mut Window, cx: &mut App| {
+            move |_, window, cx| {
+                view.update(cx, |this, cx| this.discard_selected_documents(window, cx));
+            }
+        });
+    let apply_button = Button::new("apply-clean")
+        .primary()
+        .xsmall()
+        .label(if saving { "Saving…" } else { "Save" })
+        .disabled(!any_selected_dirty || saving)
+        .on_click({
+            let view = view.clone();
+            move |_, window, cx| {
                 view.update(cx, |this, cx| {
-                    let Some(session_key) = this.view_model.current_session() else {
-                        return;
-                    };
-                    let dirty_selected: Vec<_> = {
-                        let state_ref = this.state.read(cx);
-                        let Some(session) = state_ref.session(&session_key) else {
-                            return;
-                        };
-                        session
-                            .view
-                            .selected_docs
-                            .iter()
-                            .filter(|dk| session.view.dirty.contains(*dk))
-                            .cloned()
-                            .collect()
-                    };
-                    this.state.update(cx, |state, cx| {
-                        for doc_key in &dirty_selected {
-                            state.clear_draft(&session_key, doc_key);
-                        }
-                        cx.notify();
-                    });
-                    this.view_model.clear_inline_edit();
-                    this.view_model.rebuild_tree(&this.state, cx);
-                    this.view_model.sync_dirty_state(&this.state, cx);
-                    cx.notify();
+                    this.save_selected_documents(window, cx);
                 });
             }
-        }),
-        IconName::CircleX,
-        "Discard changes",
-    );
-
-    let mut apply_button = clean_toolbar_icon_button(
-        Button::new("apply-clean").xsmall().disabled(!any_selected_dirty).on_click({
-            let state_for_apply = state_for_apply.clone();
-            let view = view.clone();
-            move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
-                view.update(cx, |this, cx| {
-                    this.view_model.commit_inline_edit(&this.state, cx);
-                });
-                let Some(session_key) = state_for_apply.read(cx).current_session_key() else {
-                    return;
-                };
-                let dirty_docs: Vec<_> = {
-                    let state_ref = state_for_apply.read(cx);
-                    let Some(session) = state_ref.session(&session_key) else {
-                        return;
-                    };
-                    session
-                        .view
-                        .selected_docs
-                        .iter()
-                        .filter(|dk| session.view.dirty.contains(*dk))
-                        .cloned()
-                        .collect()
-                };
-                let documents = dirty_docs
-                    .into_iter()
-                    .filter_map(|doc_key| {
-                        state_for_apply
-                            .read(cx)
-                            .session_draft(&session_key, &doc_key)
-                            .map(|document| (doc_key, document))
-                    })
-                    .collect::<Vec<_>>();
-                if documents.is_empty() {
-                    return;
-                }
-                let write_count = documents.len();
-                let state_for_write = state_for_apply.clone();
-                request_connection_write(
-                    state_for_apply.clone(),
-                    crate::components::WriteRequest::new(
-                        session_key.connection_id,
-                        session_key.namespace(),
-                        format!("Save {write_count} document change(s)"),
-                        None,
-                    )
-                    .for_writes(write_count),
-                    window,
-                    cx,
-                    move |_window, cx| {
-                        for (doc_key, document) in documents {
-                            AppCommands::save_document(
-                                state_for_write.clone(),
-                                session_key.clone(),
-                                doc_key,
-                                document,
-                                cx,
-                            );
-                        }
-                    },
-                );
-            }
-        }),
-        IconName::Check,
-        "Apply changes",
-    );
-    if any_selected_dirty {
-        apply_button = apply_button.bg(cx.theme().secondary.opacity(0.55));
-    }
+        });
 
     let delete_menu = render_delete_menu(
         state_for_delete.clone(),
@@ -530,12 +471,17 @@ fn render_documents_actions_clean(
 
     let refresh_button = clean_toolbar_icon_button(
         Button::new("refresh-clean").xsmall().on_click({
-            move |_: &ClickEvent, _window: &mut Window, cx: &mut App| {
-                if let Some(session_key) = state_for_refresh.read(cx).current_session_key() {
-                    AppCommands::load_documents_for_session(
+            let view = view.clone();
+            let session_key = session_key.clone();
+            move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
+                if let Some(key) = session_key.clone() {
+                    CollectionView::reload_document_page(
+                        view.clone(),
                         state_for_refresh.clone(),
-                        session_key,
+                        key,
+                        window,
                         cx,
+                        |_, _| {},
                     );
                 }
             }
@@ -548,7 +494,7 @@ fn render_documents_actions_clean(
     let view_mode =
         session_key.as_ref().map(|sk| state.read(cx).session_view_mode(sk)).unwrap_or_default();
 
-    let copy_as_dropdown = render_copy_as_dropdown(view.clone(), view_mode, cx);
+    let copy_as_dropdown = render_copy_as_dropdown(view.clone(), view_mode, selected_count, cx);
     let export_dropdown = render_export_dropdown(state.clone(), session_key.clone(), cx);
 
     let secondary_actions_menu = render_documents_secondary_menu(
@@ -567,27 +513,21 @@ fn render_documents_actions_clean(
     let tree_btn = {
         let mut btn = clean_toolbar_icon_button(
             Button::new("view-tree").xsmall().on_click({
-                let state = state.clone();
                 let session_key = session_key.clone();
                 let view = view.clone();
-                move |_: &ClickEvent, _window: &mut Window, cx: &mut App| {
+                move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
                     let Some(sk) = session_key.clone() else {
                         return;
                     };
-                    state.update(cx, |state, cx| {
-                        state.set_view_mode(&sk, DocumentViewMode::Tree);
-                        state.clear_all_selection(&sk);
-                        cx.notify();
-                    });
                     view.update(cx, |this, cx| {
-                        this.view_model.invalidate_table();
-                        cx.notify();
+                        this.change_document_view(sk, DocumentViewMode::Tree, window, cx);
                     });
                 }
             }),
             IconName::Menu,
             "Tree view",
-        );
+        )
+        .label("Tree");
         if is_tree {
             btn = btn.bg(active_bg);
         }
@@ -597,26 +537,21 @@ fn render_documents_actions_clean(
     let table_btn = {
         let mut btn = clean_toolbar_icon_button(
             Button::new("view-table").xsmall().on_click({
-                let state = state.clone();
                 let session_key = session_key.clone();
                 let view = view.clone();
-                move |_: &ClickEvent, _window: &mut Window, cx: &mut App| {
+                move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
                     let Some(sk) = session_key.clone() else {
                         return;
                     };
-                    state.update(cx, |state, cx| {
-                        state.set_view_mode(&sk, DocumentViewMode::Table);
-                        state.clear_all_selection(&sk);
-                        cx.notify();
-                    });
-                    view.update(cx, |_this, cx| {
-                        cx.notify();
+                    view.update(cx, |this, cx| {
+                        this.change_document_view(sk, DocumentViewMode::Table, window, cx);
                     });
                 }
             }),
             IconName::LayoutDashboard,
             "Table view",
-        );
+        )
+        .label("Table");
         if is_table {
             btn = btn.bg(active_bg);
         }
@@ -704,20 +639,15 @@ fn render_documents_actions_clean(
                                 let state_cb = state_pop.clone();
                                 let view_cb = view_pop.clone();
                                 let sk_cb = sk.clone();
-                                div()
-                                    .id(SharedString::from(format!("col-row-{}", key)))
-                                    .flex()
-                                    .items_center()
-                                    .gap(px(6.0))
+                                Checkbox::new(SharedString::from(format!("col-vis-{}", key)))
+                                    .checked(is_visible)
+                                    .label(label)
+                                    .with_size(Size::XSmall)
+                                    .w_full()
                                     .px(px(6.0))
                                     .py(px(2.0))
-                                    .rounded(borders::radius_sm())
-                                    .cursor_pointer()
-                                    .hover(|s| s.bg(gpui_kit::hsla(0., 0., 0.5, 0.1)))
                                     .on_click(move |_, _window, cx| {
-                                        let Some(sk) = sk_cb.clone() else {
-                                            return;
-                                        };
+                                        let Some(sk) = sk_cb.clone() else { return };
                                         state_cb.update(cx, |state, cx| {
                                             state.toggle_table_hidden_column(&sk, col_key.clone());
                                             cx.notify();
@@ -727,22 +657,6 @@ fn render_documents_actions_clean(
                                             cx.notify();
                                         });
                                     })
-                                    .child(
-                                        Checkbox::new(SharedString::from(format!(
-                                            "col-vis-{}",
-                                            key
-                                        )))
-                                        .checked(is_visible)
-                                        .with_size(Size::XSmall),
-                                    )
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_ellipsis()
-                                            .overflow_x_hidden()
-                                            .max_w(px(170.0))
-                                            .child(label),
-                                    )
                             })
                             .collect();
                         let list = div()
@@ -768,12 +682,10 @@ fn render_documents_actions_clean(
                             .px(px(6.0))
                             .py(px(2.0))
                             .child(
-                                div()
-                                    .id("col-vis-show-all")
-                                    .text_xs()
-                                    .text_color(gpui_kit::hsla(210. / 360., 0.8, 0.55, 1.0))
-                                    .cursor_pointer()
-                                    .child("Show All")
+                                Button::new("col-vis-show-all")
+                                    .ghost()
+                                    .xsmall()
+                                    .label("Show All")
                                     .on_click(move |_, _window, cx| {
                                         let Some(sk) = sk_show.clone() else {
                                             return;
@@ -789,12 +701,10 @@ fn render_documents_actions_clean(
                                     }),
                             )
                             .child(
-                                div()
-                                    .id("col-vis-hide-all")
-                                    .text_xs()
-                                    .text_color(gpui_kit::hsla(210. / 360., 0.8, 0.55, 1.0))
-                                    .cursor_pointer()
-                                    .child("Hide All")
+                                Button::new("col-vis-hide-all")
+                                    .ghost()
+                                    .xsmall()
+                                    .label("Hide All")
                                     .on_click(move |_, _window, cx| {
                                         let Some(sk) = sk_hide.clone() else {
                                             return;
@@ -830,7 +740,31 @@ fn render_documents_actions_clean(
         None
     };
 
-    let mut row = div().flex().items_center().gap(px(2.0)).child(tree_btn).child(table_btn);
+    let json_btn = Button::new("view-json")
+        .ghost()
+        .xsmall()
+        .label("JSON")
+        .disabled(is_loading || saving)
+        .when(view_mode == DocumentViewMode::Json, |button| button.bg(active_bg))
+        .on_click({
+            let view = view.clone();
+            let session_key = session_key.clone();
+            move |_, window, cx| {
+                if let Some(key) = session_key.clone() {
+                    view.update(cx, |this, cx| {
+                        this.change_document_view(key, DocumentViewMode::Json, window, cx)
+                    });
+                }
+            }
+        });
+    let mut row = div()
+        .flex()
+        .flex_wrap()
+        .items_center()
+        .gap(px(4.0))
+        .child(tree_btn)
+        .child(table_btn)
+        .child(json_btn);
     if let Some(btn) = reset_columns_btn {
         row = row.child(btn);
     }
@@ -839,10 +773,18 @@ fn render_documents_actions_clean(
     }
     row.child(toolbar_separator(cx))
         .child(insert_button)
-        .child(edit_button)
-        .child(discard_button)
-        .child(apply_button)
+        .when(view_mode != DocumentViewMode::Json, |row| row.child(edit_button))
+        .when(any_selected_dirty, |row| row.child(discard_button).child(apply_button))
         .child(delete_menu)
+        .when(selected_count > 0, |row| {
+            row.child(
+                div()
+                    .text_xs()
+                    .text_color(cx.theme().muted_foreground)
+                    .px_2()
+                    .child(format!("{selected_count} selected")),
+            )
+        })
         .child(toolbar_separator(cx))
         .child(refresh_button)
         .child(toolbar_separator(cx))
@@ -873,29 +815,31 @@ fn render_documents_secondary_menu(
             let mut menu = menu;
 
             menu = menu.item(
-                PopupMenuItem::new("Bulk Update").icon(Icon::new(IconName::Replace)).on_click({
-                    let session_key = session_key.clone();
-                    let selected_doc = selected_doc.clone();
-                    let state_for_dialog = state_for_dialog.clone();
-                    move |_, window, cx| {
-                        let Some(session_key) = session_key.clone() else {
-                            return;
-                        };
-                        BulkUpdateDialog::open(
-                            state_for_dialog.clone(),
-                            session_key,
-                            selected_doc.clone(),
-                            window,
-                            cx,
-                        );
-                    }
-                }),
+                PopupMenuItem::new("Bulk update documents…")
+                    .icon(Icon::new(IconName::Replace))
+                    .on_click({
+                        let session_key = session_key.clone();
+                        let selected_doc = selected_doc.clone();
+                        let state_for_dialog = state_for_dialog.clone();
+                        move |_, window, cx| {
+                            let Some(session_key) = session_key.clone() else {
+                                return;
+                            };
+                            BulkUpdateDialog::open(
+                                state_for_dialog.clone(),
+                                session_key,
+                                selected_doc.clone(),
+                                window,
+                                cx,
+                            );
+                        }
+                    }),
             );
 
             menu = menu
                 .item(PopupMenuItem::separator())
                 .item(
-                    PopupMenuItem::new("Export Data...")
+                    PopupMenuItem::new("Export entire collection…")
                         .icon(Icon::new(crate::assets::AppIcon::Download))
                         .on_click({
                             let session_key = session_key.clone();
@@ -918,7 +862,7 @@ fn render_documents_secondary_menu(
                         }),
                 )
                 .item(
-                    PopupMenuItem::new("Import Data...")
+                    PopupMenuItem::new("Import into collection…")
                         .icon(Icon::new(crate::assets::AppIcon::Upload))
                         .on_click({
                             let session_key = session_key.clone();
@@ -941,8 +885,9 @@ fn render_documents_secondary_menu(
                         }),
                 )
                 .item(
-                    PopupMenuItem::new("Copy Data To...").icon(Icon::new(IconName::Copy)).on_click(
-                        {
+                    PopupMenuItem::new("Copy collection to…")
+                        .icon(Icon::new(IconName::Copy))
+                        .on_click({
                             let session_key = session_key.clone();
                             let state_for_transfer = state_for_transfer.clone();
                             move |_, _, cx| {
@@ -960,8 +905,7 @@ fn render_documents_secondary_menu(
                                     );
                                 });
                             }
-                        },
-                    ),
+                        }),
                 );
 
             if ai_available {

--- a/src/views/documents/header/mod.rs
+++ b/src/views/documents/header/mod.rs
@@ -69,8 +69,9 @@ impl CollectionView {
         let (connection_name, appearance) = {
             let state_ref = self.state.read(cx);
             (
-                state_ref
-                    .selected_connection_id()
+                session_key
+                    .as_ref()
+                    .map(|key| key.connection_id)
                     .and_then(|id| state_ref.connection_name(id))
                     .unwrap_or_else(|| "Connection".to_string()),
                 state_ref.settings.appearance.clone(),
@@ -132,8 +133,13 @@ impl CollectionView {
         };
 
         // Build subview tabs
-        let subview_tabs =
-            render_subview_tabs(self.state.clone(), session_key.clone(), active_subview, cx);
+        let subview_tabs = render_subview_tabs(
+            cx.entity(),
+            self.state.clone(),
+            session_key.clone(),
+            active_subview,
+            cx,
+        );
 
         // Build the root header container
         let mut root = header_container(islands::tool_bg(&appearance, cx))
@@ -146,6 +152,7 @@ impl CollectionView {
                         .items_center()
                         .justify_start()
                         .w_full()
+                        .min_w(px(0.0))
                         .pt(px(1.0))
                         .pb(px(1.0))
                         .child(row),

--- a/src/views/documents/header/tabs_row.rs
+++ b/src/views/documents/header/tabs_row.rs
@@ -9,6 +9,7 @@ use crate::theme::islands;
 
 /// Render the collection subview tabs.
 pub fn render_subview_tabs(
+    view: Entity<super::CollectionView>,
     state: Entity<AppState>,
     session_key: Option<SessionKey>,
     active_subview: CollectionSubview,
@@ -40,6 +41,9 @@ pub fn render_subview_tabs(
             let session_key = session_key.clone();
             let state_for_subview = state.clone();
             move |index, _window, cx| {
+                if !view.update(cx, |this, cx| this.finish_document_edit(cx)) {
+                    return;
+                }
                 let Some(session_key) = session_key.clone() else {
                     return;
                 };

--- a/src/views/documents/json_view.rs
+++ b/src/views/documents/json_view.rs
@@ -1,0 +1,214 @@
+use gpui_kit::component::button::ButtonVariants as _;
+use gpui_kit::component::{ActiveTheme as _, Disableable as _, Sizable as _};
+use gpui_kit::*;
+
+use crate::bson::{doc_root_id, document_to_json_string};
+use crate::components::{Button, request_unsaved_action};
+use crate::state::{SessionKey, UnsavedScope};
+use crate::views::json_editor_detached::DetachedJsonEditorView;
+
+use super::CollectionView;
+
+impl CollectionView {
+    pub(super) fn render_json_document(
+        &mut self,
+        key: &SessionKey,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let (keys, selected) = {
+            let state = self.state.read(cx);
+            let Some(session) = state.session(key) else { return div().into_any_element() };
+            (
+                session.data.items.iter().map(|item| item.key.clone()).collect::<Vec<_>>(),
+                session.view.selected_doc.clone(),
+            )
+        };
+        let index =
+            selected.as_ref().and_then(|key| keys.iter().position(|item| item == key)).unwrap_or(0);
+        let Some(doc_key) = keys.get(index).cloned() else {
+            let data = self.state.read(cx).session_data(key);
+            let message = super::query::document_empty_message(
+                data.is_some_and(|data| data.loaded),
+                data.is_some_and(|data| data.query_error.is_some()),
+                data.is_some_and(|data| data.filter.is_some()),
+            );
+            return div()
+                .flex()
+                .flex_1()
+                .items_center()
+                .justify_center()
+                .text_sm()
+                .text_color(cx.theme().muted_foreground)
+                .child(message)
+                .into_any_element();
+        };
+        let sessions = self.state.read(cx).editor_sessions();
+        self.json_editor_cache.retain(|id, _| {
+            sessions
+                .snapshot(*id)
+                .is_some_and(|session| session.is_dirty() || session.save_in_flight)
+        });
+        if let Some(editor_id) = sessions.find_document_session(key, &doc_key)
+            && sessions.window_handle(editor_id).is_some()
+        {
+            let state = self.state.clone();
+            return div()
+                .flex()
+                .flex_col()
+                .flex_1()
+                .items_center()
+                .justify_center()
+                .gap_3()
+                .child("This document is open in a separate editor window.")
+                .child(Button::new("focus-json-window").label("Show editor window").on_click(
+                    move |_, _, cx| {
+                        crate::views::json_editor_detached::detach_json_editor(
+                            state.clone(),
+                            editor_id,
+                            cx,
+                        );
+                    },
+                ))
+                .into_any_element();
+        }
+        let matches = self.json_document.as_ref().is_some_and(|(session, document, id, _)| {
+            session == key && document == &doc_key && sessions.snapshot(*id).is_some()
+        });
+        if !matches {
+            if let Some((_, _, id, editor)) = self.json_document.take() {
+                if sessions.window_handle(id).is_none() {
+                    if sessions
+                        .snapshot(id)
+                        .is_some_and(|session| session.is_dirty() || session.save_in_flight)
+                    {
+                        // Keep pending save callbacks alive when switching collection tabs.
+                        self.json_editor_cache.insert(id, editor);
+                    } else {
+                        sessions.close(id);
+                    }
+                }
+            }
+            let state = self.state.read(cx);
+            let Some(baseline) = state.document_edit_baseline(key, &doc_key) else {
+                return div().into_any_element();
+            };
+            let Some(id) = baseline.get("_id").cloned() else {
+                return div()
+                    .p_4()
+                    .child("Include _id in the projection to edit this document.")
+                    .into_any_element();
+            };
+            let document =
+                state.session_draft_or_document(key, &doc_key).unwrap_or_else(|| baseline.clone());
+            let projected = state.session_data(key).is_some_and(|data| data.projection.is_some());
+            let has_draft = state.session_draft(key, &doc_key).is_some();
+            let existing = sessions.find_document_session(key, &doc_key);
+            let editor_id = existing.unwrap_or_else(|| {
+                let editor_id = sessions.create_document_session(
+                    key.clone(),
+                    doc_key.clone(),
+                    id,
+                    baseline.clone(),
+                    document_to_json_string(&baseline),
+                );
+                sessions.update_content(editor_id, document_to_json_string(&document));
+                editor_id
+            });
+            if existing.is_none() {
+                // Move the draft into the JSON session so each document has one save owner.
+                self.state.update(cx, |state, cx| {
+                    state.clear_draft(key, &doc_key);
+                    cx.notify();
+                });
+            }
+            let state = self.state.clone();
+            let editor = self.json_editor_cache.remove(&editor_id).unwrap_or_else(|| {
+                cx.new(|cx| {
+                    DetachedJsonEditorView::new(state, sessions.clone(), editor_id, cx).embedded()
+                })
+            });
+            if projected && !has_draft && existing.is_none() {
+                editor.update(cx, |editor, cx| editor.reload_document(cx));
+            }
+            self.json_document = Some((key.clone(), doc_key.clone(), editor_id, editor));
+        }
+        let (_, _, editor_id, editor) =
+            self.json_document.as_ref().expect("JSON editor initialized");
+        let editor = editor.clone();
+        let editor_id = *editor_id;
+        let navigation = [(-1_isize, "Previous document"), (1, "Next document")].into_iter().map(
+            |(delta, label)| {
+                let next =
+                    index.checked_add_signed(delta).and_then(|index| keys.get(index)).cloned();
+                let state = self.state.clone();
+                let key = key.clone();
+                Button::new(if delta < 0 { "json-prev" } else { "json-next" })
+                    .ghost()
+                    .xsmall()
+                    .label(label)
+                    .disabled(next.is_none())
+                    .on_click(move |_, window, cx| {
+                        let Some(doc_key) = next.clone() else { return };
+                        let state_for_select = state.clone();
+                        let key = key.clone();
+                        request_unsaved_action(
+                            state.clone(),
+                            UnsavedScope::Editor(editor_id),
+                            window,
+                            cx,
+                            move |_, cx| {
+                                state_for_select.update(cx, |state, cx| {
+                                    state.select_single_doc(
+                                        &key,
+                                        doc_key.clone(),
+                                        doc_root_id(&doc_key),
+                                    );
+                                    cx.notify();
+                                });
+                            },
+                        );
+                    })
+            },
+        );
+        let state_for_window = self.state.clone();
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h(px(0.0))
+            .min_w(px(0.0))
+            .child(
+                div()
+                    .flex()
+                    .flex_wrap()
+                    .gap_2()
+                    .items_center()
+                    .justify_between()
+                    .px_3()
+                    .py_1()
+                    .child(div().text_xs().text_color(cx.theme().muted_foreground).child(format!(
+                        "Document {} of {} on this page",
+                        index + 1,
+                        keys.len()
+                    )))
+                    .child(
+                        div().flex().gap_1().children(navigation).child(
+                            Button::new("json-open-window")
+                                .ghost()
+                                .xsmall()
+                                .label("Open in window")
+                                .on_click(move |_, _, cx| {
+                                    crate::views::json_editor_detached::detach_json_editor(
+                                        state_for_window.clone(),
+                                        editor_id,
+                                        cx,
+                                    );
+                                }),
+                        ),
+                    ),
+            )
+            .child(editor)
+            .into_any_element()
+    }
+}

--- a/src/views/documents/json_view.rs
+++ b/src/views/documents/json_view.rs
@@ -76,17 +76,17 @@ impl CollectionView {
             session == key && document == &doc_key && sessions.snapshot(*id).is_some()
         });
         if !matches {
-            if let Some((_, _, id, editor)) = self.json_document.take() {
-                if sessions.window_handle(id).is_none() {
-                    if sessions
-                        .snapshot(id)
-                        .is_some_and(|session| session.is_dirty() || session.save_in_flight)
-                    {
-                        // Keep pending save callbacks alive when switching collection tabs.
-                        self.json_editor_cache.insert(id, editor);
-                    } else {
-                        sessions.close(id);
-                    }
+            if let Some((_, _, id, editor)) = self.json_document.take()
+                && sessions.window_handle(id).is_none()
+            {
+                if sessions
+                    .snapshot(id)
+                    .is_some_and(|session| session.is_dirty() || session.save_in_flight)
+                {
+                    // Keep pending save callbacks alive when switching collection tabs.
+                    self.json_editor_cache.insert(id, editor);
+                } else {
+                    sessions.close(id);
                 }
             }
             let state = self.state.read(cx);

--- a/src/views/documents/mod.rs
+++ b/src/views/documents/mod.rs
@@ -7,6 +7,7 @@ mod explain;
 mod fast_filter;
 pub(crate) use fast_filter::compile_filter_input;
 mod header;
+mod json_view;
 mod node_meta;
 mod pagination;
 mod query;
@@ -20,6 +21,7 @@ mod state;
 mod types;
 mod view;
 mod view_model;
+mod workflow;
 
 pub mod dialogs;
 pub mod export;

--- a/src/views/documents/pagination.rs
+++ b/src/views/documents/pagination.rs
@@ -1,16 +1,16 @@
-//! Pagination controls for collection view.
+//! Native page navigation shared by Tree, Table, and JSON.
 
 use gpui_kit::component::ActiveTheme as _;
 use gpui_kit::component::button::{Button as MenuButton, ButtonVariants as _};
 use gpui_kit::component::menu::{DropdownMenu as _, PopupMenu, PopupMenuItem};
-use gpui_kit::component::{Disableable as _, Icon, IconName, Sizable as _};
+use gpui_kit::component::pagination::Pagination;
+use gpui_kit::component::{Disableable as _, Sizable as _};
+use gpui_kit::prelude::FluentBuilder as _;
 use gpui_kit::*;
 
-use crate::components::Button;
-use crate::state::{AppCommands, AppState, SessionKey};
-use crate::theme::spacing;
-
 use super::CollectionView;
+use crate::state::{AppState, SessionKey};
+use crate::theme::spacing;
 
 const PER_PAGE_OPTIONS: &[i64] = &[10, 25, 50, 100];
 
@@ -29,54 +29,98 @@ impl CollectionView {
         view: Entity<CollectionView>,
         cx: &App,
     ) -> impl IntoElement {
-        let state_for_prev = state.clone();
-        let state_for_next = state.clone();
-        let session_key_prev = session_key.clone();
-        let session_key_next = session_key.clone();
-
-        let per_page_selector = {
-            let label = format!("{} / page", per_page);
-            let btn = MenuButton::new("per-page-selector")
-                .ghost()
-                .xsmall()
-                .label(label)
-                .dropdown_caret(true)
-                .with_size(gpui_kit::component::Size::XSmall)
-                .disabled(is_loading || session_key.is_none());
-
-            let sk = session_key.clone();
-            btn.dropdown_menu_with_anchor(Anchor::TopLeft, move |mut menu: PopupMenu, _, _| {
-                for &opt in PER_PAGE_OPTIONS {
-                    let label = format!("{}", opt);
-                    let state = state.clone();
-                    let view = view.clone();
-                    let sk = sk.clone();
-                    let is_current = opt == per_page;
-                    menu = menu.item(PopupMenuItem::new(label).checked(is_current).on_click(
-                        move |_, _, cx| {
-                            let Some(sk) = sk.clone() else {
-                                return;
-                            };
-                            state.update(cx, |state, cx| {
-                                state.set_per_page(&sk, opt);
-                                cx.notify();
-                            });
-                            view.update(cx, |this, cx| {
-                                this.view_model.invalidate_table();
-                                cx.notify();
-                            });
-                            AppCommands::load_documents_for_session(state.clone(), sk, cx);
+        let disabled = is_loading || session_key.is_none();
+        let page_state = state.clone();
+        let page_view = view.clone();
+        let page_key = session_key.clone();
+        let edge_state = state.clone();
+        let edge_view = view.clone();
+        let edge_key = session_key.clone();
+        let page_edges = MenuButton::new("document-page-edges")
+            .ghost()
+            .xsmall()
+            .label(format!("Page {} of {}", page + 1, total_pages.max(1)))
+            .disabled(disabled)
+            .dropdown_caret(true)
+            .dropdown_menu_with_anchor(Anchor::TopRight, move |mut menu: PopupMenu, _, _| {
+                for (label, target) in
+                    [("First page", 0), ("Last page", total_pages.saturating_sub(1))]
+                {
+                    let state = edge_state.clone();
+                    let view = edge_view.clone();
+                    let key = edge_key.clone();
+                    menu = menu.item(PopupMenuItem::new(label).disabled(target == page).on_click(
+                        move |_, window, cx| {
+                            if let Some(key) = key.clone() {
+                                CollectionView::reload_document_page(
+                                    view.clone(),
+                                    state.clone(),
+                                    key,
+                                    window,
+                                    cx,
+                                    move |state, key| state.set_document_page(key, target),
+                                );
+                            }
                         },
                     ));
                 }
                 menu
-            })
-        };
-
+            });
+        let page_size = MenuButton::new("per-page-selector")
+            .ghost()
+            .xsmall()
+            .label(format!("{per_page} / page"))
+            .dropdown_caret(true)
+            .disabled(disabled)
+            .dropdown_menu_with_anchor(Anchor::TopLeft, move |mut menu: PopupMenu, _, _| {
+                for &size in PER_PAGE_OPTIONS {
+                    let state = state.clone();
+                    let view = view.clone();
+                    let key = session_key.clone();
+                    menu = menu.item(
+                        PopupMenuItem::new(size.to_string()).checked(size == per_page).on_click(
+                            move |_, window, cx| {
+                                let Some(key) = key.clone() else { return };
+                                CollectionView::reload_document_page(
+                                    view.clone(),
+                                    state.clone(),
+                                    key,
+                                    window,
+                                    cx,
+                                    move |state, key| state.set_per_page(key, size),
+                                );
+                            },
+                        ),
+                    );
+                }
+                menu
+            });
+        let pagination = Pagination::new("document-pages")
+            .xsmall()
+            .visible_pages(5)
+            // ponytail: Kit 0.6 builds every hidden page in its ellipsis menu; use compact controls for large result sets until that menu is virtualized.
+            .when(total_pages > 100, |pagination| pagination.compact())
+            .current_page(page.saturating_add(1) as usize)
+            .total_pages(total_pages.max(1) as usize)
+            .disabled(disabled)
+            .on_click(move |page, window, cx| {
+                let Some(key) = page_key.clone() else { return };
+                let page = page.saturating_sub(1) as u64;
+                CollectionView::reload_document_page(
+                    page_view.clone(),
+                    page_state.clone(),
+                    key,
+                    window,
+                    cx,
+                    move |state, key| state.set_document_page(key, page),
+                );
+            });
         div()
             .flex()
+            .flex_wrap()
             .items_center()
             .justify_between()
+            .gap(spacing::sm())
             .px(spacing::lg())
             .py(px(5.0))
             .child(
@@ -86,64 +130,18 @@ impl CollectionView {
                     .gap(spacing::sm())
                     .child(
                         div()
-                            .text_sm()
+                            .text_xs()
                             .text_color(cx.theme().muted_foreground)
-                            .child(format!("Showing {}-{} of {}", range_start, range_end, total)),
+                            .child(format!("{range_start}–{range_end} of {total} documents")),
                     )
-                    .child(per_page_selector),
+                    .child(page_size),
             )
             .child(
                 div()
                     .flex()
                     .items_center()
-                    .gap(spacing::xs())
-                    .child(
-                        Button::new("prev")
-                            .ghost()
-                            .disabled(page == 0 || is_loading || session_key.is_none())
-                            .icon(Icon::new(IconName::ChevronLeft).xsmall())
-                            .on_click(move |_, _, cx| {
-                                let Some(session_key) = session_key_prev.clone() else {
-                                    return;
-                                };
-                                state_for_prev.update(cx, |state, cx| {
-                                    state.prev_page(&session_key);
-                                    cx.notify();
-                                });
-                                AppCommands::load_documents_for_session(
-                                    state_for_prev.clone(),
-                                    session_key,
-                                    cx,
-                                );
-                            }),
-                    )
-                    .child(div().text_sm().text_color(cx.theme().foreground).child(format!(
-                        "Page {} of {}",
-                        page + 1,
-                        total_pages
-                    )))
-                    .child(
-                        Button::new("next")
-                            .ghost()
-                            .disabled(
-                                page + 1 >= total_pages || is_loading || session_key.is_none(),
-                            )
-                            .icon(Icon::new(IconName::ChevronRight).xsmall())
-                            .on_click(move |_, _, cx| {
-                                let Some(session_key) = session_key_next.clone() else {
-                                    return;
-                                };
-                                state_for_next.update(cx, |state, cx| {
-                                    state.next_page(&session_key, total_pages);
-                                    cx.notify();
-                                });
-                                AppCommands::load_documents_for_session(
-                                    state_for_next.clone(),
-                                    session_key,
-                                    cx,
-                                );
-                            }),
-                    ),
+                    .when(total_pages > 100, |row| row.child(page_edges))
+                    .child(pagination),
             )
     }
 }

--- a/src/views/documents/state.rs
+++ b/src/views/documents/state.rs
@@ -38,6 +38,16 @@ pub struct CollectionView {
     pub(crate) filter_expanded: bool,
     pub(crate) sort_state: Option<Entity<EditorState>>,
     pub(crate) projection_state: Option<Entity<EditorState>>,
+    pub(crate) json_document: Option<(
+        SessionKey,
+        DocumentKey,
+        crate::state::EditorSessionId,
+        Entity<crate::views::json_editor_detached::DetachedJsonEditorView>,
+    )>,
+    pub(crate) json_editor_cache: HashMap<
+        crate::state::EditorSessionId,
+        Entity<crate::views::json_editor_detached::DetachedJsonEditorView>,
+    >,
     pub(crate) schema_filter_state: Option<Entity<EditorState>>,
     pub(crate) filter_auto_pair: AutoPairState,
     pub(crate) sort_auto_pair: AutoPairState,
@@ -152,47 +162,19 @@ impl CollectionView {
                     }
                     return;
                 }
+                if this.view_model.current_session().is_some_and(|key| {
+                    this.state.read(cx).session_view_mode(&key)
+                        == crate::state::DocumentViewMode::Json
+                        && this.state.read(cx).session_subview(&key)
+                            == Some(CollectionSubview::Documents)
+                }) {
+                    return;
+                }
                 let mut handled = false;
 
                 let save_selected_document =
                     |this: &mut CollectionView, window: &mut Window, cx: &mut Context<Self>| {
-                        let Some(session_key) = this.view_model.current_session() else {
-                            return false;
-                        };
-                        let (doc_key, doc) = {
-                            let state_ref = this.state.read(cx);
-                            let doc_key = state_ref.session_selected_doc(&session_key);
-                            let doc = doc_key
-                                .as_ref()
-                                .and_then(|doc_key| state_ref.session_draft(&session_key, doc_key));
-                            (doc_key, doc)
-                        };
-                        let (Some(doc_key), Some(doc)) = (doc_key, doc) else {
-                            return false;
-                        };
-                        let state = this.state.clone();
-                        let state_for_write = state.clone();
-                        crate::components::request_connection_write(
-                            state,
-                            crate::components::WriteRequest::new(
-                                session_key.connection_id,
-                                session_key.namespace(),
-                                "Save document changes",
-                                None,
-                            ),
-                            window,
-                            cx,
-                            move |_window, cx| {
-                                AppCommands::save_document(
-                                    state_for_write,
-                                    session_key,
-                                    doc_key,
-                                    doc,
-                                    cx,
-                                );
-                            },
-                        );
-                        true
+                        this.save_selected_documents(window, cx)
                     };
                 let is_aggregation = this
                     .view_model
@@ -230,6 +212,14 @@ impl CollectionView {
                 } else if is_enter {
                     let modifiers = event.keystroke.modifiers;
                     let cmd_or_ctrl = modifiers.secondary() || modifiers.control;
+                    if !cmd_or_ctrl
+                        && this.view_model.inline_state().is_some()
+                        && !this.documents_focus.is_focused(window)
+                        && !this.view_model.inline_input_focused(window, cx)
+                    {
+                        // Done, Cancel, and the boolean switch keep their native Enter action.
+                        return;
+                    }
                     if this.view_model.inline_state().is_some() {
                         this.view_model.commit_inline_edit(&this.state, cx);
                         let committed = this.view_model.inline_state().is_none();
@@ -348,6 +338,14 @@ impl CollectionView {
                 this.input_session = None;
                 cx.notify();
             }
+            AppEvent::DocumentDraftChanged { session } => {
+                if this.view_model.is_current_session(session) {
+                    this.view_model.rebuild_tree(&state, cx);
+                    this.view_model.invalidate_table();
+                    this.update_search_results(cx);
+                    cx.notify();
+                }
+            }
             AppEvent::DocumentSaved { session, document, .. } => {
                 if !this.view_model.is_current_session(session) {
                     return;
@@ -430,6 +428,8 @@ impl CollectionView {
             aggregation_stage_count: 0,
             aggregation_drag_over: None,
             aggregation_drag_source: None,
+            json_document: None,
+            json_editor_cache: HashMap::new(),
             filter_subscription: None,
             sort_subscription: None,
             projection_subscription: None,

--- a/src/views/documents/table/document_table_delegate.rs
+++ b/src/views/documents/table/document_table_delegate.rs
@@ -368,6 +368,25 @@ impl TableDelegate for DocumentTableDelegate {
         };
         let doc_key = item.key.clone();
         let is_dirty = self.is_row_dirty(row_ix);
+        self.state.update(cx, |state, cx| {
+            if !state
+                .session_view(&session_key)
+                .is_some_and(|view| view.selected_docs.contains(&doc_key))
+            {
+                state.select_single_doc(
+                    &session_key,
+                    doc_key.clone(),
+                    crate::bson::doc_root_id(&doc_key),
+                );
+            } else {
+                state.set_selected_node(
+                    &session_key,
+                    doc_key.clone(),
+                    crate::bson::doc_root_id(&doc_key),
+                );
+            }
+            cx.notify();
+        });
         let selected_count = {
             let state_ref = self.state.read(cx);
             state_ref.session_view(&session_key).map(|v| v.selected_docs.len().max(1)).unwrap_or(1)

--- a/src/views/documents/tree/document_tree.rs
+++ b/src/views/documents/tree/document_tree.rs
@@ -59,9 +59,8 @@ pub fn build_documents_tree(
         meta.insert(root_id.clone(), root_meta);
 
         let is_expanded = expanded_nodes.contains(&root_id);
-        let mut root = TreeItem::new(root_id.clone(), key_label)
-            .expanded(expanded_nodes.contains(&root_id))
-            .disabled(true);
+        let mut root =
+            TreeItem::new(root_id.clone(), key_label).expanded(expanded_nodes.contains(&root_id));
         if is_expanded {
             let children: Vec<TreeItem> = doc
                 .iter()
@@ -143,7 +142,7 @@ pub fn build_bson_tree_item(
         },
     );
 
-    let mut item = TreeItem::new(node_id.clone(), key_label).expanded(is_expanded).disabled(true);
+    let mut item = TreeItem::new(node_id.clone(), key_label).expanded(is_expanded);
 
     if is_expanded {
         match value {
@@ -222,5 +221,42 @@ pub fn flatten_tree_order(item: &TreeItem, order: &mut Vec<String>) {
         for child in &item.children {
             flatten_tree_order(child, order);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use gpui_kit::AppContext as _;
+    use gpui_kit::component::tree::TreeState;
+    use mongodb::bson::doc;
+
+    use super::build_documents_tree;
+    use crate::bson::{DocumentKey, PathSegment, doc_root_id, path_to_id};
+    use crate::state::SessionDocument;
+
+    #[gpui_kit::test]
+    fn document_fields_remain_selectable_even_when_not_editable(cx: &mut gpui_kit::TestAppContext) {
+        cx.update(|cx| {
+            gpui_kit::init(cx);
+            let document = doc! { "_id": 1, "nested": { "name": "value" } };
+            let key = DocumentKey::from_document(&document, 0);
+            let id_field = path_to_id(&key, &[PathSegment::Key("_id".into())]);
+            let expanded = HashSet::from([
+                doc_root_id(&key),
+                path_to_id(&key, &[PathSegment::Key("nested".into())]),
+            ]);
+            let documents = [SessionDocument { key, doc: document }];
+            let (items, metadata, order) =
+                build_documents_tree(&documents, &HashMap::new(), &expanded, cx);
+            let tree = cx.new(|cx| TreeState::new(cx).items(items));
+            for index in 0..order.len() {
+                tree.update(cx, |tree, cx| tree.set_selected_index(Some(index), cx));
+                let entry = tree.read(cx).selected_entry().expect("selected document field");
+                assert!(!entry.is_disabled(), "Kit must be able to paint selection");
+            }
+            assert!(!metadata[&id_field].is_editable, "The root _id remains immutable");
+        });
     }
 }

--- a/src/views/documents/tree/tree_menus.rs
+++ b/src/views/documents/tree/tree_menus.rs
@@ -4,7 +4,7 @@ use gpui_kit::*;
 use mongodb::bson::{Bson, Document};
 
 use crate::bson::{
-    DocumentKey, PathSegment, bson_value_for_edit, document_to_shell_string,
+    DocumentKey, PathSegment, document_to_json_string, format_bson_for_clipboard,
     format_relaxed_json_value, get_bson_at_path, parse_document_from_json,
     parse_documents_from_json,
 };
@@ -26,7 +26,7 @@ use super::super::CollectionView;
 pub(in crate::views::documents) fn build_document_menu(
     mut menu: PopupMenu,
     state: Entity<AppState>,
-    view: Entity<CollectionView>,
+    _view: Entity<CollectionView>,
     session_key: SessionKey,
     doc_key: DocumentKey,
     is_dirty: bool,
@@ -53,23 +53,7 @@ pub(in crate::views::documents) fn build_document_menu(
             PopupMenuItem::new("Edit JSON")
                 .icon(Icon::new(crate::assets::AppIcon::Braces))
                 .disabled(multi)
-                .action(Box::new(EditDocumentJson))
-                .on_click({
-                    let view = view.clone();
-                    let state = state.clone();
-                    let session_key = session_key.clone();
-                    let doc_key = doc_key.clone();
-                    move |_, window, cx| {
-                        CollectionView::open_document_json_editor(
-                            view.clone(),
-                            state.clone(),
-                            session_key.clone(),
-                            doc_key.clone(),
-                            window,
-                            cx,
-                        );
-                    }
-                }),
+                .action(Box::new(EditDocumentJson)),
         )
         .item(
             PopupMenuItem::new(delete_label)
@@ -93,7 +77,7 @@ pub(in crate::views::documents) fn build_document_menu(
         );
 
     let formats = match view_mode {
-        DocumentViewMode::Tree => CopyFormat::tree_formats(),
+        DocumentViewMode::Tree | DocumentViewMode::Json => CopyFormat::tree_formats(),
         DocumentViewMode::Table => CopyFormat::table_formats(),
     };
     let copy_as_submenu = PopupMenu::build(window, cx, |mut menu, _window, _cx| {
@@ -114,72 +98,17 @@ pub(in crate::views::documents) fn build_document_menu(
 
     menu = menu
         .item(
-            PopupMenuItem::new("Duplicate Document")
+            PopupMenuItem::new("Duplicate as new document…")
                 .icon(Icon::new(IconName::Copy))
                 .disabled(multi)
-                .action(Box::new(DuplicateDocument))
-                .on_click({
-                    let state = state.clone();
-                    let session_key = session_key.clone();
-                    let doc_key = doc_key.clone();
-                    move |_, window, cx| {
-                        if let Some(doc) = resolve_document(&state, &session_key, &doc_key, cx) {
-                            let mut new_doc = doc.clone();
-                            new_doc.insert("_id", mongodb::bson::oid::ObjectId::new());
-                            let state_for_write = state.clone();
-                            let session_for_write = session_key.clone();
-                            request_connection_write(
-                                state.clone(),
-                                crate::components::WriteRequest::new(
-                                    session_key.connection_id,
-                                    session_key.namespace(),
-                                    "Insert a duplicated document",
-                                    None,
-                                ),
-                                window,
-                                cx,
-                                move |_window, cx| {
-                                    AppCommands::insert_document(
-                                        state_for_write,
-                                        session_for_write,
-                                        new_doc,
-                                        cx,
-                                    );
-                                },
-                            );
-                        }
-                    }
-                }),
+                .action(Box::new(DuplicateDocument)),
         )
-        .item(PopupMenuItem::new("Paste Document(s)").action(Box::new(PasteDocuments)).on_click({
-            let state = state.clone();
-            let session_key = session_key.clone();
-            move |_, window, cx| {
-                paste_documents_from_clipboard(state.clone(), session_key.clone(), window, cx);
-            }
-        }))
+        .item(PopupMenuItem::new("Paste as new documents…").action(Box::new(PasteDocuments)))
         .item(
-            PopupMenuItem::new("Discard Changes")
+            PopupMenuItem::new("Discard selected changes…")
                 .icon(Icon::new(IconName::Undo))
                 .action(Box::new(DiscardDocumentChanges))
-                .disabled(!is_dirty)
-                .on_click({
-                    let view = view.clone();
-                    let session_key = session_key.clone();
-                    let doc_key = doc_key.clone();
-                    move |_, _window, cx| {
-                        view.update(cx, |this, cx| {
-                            this.state.update(cx, |state, cx| {
-                                state.clear_draft(&session_key, &doc_key);
-                                cx.notify();
-                            });
-                            this.view_model.clear_inline_edit();
-                            this.view_model.rebuild_tree(&this.state, cx);
-                            this.view_model.sync_dirty_state(&this.state, cx);
-                            cx.notify();
-                        });
-                    }
-                }),
+                .disabled(!is_dirty),
         );
 
     menu
@@ -197,9 +126,14 @@ pub(super) fn build_property_menu(
     let is_array_element = matches!(meta.path.last(), Some(PathSegment::Index(_)));
     let has_index = meta.path.iter().any(|segment| matches!(segment, PathSegment::Index(_)));
     let allow_bulk = !has_index;
-    let is_id = matches!(meta.path.last(), Some(PathSegment::Key(key)) if key == "_id");
+    let is_id = matches!(meta.path.first(), Some(PathSegment::Key(key)) if key == "_id");
     let is_array = matches!(meta.value, Some(Bson::Array(_)));
     let can_edit_value = !is_id;
+    menu = menu.item(
+        PopupMenuItem::new("Paste value")
+            .disabled(!can_edit_value)
+            .action(Box::new(PasteDocuments)),
+    );
     let can_rename_field = !is_id && !is_array_element;
     let can_remove_field = !is_id && !is_array_element;
     let can_remove_element = is_array_element && meta.value.is_some();
@@ -407,7 +341,7 @@ pub(super) fn build_property_menu(
         }),
     );
     menu = menu.item(
-        PopupMenuItem::new("Copy as JSON")
+        PopupMenuItem::new("Copy field and value as JSON")
             .icon(Icon::new(crate::assets::AppIcon::Braces))
             .on_click({
                 let state = state.clone();
@@ -419,17 +353,9 @@ pub(super) fn build_property_menu(
                     if let Some(doc) = resolve_document(&state, &session_key, &doc_key, cx)
                         && let Some(value) = get_bson_at_path(&doc, &path)
                     {
-                        let json_value = format_bson_for_clipboard(value);
-                        let needs_quotes = matches!(value, Bson::String(_));
-                        let text = if needs_quotes {
-                            format!(
-                                "\"{}\": {}",
-                                key_label,
-                                serde_json::to_string(&json_value).unwrap_or(json_value)
-                            )
-                        } else {
-                            format!("\"{}\": {}", key_label, json_value)
-                        };
+                        let mut field = Document::new();
+                        field.insert(key_label.clone(), value.clone());
+                        let text = document_to_json_string(&field);
                         cx.write_to_clipboard(ClipboardItem::new_string(text));
                     }
                 }
@@ -533,7 +459,16 @@ pub(crate) fn paste_documents_from_clipboard(
             session_key.connection_id,
             target,
             format!("Insert {} documents from the clipboard", docs.len()),
-            None,
+            Some(crate::components::WriteConfirmation {
+                title: "Paste as new documents".into(),
+                message: format!(
+                    "Insert {} document(s) into {} with new _id values?",
+                    docs.len(),
+                    session_key.namespace()
+                ),
+                confirm_label: "Insert documents".into(),
+                destructive: false,
+            }),
         ),
         window,
         cx,
@@ -541,17 +476,6 @@ pub(crate) fn paste_documents_from_clipboard(
             AppCommands::insert_documents(state_for_write, session_key, docs, cx);
         },
     );
-}
-
-fn format_bson_for_clipboard(value: &Bson) -> String {
-    match value {
-        Bson::Document(doc) => document_to_shell_string(doc),
-        Bson::Array(arr) => {
-            let value = Bson::Array(arr.clone()).into_relaxed_extjson();
-            format_relaxed_json_value(&value)
-        }
-        _ => bson_value_for_edit(value),
-    }
 }
 
 fn path_to_dot_notation(path: &[PathSegment]) -> String {

--- a/src/views/documents/tree/tree_row.rs
+++ b/src/views/documents/tree/tree_row.rs
@@ -9,7 +9,9 @@ use gpui_kit::component::list::ListItem;
 use gpui_kit::component::menu::ContextMenuExt;
 use gpui_kit::component::switch::Switch;
 use gpui_kit::component::tree::{TreeEntry, TreeState};
-use gpui_kit::component::{ActiveTheme as _, Icon, IconName, Sizable as _};
+use gpui_kit::component::{
+    ActiveTheme as _, Disableable as _, FocusableExt as _, Icon, IconName, Sizable as _,
+};
 use gpui_kit::prelude::FluentBuilder as _;
 use gpui_kit::*;
 
@@ -42,6 +44,7 @@ pub(crate) fn render_tree_row(
     node_meta: &Arc<HashMap<String, NodeMeta>>,
     editing_node_id: &Option<String>,
     inline_state: &Option<InlineEditor>,
+    inline_error: Option<&str>,
     view: Entity<CollectionView>,
     tree_state: Entity<TreeState>,
     state: Entity<AppState>,
@@ -137,92 +140,91 @@ pub(crate) fn render_tree_row(
         None
     };
 
-    let mut row = div()
-        .id(("tree-row", ix))
-        .flex()
-        .items_center()
-        .w_full()
-        .gap(spacing::xs())
-        .rounded(borders::radius_sm());
-    let theme_primary = cx.theme().primary;
-    row = row
-        .border_l_2()
-        .border_color(gpui_kit::transparent_black())
-        .when(_selected, |s| s.bg(cx.theme().list_active).border_color(theme_primary))
-        .when(!_selected && is_multi_selected, |s| s.bg(cx.theme().list_active))
-        .when(!_selected && !is_multi_selected, |s| s.hover(|s| s.bg(cx.theme().list_hover)));
+    let row = div().id(("tree-row", ix)).flex().items_center().w_full().gap(spacing::xs());
 
-    let row = row
-        // Prevent TreeState from toggling expansion on single click.
-        // Also handle selection when clicking outside key/value columns.
-        .on_mouse_down(MouseButton::Left, {
-            let row_session = row_session.clone();
-            let row_state = row_state.clone();
-            let row_tree = row_tree.clone();
-            let range_node_meta = node_meta.clone();
-            let range_tree_order = tree_order.clone();
-            move |event, window, cx| {
-                window.focus(&row_focus, cx);
-                cx.stop_propagation();
-                let is_shift = event.modifiers.shift;
-                let anchor = row_tree.read(cx).selected_index();
-                // Only move the anchor on non-shift clicks so repeated
-                // shift+clicks always extend from the original anchor.
-                if !is_shift {
-                    row_tree.update(cx, |tree, cx| {
-                        tree.set_selected_index(Some(ix), cx);
-                    });
-                }
-                if let (Some(meta), Some(session_key)) =
-                    (range_node_meta.get(&row_item_id), row_session.clone())
+    // Consume the whole Kit row, including padding, before Tree handles expansion.
+    let on_mouse_down = {
+        let row_session = row_session.clone();
+        let row_state = row_state.clone();
+        let row_tree = row_tree.clone();
+        let range_node_meta = node_meta.clone();
+        let range_tree_order = tree_order.clone();
+        move |event: &MouseDownEvent, window: &mut Window, cx: &mut App| {
+            cx.stop_propagation();
+            let can_select = row_view.update(cx, |this, cx| {
+                let editing = this.view_model.editing_node_id();
+                if editing.is_some()
+                    && (editing.as_deref() != Some(row_item_id.as_str()) || event.click_count != 2)
                 {
-                    let is_cmd = event.modifiers.secondary() || event.modifiers.control;
-                    row_state.update(cx, |state, cx| {
-                        if is_shift && meta.path.is_empty() {
-                            let anchor_ix = anchor.unwrap_or(0);
-                            let lo = anchor_ix.min(ix);
-                            let hi = anchor_ix.max(ix);
-                            let doc_keys: HashSet<DocumentKey> = range_tree_order
-                                [lo..=hi.min(range_tree_order.len().saturating_sub(1))]
-                                .iter()
-                                .filter_map(|id| range_node_meta.get(id))
-                                .filter(|m| m.path.is_empty())
-                                .map(|m| m.doc_key.clone())
-                                .collect();
-                            state.select_doc_range(
-                                &session_key,
-                                doc_keys,
-                                meta.doc_key.clone(),
-                                row_item_id.clone(),
-                            );
-                        } else if is_cmd && meta.path.is_empty() {
-                            state.toggle_doc_selection(&session_key, &meta.doc_key);
-                            state.set_selected_node(
-                                &session_key,
-                                meta.doc_key.clone(),
-                                row_item_id.clone(),
-                            );
-                        } else {
-                            state.select_single_doc(
-                                &session_key,
-                                meta.doc_key.clone(),
-                                row_item_id.clone(),
-                            );
-                        }
-                        if event.click_count == 2 && meta.is_folder {
-                            state.toggle_expanded_node(&session_key, &row_item_id);
-                        }
+                    this.finish_document_edit(cx)
+                } else {
+                    true
+                }
+            });
+            if !can_select {
+                return;
+            }
+            window.focus(&row_focus, cx);
+            let is_shift = event.modifiers.shift;
+            let anchor = row_tree.read(cx).selected_index();
+            // Only move the anchor on non-shift clicks so repeated
+            // shift+clicks always extend from the original anchor.
+            if !is_shift {
+                row_tree.update(cx, |tree, cx| {
+                    tree.set_selected_index(Some(ix), cx);
+                });
+            }
+            if let (Some(meta), Some(session_key)) =
+                (range_node_meta.get(&row_item_id), row_session.clone())
+            {
+                let is_cmd = event.modifiers.secondary() || event.modifiers.control;
+                row_state.update(cx, |state, cx| {
+                    if is_shift && meta.path.is_empty() {
+                        let anchor_ix = anchor.unwrap_or(0);
+                        let lo = anchor_ix.min(ix);
+                        let hi = anchor_ix.max(ix);
+                        let doc_keys: HashSet<DocumentKey> = range_tree_order
+                            [lo..=hi.min(range_tree_order.len().saturating_sub(1))]
+                            .iter()
+                            .filter_map(|id| range_node_meta.get(id))
+                            .filter(|m| m.path.is_empty())
+                            .map(|m| m.doc_key.clone())
+                            .collect();
+                        state.select_doc_range(
+                            &session_key,
+                            doc_keys,
+                            meta.doc_key.clone(),
+                            row_item_id.clone(),
+                        );
+                    } else if is_cmd && meta.path.is_empty() {
+                        state.toggle_doc_selection(&session_key, &meta.doc_key);
+                        state.set_selected_node(
+                            &session_key,
+                            meta.doc_key.clone(),
+                            row_item_id.clone(),
+                        );
+                    } else {
+                        state.select_single_doc(
+                            &session_key,
+                            meta.doc_key.clone(),
+                            row_item_id.clone(),
+                        );
+                    }
+                    if event.click_count == 2 && meta.is_folder {
+                        state.toggle_expanded_node(&session_key, &row_item_id);
+                    }
+                    cx.notify();
+                });
+                if event.click_count == 2 && meta.is_folder {
+                    row_view.update(cx, |this, cx| {
+                        this.view_model.rebuild_tree(&this.state, cx);
                         cx.notify();
                     });
-                    if event.click_count == 2 && meta.is_folder {
-                        row_view.update(cx, |this, cx| {
-                            this.view_model.rebuild_tree(&this.state, cx);
-                            cx.notify();
-                        });
-                    }
                 }
             }
-        })
+        }
+    };
+    let row = row
         .child(render_key_column(
             ix,
             depth,
@@ -245,15 +247,12 @@ pub(crate) fn render_tree_row(
             &value_label,
             value_color,
             inline_state,
+            inline_error,
             node_meta.clone(),
             view.clone(),
-            tree_state.clone(),
-            state.clone(),
-            session_key.clone(),
             value_drag,
             search_opts,
             current_match_id,
-            documents_focus.clone(),
             cx,
         ))
         .child(
@@ -266,13 +265,13 @@ pub(crate) fn render_tree_row(
                 .child(type_label),
         );
 
-    let selected_count = selected_docs.len();
     let row = row.context_menu({
         let node_meta = node_meta.clone();
         let menu_item_id = item_id.clone();
         let state = state.clone();
         let view = view.clone();
         let session_key = session_key.clone();
+        let tree_state = tree_state.clone();
         move |menu, window, cx| {
             let menu = menu.action_context(documents_focus.clone());
             let Some(meta) = node_meta.get(&menu_item_id).cloned() else {
@@ -281,6 +280,33 @@ pub(crate) fn render_tree_row(
             let Some(session_key) = session_key.clone() else {
                 return menu;
             };
+            tree_state.update(cx, |tree, cx| tree.set_selected_index(Some(ix), cx));
+
+            // A field always targets its own document; a selected root keeps the multi-selection.
+            state.update(cx, |state, cx| {
+                let already_selected = state
+                    .session_view(&session_key)
+                    .is_some_and(|view| view.selected_docs.contains(&meta.doc_key));
+                if !meta.path.is_empty() || !already_selected {
+                    state.select_single_doc(
+                        &session_key,
+                        meta.doc_key.clone(),
+                        menu_item_id.clone(),
+                    );
+                } else {
+                    state.set_selected_node(
+                        &session_key,
+                        meta.doc_key.clone(),
+                        menu_item_id.clone(),
+                    );
+                }
+                cx.notify();
+            });
+            let selected_count = state
+                .read(cx)
+                .session_view(&session_key)
+                .map(|view| view.selected_docs.len())
+                .unwrap_or(0);
 
             if meta.path.is_empty() {
                 build_document_menu(
@@ -301,7 +327,12 @@ pub(crate) fn render_tree_row(
         }
     });
 
-    ListItem::new(ix).child(row).selected(false).px_0().py(px(2.0))
+    ListItem::new(ix)
+        .child(row)
+        .selected(!is_editing && if is_root { is_multi_selected } else { _selected })
+        .px_0()
+        .py(px(2.0))
+        .on_mouse_down(MouseButton::Left, on_mouse_down)
 }
 
 #[allow(dead_code)]
@@ -369,33 +400,30 @@ pub fn render_readonly_tree_row(
         div().w(px(18.0)).into_any_element()
     };
 
-    let mut row =
-        div().flex().items_center().w_full().gap(spacing::xs()).rounded(borders::radius_sm());
-    row = row
-        .when(selected, |s: Div| s.bg(cx.theme().list_active))
-        .when(!selected, |s: Div| s.hover(|s| s.bg(cx.theme().list_hover)));
-    let row = row
-        .on_mouse_down(MouseButton::Left, {
-            let row_item_id = item_id.clone();
-            let row_view = view.clone();
-            let row_tree = tree_state.clone();
-            move |event, _window, cx| {
-                cx.stop_propagation();
-                row_tree.update(cx, |tree, cx| {
-                    tree.set_selected_index(Some(ix), cx);
+    let row = div().flex().items_center().w_full().gap(spacing::xs());
+    // Consume the whole Kit row, including padding, before Tree handles expansion.
+    let on_mouse_down = {
+        let row_item_id = item_id.clone();
+        let row_view = view.clone();
+        let row_tree = tree_state.clone();
+        move |event: &MouseDownEvent, _window: &mut Window, cx: &mut App| {
+            cx.stop_propagation();
+            row_tree.update(cx, |tree, cx| {
+                tree.set_selected_index(Some(ix), cx);
+            });
+            if event.click_count == 2 && is_folder {
+                row_view.update(cx, |this, cx| {
+                    if this.aggregation_results_expanded_nodes.contains(&row_item_id) {
+                        this.aggregation_results_expanded_nodes.remove(&row_item_id);
+                    } else {
+                        this.aggregation_results_expanded_nodes.insert(row_item_id.clone());
+                    }
+                    cx.notify();
                 });
-                if event.click_count == 2 && is_folder {
-                    row_view.update(cx, |this, cx| {
-                        if this.aggregation_results_expanded_nodes.contains(&row_item_id) {
-                            this.aggregation_results_expanded_nodes.remove(&row_item_id);
-                        } else {
-                            this.aggregation_results_expanded_nodes.insert(row_item_id.clone());
-                        }
-                        cx.notify();
-                    });
-                }
             }
-        })
+        }
+    };
+    let row = row
         .child(render_key_column(
             ix,
             depth,
@@ -420,7 +448,12 @@ pub fn render_readonly_tree_row(
                 .child(type_label),
         );
 
-    ListItem::new(ix).child(row).selected(false).px_0().py(px(2.0))
+    ListItem::new(ix)
+        .child(row)
+        .selected(selected)
+        .px_0()
+        .py(px(2.0))
+        .on_mouse_down(MouseButton::Left, on_mouse_down)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -503,15 +536,12 @@ fn render_value_column(
     value_label: &str,
     value_color: Hsla,
     inline_state: &Option<InlineEditor>,
+    inline_error: Option<&str>,
     node_meta: Arc<HashMap<String, NodeMeta>>,
     view: Entity<CollectionView>,
-    tree_state: Entity<TreeState>,
-    state: Entity<AppState>,
-    session_key: Option<SessionKey>,
     value_drag: Option<DragValue>,
     search_opts: &SearchOptions,
     current_match_id: Option<&str>,
-    documents_focus: FocusHandle,
     cx: &App,
 ) -> impl IntoElement {
     let item_id = item_id.to_string();
@@ -519,7 +549,6 @@ fn render_value_column(
     let is_match =
         search_opts.matcher.as_ref().is_some_and(|matcher| matcher.matches(&value_label));
     let is_current_match = current_match_id.is_some_and(|id| id == item_id.as_str());
-    let focus_handle = documents_focus.clone();
 
     // Index-based id avoids allocating + hashing a per-node string every frame.
     let mut value = div()
@@ -529,15 +558,15 @@ fn render_value_column(
         .gap(spacing::xs())
         .flex_1()
         .min_w(px(0.0))
-        .when(is_dirty && !selected, {
+        .when(is_dirty && !selected && !is_editing, {
             let dirty_bg = colors::bg_dirty(cx);
             move |s| s.bg(dirty_bg).rounded(borders::radius_sm()).px(spacing::xs()).py(px(1.0))
         })
-        .when(is_match && !is_dirty && !selected, {
+        .when(is_match && !is_dirty && !selected && !is_editing, {
             let dirty_bg = colors::bg_dirty(cx);
             move |s| s.bg(dirty_bg).rounded(borders::radius_sm()).px(spacing::xs()).py(px(1.0))
         })
-        .when(is_current_match && !selected, |s| {
+        .when(is_current_match && !selected && !is_editing, |s| {
             s.border_1()
                 .border_color(cx.theme().primary)
                 .rounded(borders::radius_sm())
@@ -548,27 +577,11 @@ fn render_value_column(
             let item_id = item_id.clone();
             let node_meta = node_meta.clone();
             let view = view.clone();
-            let tree_state = tree_state.clone();
-            let state = state.clone();
             move |this| {
                 this.on_mouse_down(
                     MouseButton::Left,
                     move |event: &MouseDownEvent, window: &mut Window, cx: &mut App| {
-                        window.focus(&focus_handle, cx);
-                        tree_state.update(cx, |tree, cx| {
-                            tree.set_selected_index(Some(ix), cx);
-                        });
                         if let Some(meta) = node_meta.get(&item_id) {
-                            if let Some(session_key) = session_key.clone() {
-                                state.update(cx, |state, cx| {
-                                    state.set_selected_node(
-                                        &session_key,
-                                        meta.doc_key.clone(),
-                                        item_id.clone(),
-                                    );
-                                    cx.notify();
-                                });
-                            }
                             view.update(cx, |this, cx| {
                                 if event.click_count == 2 && meta.is_editable {
                                     this.view_model.begin_inline_edit(
@@ -587,7 +600,7 @@ fn render_value_column(
             }
         })
         .child(if is_editing {
-            render_inline_editor(ix, inline_state, view.clone(), cx)
+            render_inline_editor(ix, inline_state, inline_error, view.clone(), cx)
         } else {
             div()
                 .text_sm()
@@ -615,23 +628,36 @@ fn render_value_column(
 fn render_inline_editor(
     ix: usize,
     inline_state: &Option<InlineEditor>,
+    inline_error: Option<&str>,
     view: Entity<CollectionView>,
     cx: &App,
 ) -> AnyElement {
     let Some(inline_state) = inline_state else {
         return div().into_any_element();
     };
+    let border_color = if inline_error.is_some() { cx.theme().danger } else { cx.theme().ring };
 
     let editor = match inline_state {
         InlineEditor::Text(state) => Input::new(state)
             .font_family(crate::theme::fonts::mono())
-            .small()
+            .xsmall()
+            .text_sm()
+            .focus_bordered(false)
+            .border_color(border_color)
+            .rounded(borders::radius_xs())
             .flex_1()
+            .min_w(px(0.0))
             .into_any_element(),
         InlineEditor::Number(state) => NumberInput::new(state)
             .font_family(crate::theme::fonts::mono())
-            .small()
+            .xsmall()
+            .text_sm()
+            .focus_ring(false)
+            .border_color(border_color)
+            .rounded(borders::radius_xs())
             .flex_1()
+            .min_w(px(0.0))
+            .max_w(px(320.0))
             .into_any_element(),
         InlineEditor::Bool(current) => {
             let current = *current;
@@ -639,7 +665,7 @@ fn render_inline_editor(
                 .flex()
                 .items_center()
                 .gap(spacing::xs())
-                .child(Switch::new(("inline-bool", ix)).checked(current).small().on_click({
+                .child(Switch::new(("inline-bool", ix)).checked(current).xsmall().on_click({
                     let view = view.clone();
                     move |checked, _window, cx| {
                         view.update(cx, |this, cx| {
@@ -667,30 +693,49 @@ fn render_inline_editor(
         .gap(spacing::xs())
         .flex_1()
         .min_w(px(0.0))
+        .max_w(px(640.0))
         .on_mouse_down(MouseButton::Left, |_, _, cx| {
-            // Prevent the parent row's mousedown handler from stealing focus,
-            // which would blur the inline editor before the Save button click fires.
+            // Keep focus and Done/Cancel handling inside the editing controls.
             cx.stop_propagation();
         })
         .child(editor)
-        .child(Button::new("inline-save").xsmall().primary().label("Save").on_click({
-            let view = view.clone();
-            move |_, _, cx| {
-                view.update(cx, |this, cx| {
-                    this.view_model.commit_inline_edit(&this.state, cx);
-                    cx.notify();
-                });
-            }
-        }))
-        .child(Button::new("inline-cancel").xsmall().ghost().label("Cancel").on_click({
-            let view = view.clone();
-            move |_, _, cx| {
-                view.update(cx, |this, cx| {
-                    this.view_model.clear_inline_edit();
-                    cx.notify();
-                });
-            }
-        }))
+        .child(
+            Button::new("inline-save")
+                .xsmall()
+                .ghost()
+                .label("Done")
+                .tooltip("Keep this field change in the document draft (Enter)")
+                .disabled(inline_error.is_some())
+                .on_click({
+                    let view = view.clone();
+                    move |_, window, cx| {
+                        view.update(cx, |this, cx| {
+                            this.view_model.commit_inline_edit(&this.state, cx);
+                            if this.view_model.inline_state().is_none() {
+                                window.focus(&this.documents_focus, cx);
+                            }
+                            cx.notify();
+                        });
+                    }
+                }),
+        )
+        .child(
+            Button::new("inline-cancel")
+                .xsmall()
+                .ghost()
+                .label("Cancel")
+                .tooltip("Restore this field's previous value (Escape)")
+                .on_click({
+                    let view = view.clone();
+                    move |_, window, cx| {
+                        view.update(cx, |this, cx| {
+                            this.view_model.cancel_inline_edit(&this.state, cx);
+                            window.focus(&this.documents_focus, cx);
+                            cx.notify();
+                        });
+                    }
+                }),
+        )
         .into_any_element()
 }
 

--- a/src/views/documents/view_model.rs
+++ b/src/views/documents/view_model.rs
@@ -44,7 +44,6 @@ pub struct DocumentViewModel {
     inline_editor_state: Option<InlineEditor>,
     inline_editor_subscription: Option<Subscription>,
     inline_value_subscription: Option<Subscription>,
-    inline_blur_subscription: Option<Subscription>,
     editing_node_id: Option<String>,
     editing_doc_key: Option<DocumentKey>,
     editing_path: Vec<PathSegment>,
@@ -90,7 +89,6 @@ impl DocumentViewModel {
             inline_editor_state: None,
             inline_editor_subscription: None,
             inline_value_subscription: None,
-            inline_blur_subscription: None,
             editing_node_id: None,
             editing_doc_key: None,
             editing_path: Vec::new(),
@@ -351,7 +349,6 @@ impl DocumentViewModel {
         self.inline_editor_state = None;
         self.inline_editor_subscription = None;
         self.inline_value_subscription = None;
-        self.inline_blur_subscription = None;
     }
 
     pub fn begin_inline_edit(
@@ -363,6 +360,23 @@ impl DocumentViewModel {
         cx: &mut Context<CollectionView>,
     ) {
         if !meta.is_editable {
+            return;
+        }
+        if self.editing_node_id.is_some() {
+            self.commit_inline_edit(state, cx);
+            if self.editing_node_id.is_some() {
+                return;
+            }
+        }
+        if let Some(reason) = self
+            .current_session
+            .as_ref()
+            .and_then(|key| state.read(cx).document_field_edit_restriction(key))
+        {
+            state.update(cx, |state, cx| {
+                state.set_status_message(Some(crate::state::StatusMessage::error(reason)));
+                cx.notify();
+            });
             return;
         }
         self.inline_editor_subscription = None;
@@ -415,7 +429,7 @@ impl DocumentViewModel {
                                 StepAction::Increment => 1,
                                 StepAction::Decrement => -1,
                             };
-                            (value + delta).to_string()
+                            value.saturating_add(delta).to_string()
                         };
                         state.update(cx, |input, cx| {
                             input.set_value(next, window, cx);
@@ -473,16 +487,6 @@ impl DocumentViewModel {
                     }
                 });
             self.inline_value_subscription = Some(value_sub);
-
-            let app_state = state.clone();
-            let blur_sub =
-                cx.subscribe_in(input, window, move |view, _state, event, _window, cx| {
-                    if matches!(event, InputEvent::Blur) {
-                        view.view_model.commit_inline_edit(&app_state, cx);
-                        cx.notify();
-                    }
-                });
-            self.inline_blur_subscription = Some(blur_sub);
         }
         if let Some(input) = focus_state {
             let focus = input.read(cx).focus_handle(cx);
@@ -507,6 +511,20 @@ impl DocumentViewModel {
                 parse_edited_value(original, state.read(cx).value().as_ref())
             }
             _ => Err("Unsupported inline editor state".to_string()),
+        }
+    }
+
+    pub fn inline_edit_error(&self, cx: &App) -> Option<String> {
+        self.inline_editor_state.as_ref()?;
+        self.inline_edited_value(cx).err()
+    }
+
+    pub fn inline_input_focused(&self, window: &Window, cx: &App) -> bool {
+        match self.inline_editor_state.as_ref() {
+            Some(InlineEditor::Text(input) | InlineEditor::Number(input)) => {
+                input.read(cx).focus_handle(cx).is_focused(window)
+            }
+            _ => false,
         }
     }
 
@@ -597,6 +615,11 @@ impl DocumentViewModel {
                 if let Some(session_key) = self.current_session.clone() {
                     state.update(cx, |state, cx| {
                         state.set_invalid_inline_edit(session_key, true);
+                        state.set_status_message(Some(crate::state::StatusMessage::error(
+                            format!(
+                                "Invalid field value: {err}. Correct it or press Escape to cancel."
+                            ),
+                        )));
                         cx.notify();
                     });
                 }
@@ -656,8 +679,6 @@ impl DocumentViewModel {
         });
 
         // Subscribe to table events for row selection and double-click.
-        let state_clone = state.clone();
-        let view_clone = view.clone();
         cx.subscribe_in(&table_state, window, move |cv, ts, event, window, cx| {
             use gpui_kit::component::table::TableEvent;
             match event {
@@ -685,11 +706,13 @@ impl DocumentViewModel {
                     let session_key = cv.view_model.current_session();
                     let doc_key = ts.read(cx).delegate().document_key(row_ix);
                     if let (Some(sk), Some(dk)) = (session_key, doc_key) {
-                        CollectionView::open_document_json_editor(
-                            view_clone.clone(),
-                            state_clone.clone(),
+                        cv.state.update(cx, |state, cx| {
+                            state.select_single_doc(&sk, dk.clone(), crate::bson::doc_root_id(&dk));
+                            cx.notify();
+                        });
+                        cv.change_document_view(
                             sk,
-                            dk,
+                            crate::state::DocumentViewMode::Json,
                             window,
                             cx,
                         );
@@ -933,5 +956,60 @@ impl DocumentViewModel {
         let state = cx.new(|cx| InputState::new(window, cx).placeholder("Search columns..."));
         self.col_visibility_search = Some(state.clone());
         state
+    }
+}
+
+#[cfg(test)]
+mod inline_edit_tests {
+    use gpui_kit::AppContext as _;
+    use mongodb::bson::{Bson, doc};
+
+    use super::{CollectionView, InlineEditor};
+    use crate::bson::{DocumentKey, PathSegment, path_to_id};
+    use crate::state::{AppState, SessionDocument, SessionKey};
+
+    #[gpui_kit::test]
+    fn cancel_restores_the_prior_draft_without_losing_other_field_changes(
+        cx: &mut gpui_kit::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            gpui_kit::init(cx);
+            let key = SessionKey::new(uuid::Uuid::new_v4(), "db", "collection");
+            let original = doc! { "_id": 1, "enabled": false, "name": "original" };
+            let document = DocumentKey::from_document(&original, 0);
+            let previous = doc! { "_id": 1, "enabled": false, "name": "staged" };
+            let state = cx.new(|_| AppState::new());
+            state.update(cx, |state, _| {
+                let session = state.ensure_session(key.clone());
+                session.data.index_by_key.insert(document.clone(), 0);
+                session.data.items.push(SessionDocument { key: document.clone(), doc: original });
+                state.set_draft(&key, document.clone(), previous.clone());
+            });
+            let view = cx.new(|cx| CollectionView::new(state.clone(), cx));
+            view.update(cx, |view, cx| {
+                let model = &mut view.view_model;
+                let path = vec![PathSegment::Key("enabled".into())];
+                model.current_session = Some(key.clone());
+                model.editing_node_id = Some(path_to_id(&document, &path));
+                model.editing_doc_key = Some(document.clone());
+                model.editing_path = path;
+                model.editing_original = Some(Bson::Boolean(false));
+                model.editing_draft_before = Some(previous.clone());
+                model.inline_editor_state = Some(InlineEditor::Bool(true));
+                model.sync_inline_edit_draft(&state, cx);
+                assert!(
+                    state
+                        .read(cx)
+                        .session_draft(&key, &document)
+                        .unwrap()
+                        .get_bool("enabled")
+                        .unwrap()
+                );
+                model.cancel_inline_edit(&state, cx);
+                assert_eq!(state.read(cx).session_draft(&key, &document), Some(previous));
+                assert!(model.editing_node_id().is_none());
+                assert!(!state.read(cx).session_has_invalid_edit(&key));
+            });
+        });
     }
 }

--- a/src/views/documents/views/documents_view.rs
+++ b/src/views/documents/views/documents_view.rs
@@ -1,10 +1,12 @@
+use gpui_kit::base::Tree;
 use gpui_kit::component::ActiveTheme as _;
 use gpui_kit::component::Disableable as _;
 use gpui_kit::component::button::ButtonVariants as _;
 use gpui_kit::component::input::Input;
+use gpui_kit::component::scroll::ScrollableElement as _;
 use gpui_kit::component::spinner::Spinner;
-use gpui_kit::component::tree::tree;
 use gpui_kit::component::{Icon, IconName, Sizable as _};
+use gpui_kit::prelude::FluentBuilder as _;
 use gpui_kit::*;
 
 use crate::bson::DocumentKey;
@@ -38,6 +40,32 @@ impl CollectionView {
             .as_ref()
             .map(|sk| self.state.read(cx).session_view_mode(sk))
             .unwrap_or_default();
+        if view_mode == DocumentViewMode::Json
+            && let Some(key) = session_key.as_ref()
+        {
+            let content = self.render_json_document(key, window, cx);
+            return div()
+                .flex()
+                .flex_col()
+                .flex_1()
+                .min_h(px(0.0))
+                .min_w(px(0.0))
+                .child(content)
+                .child(Self::render_pagination(
+                    display_page,
+                    total_pages,
+                    per_page,
+                    range_start,
+                    range_end,
+                    total,
+                    is_loading,
+                    session_key,
+                    self.state.clone(),
+                    cx.entity(),
+                    cx,
+                ))
+                .into_any_element();
+        }
         if view_mode == DocumentViewMode::Table {
             return self.render_table_subview(
                 total,
@@ -71,9 +99,12 @@ impl CollectionView {
         let editing_node_id = self.view_model.editing_node_id();
         let tree_state = self.view_model.tree_state();
         let inline_state = self.view_model.inline_state();
+        let inline_error = self.view_model.inline_edit_error(cx);
+        let tree_scroll = tree_state.read(cx).scroll_handle().clone();
         let deselect_state = self.state.clone();
         let deselect_session = session_key.clone();
         let deselect_tree = self.view_model.tree_state();
+        let deselect_view = view.clone();
         let documents_view = div()
             .flex()
             .flex_1()
@@ -82,6 +113,7 @@ impl CollectionView {
             .overflow_hidden()
             .track_focus(&self.documents_focus)
             .on_mouse_down(MouseButton::Left, move |_event, _window, cx| {
+                if !deselect_view.update(cx, |this, cx| this.finish_document_edit(cx)) { return; }
                 let Some(sk) = deselect_session.clone() else {
                     return;
                 };
@@ -446,11 +478,14 @@ impl CollectionView {
                                     )
                                     .into_any_element()
                             } else {
-                                tree(&tree_state, {
+                                // Kit's styled Tree always reapplies selection. Compose its base
+                                // tree with Kit ListItems so editing can use just the input frame.
+                                div().id("document-tree").relative().size_full().child(Tree::new(&tree_state).item({
                                     let view = view.clone();
                                     let node_meta = node_meta.clone();
                                     let editing_node_id = editing_node_id.clone();
                                     let inline_state = inline_state.clone();
+                                    let inline_error = inline_error.clone();
                                     let tree_state = tree_state.clone();
                                     let state_clone = self.state.clone();
                                     let session_key = session_key.clone();
@@ -465,14 +500,15 @@ impl CollectionView {
                                     let current_match_id = current_match_id.clone();
                                     let documents_focus = self.documents_focus.clone();
 
-                                    move |ix, entry, selected, _window, cx| {
+                                    move |ix, entry, entry_state, _window, cx| {
                                         render_tree_row(
                                             ix,
                                             entry,
-                                            selected,
+                                            entry_state.is_selected(),
                                             &node_meta,
                                             &editing_node_id,
                                             &inline_state,
+                                            inline_error.as_deref(),
                                             view.clone(),
                                             tree_state.clone(),
                                             state_clone.clone(),
@@ -484,9 +520,10 @@ impl CollectionView {
                                             drag_enabled,
                                             documents_focus.clone(),
                                             cx,
-                                        )
+                                        ).into_any_element()
                                     }
-                                })
+                                }).list_style(StyleRefinement::default().flex_grow_1().size_full()).size_full())
+                                .vertical_scrollbar(&tree_scroll)
                                 .into_any_element()
                             }),
                     ),
@@ -500,6 +537,12 @@ impl CollectionView {
             .min_w(px(0.0))
             .min_h(px(0.0))
             .child(documents_view)
+            .when(editing_node_id.is_some(), |panel| panel.child(
+                div().px(spacing::lg()).py(spacing::xs()).text_xs()
+                    .text_color(if inline_error.is_some() { cx.theme().danger } else { cx.theme().muted_foreground })
+                    .child(inline_error.map(|error| format!("Invalid value: {error}. Escape cancels this edit."))
+                        .unwrap_or_else(|| "Enter to keep change · Escape to cancel · Save the document to write".into()))
+            ))
             .child(Self::render_pagination(
                 display_page,
                 total_pages,

--- a/src/views/documents/workflow.rs
+++ b/src/views/documents/workflow.rs
@@ -1,0 +1,234 @@
+//! Shared transitions used by the toolbar, pagination, and keyboard actions.
+
+use gpui_kit::*;
+
+use crate::components::request_unsaved_action;
+use crate::state::{AppCommands, AppState, DocumentViewMode, SessionKey, UnsavedScope};
+
+use super::CollectionView;
+
+impl CollectionView {
+    pub(super) fn save_selected_documents(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if !self.finish_document_edit(cx) {
+            return false;
+        }
+        let Some(key) = self.view_model.current_session() else { return false };
+        let documents = self
+            .state
+            .read(cx)
+            .session(&key)
+            .map(|session| {
+                session
+                    .data
+                    .items
+                    .iter()
+                    .filter(|item| session.view.selected_docs.contains(&item.key))
+                    .filter_map(|item| {
+                        session
+                            .view
+                            .drafts
+                            .get(&item.key)
+                            .cloned()
+                            .map(|doc| (item.key.clone(), doc))
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if documents.is_empty() {
+            return false;
+        }
+        let state = self.state.clone();
+        let count = documents.len();
+        crate::components::request_connection_write(
+            state.clone(),
+            crate::components::WriteRequest::new(
+                key.connection_id,
+                key.namespace(),
+                format!("Save {count} selected document(s)"),
+                None,
+            )
+            .for_writes(count),
+            window,
+            cx,
+            move |_, cx| {
+                for (doc_key, document) in documents {
+                    AppCommands::save_document(state.clone(), key.clone(), doc_key, document, cx);
+                }
+            },
+        );
+        true
+    }
+
+    pub(super) fn discard_selected_documents(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(key) = self.view_model.current_session() else { return };
+        if self
+            .state
+            .read(cx)
+            .session_view(&key)
+            .is_some_and(|view| !view.saving_documents.is_empty())
+        {
+            return;
+        }
+        let selected = self
+            .state
+            .read(cx)
+            .session(&key)
+            .map(|session| {
+                session
+                    .view
+                    .selected_docs
+                    .iter()
+                    .filter(|doc| session.view.dirty.contains(*doc))
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if selected.is_empty() {
+            return;
+        }
+        let view = cx.entity();
+        crate::components::open_confirm_dialog(
+            window,
+            cx,
+            "Discard document changes",
+            format!("Discard local edits to {} selected document(s)?", selected.len()),
+            "Discard",
+            true,
+            move |_, cx| {
+                view.update(cx, |this, cx| {
+                    this.view_model.clear_inline_edit();
+                    this.state.update(cx, |state, cx| {
+                        for document in selected {
+                            state.clear_draft(&key, &document);
+                        }
+                        state.set_invalid_inline_edit(key, false);
+                        cx.notify();
+                    });
+                    this.view_model.rebuild_tree(&this.state, cx);
+                    this.view_model.invalidate_table();
+                    this.view_model.sync_dirty_state(&this.state, cx);
+                    cx.notify();
+                });
+            },
+        );
+    }
+
+    pub(super) fn finish_document_edit(&mut self, cx: &mut Context<Self>) -> bool {
+        self.view_model.commit_inline_edit(&self.state, cx);
+        self.view_model.editing_node_id().is_none()
+    }
+
+    pub(super) fn change_document_view(
+        &mut self,
+        key: SessionKey,
+        mode: DocumentViewMode,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.finish_document_edit(cx) {
+            return;
+        }
+        if self.state.read(cx).session_view_mode(&key) == mode {
+            return;
+        }
+        if mode == DocumentViewMode::Json
+            && self
+                .state
+                .read(cx)
+                .session_view(&key)
+                .is_some_and(|view| !view.saving_documents.is_empty())
+        {
+            return;
+        }
+        let state = self.state.clone();
+        let sessions = state.read(cx).editor_sessions();
+        let editor = self
+            .json_document
+            .as_ref()
+            .filter(|(session, _, id, _)| session == &key && sessions.window_handle(*id).is_none())
+            .map(|(_, _, id, _)| *id);
+        let change = move |_: &mut Window, cx: &mut App| {
+            if let Some(editor) = editor {
+                sessions.close(editor);
+            }
+            state.update(cx, |state, cx| {
+                if mode == DocumentViewMode::Json {
+                    let document = state.session_selected_doc(&key).or_else(|| {
+                        state
+                            .session_data(&key)
+                            .and_then(|data| data.items.first().map(|item| item.key.clone()))
+                    });
+                    if let Some(document) = document {
+                        state.select_single_doc(
+                            &key,
+                            document.clone(),
+                            crate::bson::doc_root_id(&document),
+                        );
+                    }
+                }
+                state.set_view_mode(&key, mode);
+                cx.notify();
+            });
+        };
+        if let Some(editor) = editor {
+            request_unsaved_action(
+                self.state.clone(),
+                UnsavedScope::Editor(editor),
+                window,
+                cx,
+                change,
+            );
+        } else {
+            change(window, cx);
+        }
+    }
+
+    pub(super) fn reload_document_page(
+        view: Entity<Self>,
+        state: Entity<AppState>,
+        key: SessionKey,
+        window: &mut Window,
+        cx: &mut App,
+        change: impl FnOnce(&mut AppState, &SessionKey) + 'static,
+    ) {
+        if !view.update(cx, |this, cx| this.finish_document_edit(cx)) {
+            return;
+        }
+        request_unsaved_action(
+            state.clone(),
+            UnsavedScope::Preview(key.clone()),
+            window,
+            cx,
+            move |_, cx| {
+                view.update(cx, |this, cx| {
+                    if this.json_document.as_ref().is_some_and(|(session, _, _, _)| session == &key)
+                    {
+                        if let Some((_, _, editor, _)) = this.json_document.take() {
+                            let sessions = this.state.read(cx).editor_sessions();
+                            if sessions.window_handle(editor).is_none() {
+                                sessions.close(editor);
+                            }
+                        }
+                    }
+                    if this.view_model.is_current_session(&key) {
+                        this.view_model.clear_inline_edit();
+                        this.view_model.invalidate_table();
+                    }
+                });
+                state.update(cx, |state, cx| {
+                    change(state, &key);
+                    cx.notify();
+                });
+                AppCommands::load_documents_for_session(state, key, cx);
+            },
+        );
+    }
+}

--- a/src/views/documents/workflow.rs
+++ b/src/views/documents/workflow.rs
@@ -210,12 +210,11 @@ impl CollectionView {
             move |_, cx| {
                 view.update(cx, |this, cx| {
                     if this.json_document.as_ref().is_some_and(|(session, _, _, _)| session == &key)
+                        && let Some((_, _, editor, _)) = this.json_document.take()
                     {
-                        if let Some((_, _, editor, _)) = this.json_document.take() {
-                            let sessions = this.state.read(cx).editor_sessions();
-                            if sessions.window_handle(editor).is_none() {
-                                sessions.close(editor);
-                            }
+                        let sessions = this.state.read(cx).editor_sessions();
+                        if sessions.window_handle(editor).is_none() {
+                            sessions.close(editor);
                         }
                     }
                     if this.view_model.is_current_session(&key) {

--- a/src/views/json_editor_detached.rs
+++ b/src/views/json_editor_detached.rs
@@ -1,6 +1,7 @@
 //! Detached JSON editor window.
 
 use gpui_kit::component::ActiveTheme as _;
+use gpui_kit::component::Disableable as _;
 use gpui_kit::component::Root;
 use gpui_kit::component::Sizable as _;
 use gpui_kit::component::button::ButtonVariants as _;
@@ -9,12 +10,9 @@ use gpui_kit::prelude::FluentBuilder as _;
 use gpui_kit::*;
 use mongodb::bson::{Bson, Document, oid::ObjectId};
 
-use crate::bson::{
-    DocumentKey, document_to_shell_string, format_relaxed_json_value, parse_bson_from_relaxed_json,
-    parse_document_from_json, parse_value_from_relaxed_json,
-};
+use crate::bson::{DocumentKey, document_to_json_string, parse_document_from_json};
 use crate::components::{Button, request_connection_write, request_unsaved_action};
-use crate::keyboard::CloseEditorWindow;
+use crate::keyboard::{CloseEditorWindow, SaveDocument};
 use crate::state::{
     AppCommands, AppEvent, AppState, EditorSessionId, EditorSessionStore, EditorSessionTarget,
     SessionKey, UnsavedScope,
@@ -43,6 +41,8 @@ pub struct DetachedJsonEditorView {
     pending_editor_content: Option<String>,
     awaiting_create_as_new: bool,
     save_in_flight: bool,
+    embedded: bool,
+    reloading: bool,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -54,7 +54,7 @@ impl DetachedJsonEditorView {
         cx: &mut Context<Self>,
     ) -> Self {
         let mut subscriptions = Vec::new();
-        subscriptions.push(cx.subscribe(&state, |this, state, event, cx| {
+        subscriptions.push(cx.subscribe(&state, |this, _state, event, cx| {
             let Some(session) = this.sessions.snapshot(this.session_id) else {
                 return;
             };
@@ -75,11 +75,6 @@ impl DetachedJsonEditorView {
                         } if tab_doc_key == document
                     ) =>
                 {
-                    if let Some(latest) =
-                        state.read(cx).session_draft_or_document(saved_session, document)
-                    {
-                        this.sessions.refresh_document_baseline(this.session_id, latest);
-                    }
                     this.awaiting_create_as_new = false;
                     this.set_save_in_flight(false);
                     this.clear_sync_issue();
@@ -114,7 +109,18 @@ impl DetachedJsonEditorView {
                     this.awaiting_create_as_new = false;
                     this.set_save_in_flight(false);
                     this.clear_sync_issue();
-                    this.close_window(cx);
+                    if this.embedded {
+                        this.sessions.close(this.session_id);
+                        this.state.update(cx, |state, cx| {
+                            state.set_view_mode(
+                                inserted_session,
+                                crate::state::DocumentViewMode::Tree,
+                            );
+                            cx.notify();
+                        });
+                    } else {
+                        this.close_window(cx);
+                    }
                 }
                 AppEvent::DocumentInsertFailed {
                     session: failed_session,
@@ -149,8 +155,15 @@ impl DetachedJsonEditorView {
             pending_editor_content: None,
             awaiting_create_as_new: false,
             save_in_flight: false,
+            embedded: false,
+            reloading: false,
             _subscriptions: subscriptions,
         }
+    }
+
+    pub(crate) fn embedded(mut self) -> Self {
+        self.embedded = true;
+        self
     }
 
     fn ensure_editor_state(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -165,7 +178,7 @@ impl DetachedJsonEditorView {
             .unwrap_or_default();
         let editor_state = cx.new(|cx| {
             EditorState::new(window, cx)
-                .language("javascript")
+                .language("json")
                 .line_number(true)
                 .searchable(true)
                 .soft_wrap(true)
@@ -180,13 +193,20 @@ impl DetachedJsonEditorView {
         let sessions = self.sessions.clone();
         let session_id = self.session_id;
         let input_sub =
-            cx.subscribe_in(&editor_state, window, move |_view, state, event, _window, cx| {
+            cx.subscribe_in(&editor_state, window, move |view, state, event, _window, cx| {
                 if !matches!(event, InputEvent::Change) {
                     return;
                 }
 
                 let value = state.read(cx).value().to_string();
                 sessions.update_content(session_id, value);
+                if view.embedded {
+                    view.set_notice(
+                        false,
+                        if sessions.is_dirty(session_id) { "Unsaved JSON changes" } else { "" },
+                    );
+                    cx.notify();
+                }
             });
         self._subscriptions.push(input_sub);
         self.editor_state = Some(editor_state);
@@ -227,12 +247,21 @@ impl DetachedJsonEditorView {
     }
 
     fn format_json(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        cx.notify();
+        if self.save_in_flight
+            || self.reloading
+            || self.sessions.snapshot(self.session_id).is_some_and(|session| {
+                self.state.read(cx).connection_read_only(session.session_key.connection_id)
+            })
+        {
+            return;
+        }
         let Some(editor_state) = self.editor_state.clone() else {
             return;
         };
         let raw = editor_state.read(cx).value().to_string();
-        let formatted = match parse_value_from_relaxed_json(&raw) {
-            Ok(value) => format_relaxed_json_value(&value),
+        let formatted = match parse_document_from_json(&raw) {
+            Ok(value) => document_to_json_string(&value),
             Err(err) => {
                 self.set_error(format!("Invalid JSON: {err}"));
                 return;
@@ -248,6 +277,10 @@ impl DetachedJsonEditorView {
     }
 
     fn save_or_insert(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        cx.notify();
+        if self.reloading || self.save_in_flight {
+            return;
+        }
         let Some(session) = self.sessions.snapshot(self.session_id) else {
             self.set_error("Editor session is no longer available.");
             return;
@@ -276,6 +309,7 @@ impl DetachedJsonEditorView {
     }
 
     fn save_or_insert_authorized(&mut self, cx: &mut Context<Self>) {
+        cx.notify();
         if self.state.read(cx).unsaved_guard_is_active() {
             self.set_notice(false, "Finish the open unsaved-changes prompt before saving.");
             cx.notify();
@@ -501,7 +535,7 @@ impl DetachedJsonEditorView {
             return;
         };
 
-        let content = document_to_shell_string(&draft);
+        let content = document_to_json_string(&draft);
         self.sessions.update_content(self.session_id, content.clone());
         self.pending_editor_content = Some(content);
         self.clear_sync_issue();
@@ -517,19 +551,36 @@ impl DetachedJsonEditorView {
         }
         let session_id = self.session_id;
         let sessions = self.sessions.clone();
+        let embedded = self.embedded;
+        let state = self.state.clone();
+        let session_key = sessions.snapshot(session_id).map(|session| session.session_key);
         request_unsaved_action(
             self.state.clone(),
             UnsavedScope::Editor(session_id),
             window,
             cx,
-            move |window, _cx| {
+            move |window, cx| {
                 sessions.close(session_id);
-                window.remove_window();
+                if embedded {
+                    if let Some(key) = session_key {
+                        state.update(cx, |state, cx| {
+                            state.set_view_mode(&key, crate::state::DocumentViewMode::Tree);
+                            cx.notify();
+                        });
+                    }
+                } else {
+                    window.remove_window();
+                }
             },
         );
     }
 
     fn close_window(&mut self, cx: &mut Context<Self>) {
+        if self.embedded {
+            self.set_notice(false, "Document saved.");
+            cx.notify();
+            return;
+        }
         self.sessions.close(self.session_id);
         if let Some(handle) = self.window_handle {
             let _ = handle.update(cx, |_view, window, _cx| {
@@ -538,7 +589,10 @@ impl DetachedJsonEditorView {
         }
     }
 
-    fn reload_document(&mut self, cx: &mut Context<Self>) {
+    pub(crate) fn reload_document(&mut self, cx: &mut Context<Self>) {
+        if self.reloading || self.save_in_flight {
+            return;
+        }
         let Some(session) = self.sessions.snapshot(self.session_id) else {
             self.set_error("Editor session is no longer available.");
             return;
@@ -565,7 +619,9 @@ impl DetachedJsonEditorView {
             return;
         };
 
-        self.set_notice(false, "Reloading latest document...");
+        self.reloading = true;
+        self.sessions.set_save_in_flight(self.session_id, true);
+        self.set_notice(false, "Loading the full document…");
 
         let database = session_key.database.clone();
         let collection = session_key.collection.clone();
@@ -577,9 +633,9 @@ impl DetachedJsonEditorView {
         cx.spawn(async move |view: WeakEntity<Self>, cx: &mut AsyncApp| {
             let result: Result<Option<Document>, crate::error::Error> = task.await;
             cx.update(|cx| {
-                let _ = view.update(cx, |this, cx| match result {
+                let _ = view.update(cx, |this, cx| { this.reloading = false; this.sessions.set_save_in_flight(this.session_id, false); cx.notify(); match result {
                     Ok(Some(current)) => {
-                        let content = document_to_shell_string(&current);
+                        let content = document_to_json_string(&current);
                         this.sessions
                             .refresh_document_baseline(this.session_id, current.clone());
                         this.sessions.update_content(this.session_id, content.clone());
@@ -600,13 +656,14 @@ impl DetachedJsonEditorView {
                             format!("Failed to reload latest document: {err}"),
                         );
                     }
-                });
+                }});
             });
         })
         .detach();
     }
 
     fn create_as_new(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        cx.notify();
         if self.state.read(cx).unsaved_guard_is_active() {
             self.set_notice(false, "Finish the open unsaved-changes prompt before saving.");
             cx.notify();
@@ -679,6 +736,7 @@ impl DetachedJsonEditorView {
     }
 
     fn copy_json(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        cx.notify();
         let Some(editor_state) = self.editor_state.clone() else {
             return;
         };
@@ -727,15 +785,17 @@ impl Render for DetachedJsonEditorView {
             EditorSessionTarget::Insert => "Insert document",
             EditorSessionTarget::Document { .. } => "Edit document",
         };
-        let primary_label = match &session.target {
-            EditorSessionTarget::Insert => "Insert & Close",
-            EditorSessionTarget::Document { .. } => "Save & Close",
+        let primary_label = match (&session.target, self.embedded) {
+            (EditorSessionTarget::Document { .. }, true) => "Save document",
+            (EditorSessionTarget::Insert, _) => "Insert & Close",
+            (EditorSessionTarget::Document { .. }, false) => "Save & Close",
         };
         let notice = self.inline_notice.clone();
         let sync_issue = self.sync_issue;
         let state_ref = self.state.read(cx);
         let appearance = state_ref.settings.appearance.clone();
         let vibrancy = state_ref.startup_vibrancy;
+        let read_only = state_ref.connection_read_only(session.session_key.connection_id);
         let connection_identity = crate::components::connection_identity_for(
             &self.state,
             session.session_key.connection_id,
@@ -760,12 +820,19 @@ impl Render for DetachedJsonEditorView {
             .flex()
             .flex_col()
             .size_full()
-            .when(vibrancy, |s| s.pt(px(28.0)))
+            .min_h(px(0.0))
+            .min_w(px(0.0))
+            .when(self.embedded, |view| view.flex_1())
+            .when(vibrancy && !self.embedded, |s| s.pt(px(28.0)))
             .bg(islands::content_bg(&appearance, cx))
             .text_color(cx.theme().foreground)
             .on_action(cx.listener(|this, _: &CloseEditorWindow, window, cx| {
                 cx.stop_propagation();
                 this.request_close_window(window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &SaveDocument, window, cx| {
+                cx.stop_propagation();
+                this.save_or_insert(window, cx);
             }))
             .on_key_down({
                 let view = view.clone();
@@ -796,6 +863,8 @@ impl Render for DetachedJsonEditorView {
             .child(
                 div()
                     .flex()
+                    .flex_wrap()
+                    .gap(spacing::sm())
                     .items_center()
                     .justify_between()
                     .px(spacing::md())
@@ -811,13 +880,16 @@ impl Render for DetachedJsonEditorView {
                             .child(
                                 div().text_sm().font_weight(FontWeight::MEDIUM).child(mode_label),
                             )
-                            .child(
-                                div()
-                                    .text_xs()
-                                    .text_color(cx.theme().muted_foreground)
-                                    .child(format!("{}  •  {}", subtitle, session.title())),
-                            )
-                            .child(connection_identity),
+                            .when(!self.embedded, |column| {
+                                column
+                                    .child(
+                                        div()
+                                            .text_xs()
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child(format!("{}  •  {}", subtitle, session.title())),
+                                    )
+                                    .child(connection_identity)
+                            }),
                     )
                     .child(
                         div()
@@ -839,6 +911,7 @@ impl Render for DetachedJsonEditorView {
                                 Button::new("json-editor-window-format")
                                     .xsmall()
                                     .label("Format JSON")
+                                    .disabled(read_only || self.save_in_flight || self.reloading)
                                     .on_click({
                                         let view = view.clone();
                                         move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
@@ -853,6 +926,15 @@ impl Render for DetachedJsonEditorView {
                                     .primary()
                                     .xsmall()
                                     .label(primary_label)
+                                    .disabled(
+                                        read_only
+                                            || self.save_in_flight
+                                            || self.reloading
+                                            || (matches!(
+                                                session.target,
+                                                EditorSessionTarget::Document { .. }
+                                            ) && !session.is_dirty()),
+                                    )
                                     .on_click({
                                         let view = view.clone();
                                         move |_: &ClickEvent, window: &mut Window, cx: &mut App| {
@@ -935,81 +1017,55 @@ impl Render for DetachedJsonEditorView {
                 this.child(row)
             })
             .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .flex_1()
-                    .min_h(px(0.0))
-                    .p(spacing::md())
-                    .child(Editor::new(&editor).font_family(fonts::mono()).h_full().w_full()),
+                div().flex().flex_col().flex_1().min_h(px(0.0)).p(spacing::md()).child(
+                    Editor::new(&editor)
+                        .readonly(read_only || self.save_in_flight || self.reloading)
+                        .font_family(fonts::mono())
+                        .h_full()
+                        .w_full(),
+                ),
             )
     }
 }
 
-pub fn open_document_json_editor_window(
+pub(crate) fn detach_json_editor(
     state: Entity<AppState>,
-    session_key: SessionKey,
-    doc_key: DocumentKey,
+    session_id: EditorSessionId,
     cx: &mut App,
 ) {
-    if state.read(cx).active_connection_by_id(session_key.connection_id).is_none() {
-        return;
-    }
-
-    state.update(cx, |state, cx| {
-        if state.promote_preview_collection_tab(&session_key) {
-            cx.notify();
-        }
-    });
-
     let sessions = state.read(cx).editor_sessions();
-    if let Some(existing_id) = sessions.find_any_document_session() {
-        if focus_existing_window(&sessions, existing_id, cx) {
-            return;
-        }
-        if sessions.is_dirty(existing_id) {
-            log::warn!("Could not focus the existing JSON editor; preserving its unsaved content");
-            return;
-        }
-        sessions.close(existing_id);
+    let Some(session) = sessions.snapshot(session_id) else { return };
+    if session.save_in_flight {
+        return;
     }
-
-    let Some(document) = state.read(cx).session_draft_or_document(&session_key, &doc_key) else {
-        log::warn!("Could not open JSON editor: document is no longer available");
+    if focus_existing_window(&sessions, session_id, cx) {
         return;
-    };
-
-    let original_id = document
-        .get("_id")
-        .cloned()
-        .or_else(|| parse_bson_from_relaxed_json(doc_key.as_str()).ok());
-    let Some(original_id) = original_id else {
-        log::warn!("Could not open JSON editor: failed to resolve original _id");
-        return;
-    };
-
-    let session_id = sessions.create_document_session(
-        session_key,
-        doc_key,
-        original_id,
-        document.clone(),
-        document_to_shell_string(&document),
-    );
-    match open_detached_json_editor_window(state, sessions.clone(), session_id, cx) {
+    }
+    match open_detached_json_editor_window(state.clone(), sessions.clone(), session_id, cx) {
         Ok(window) => {
             focus_window_handle(&window, cx);
             sessions.register_window(session_id, window.into());
+            state.update(cx, |state, cx| {
+                state.set_view_mode(&session.session_key, crate::state::DocumentViewMode::Tree);
+                cx.notify();
+            });
         }
-        Err(err) => {
-            sessions.close(session_id);
-            log::error!("Failed to open JSON editor window: {err}");
-        }
+        Err(error) => log::error!("Failed to open JSON editor window: {error}"),
     }
 }
 
 pub fn open_insert_json_editor_window(
     state: Entity<AppState>,
     session_key: SessionKey,
+    cx: &mut App,
+) {
+    open_insert_json_editor_with_content(state, session_key, "{}".to_string(), cx);
+}
+
+pub(crate) fn open_insert_json_editor_with_content(
+    state: Entity<AppState>,
+    session_key: SessionKey,
+    content: String,
     cx: &mut App,
 ) {
     if state.read(cx).active_connection_by_id(session_key.connection_id).is_none() {
@@ -1036,7 +1092,7 @@ pub fn open_insert_json_editor_window(
         sessions.close(existing_id);
     }
 
-    let session_id = sessions.create_insert_session(session_key, "{}".to_string());
+    let session_id = sessions.create_insert_session(session_key, content);
     match open_detached_json_editor_window(state, sessions.clone(), session_id, cx) {
         Ok(window) => {
             focus_window_handle(&window, cx);


### PR DESCRIPTION
## Summary

The Documents view mixed staged field edits with immediate database writes and exposed unclear document, page, and collection actions. This change makes browsing and editing consistent across Tree, Table, and JSON.

- Add in-tab JSON editing with syntax highlighting and shared buffers for detached windows.
- Stage single-document field edits, provide compact Done/Cancel controls, restore prior values on cancellation, and retain invalid edits for correction.
- Check the original document atomically before saving, preserve draft baselines across reloads, and load full documents before editing projected results in JSON.
- Clarify action scopes and right-click targets; preserve BSON types and string whitespace in clipboard operations; preview duplicates and confirm pasted inserts.
- Use Kit controls for selection, column visibility, and pagination, including bounded navigation for large result sets.

## Validation

- Changed Rust sources formatted with `rustfmt`; `git diff --check` passed.
- Added regression coverage for BSON round trips, draft rollback and baselines, selectable tree entries, editor clean-state tracking, and page bounds.
- [GitHub Actions CI run 34577296654](https://github.com/ggagosh/openmango/actions/runs/34577296654) passed on `f4ec8c6`: quality (format, compile, Clippy, sidecar, unit tests) and Linux integration tests.
- Builds, clippy, and test suites were not run locally. GUI verification remains manual.
- [Manual validation guide](https://github.com/ggagosh/openmango/blob/redesign/documents-workflow/docs/DOCUMENTS_WORKFLOW.md). Updated UI screenshots are not attached.

