### PR TITLE
Fix updater download failures and stable/nightly workflow

### DIFF
--- a/docs/UPDATER_WORKFLOW.md
+++ b/docs/UPDATER_WORKFLOW.md
@@ -1,0 +1,36 @@
+# Updater workflow changes
+
+Branch: `fix/updater-workflow`, based on merged PR #15 (`900cf38`).
+
+## Findings
+
+- The app log records repeated download failures with `No such file or directory`. The report places the failure after progress reaches 100%.
+- Downloads previously shared `.OpenMango-update.download` and `OpenMango-update.zip`. A second attempt or another attempt's cleanup could remove the first attempt's file before its final rename. The existing logs do not identify which competing operation triggered each occurrence.
+- Checks could replace an active download's state, and the independent progress task could overwrite completion with a late percentage update.
+- Stable installations also checked nightly and accepted any different commit as an update, including older history.
+- Installation replaced the app before asking about unsaved work and fell back to `/Applications` when launched from a development executable.
+
+## Changes
+
+- Each download owns a unique temporary file. Verification passes ownership to the ready-to-install state; there is no shared-file deletion or final rename. Canceling or failing an attempt cleans up only its own file.
+- Checking and downloading have cancellation and request IDs. Progress, verification, and completion use one ordered stream, and download progress stops at 99% until verification finishes.
+- Settings expose Stable and Nightly explicitly, defaulting to the build's release channel. Same-channel nightly updates require GitHub to report forward ancestry. Downloads pin GitHub asset IDs and verify size and SHA-256.
+- A Software Update dialog uses Kit buttons, channel menus, progress, spinner, and error alerts. It shows the current build, selected channel, available build, download details, verification, preparation, and recovery actions.
+- Installation uses isolated staging and a filesystem lock, verifies signatures and the installed app's signing identity, and asks about unsaved work before swapping bundles. Failed swaps or launches restore the previous app; failed restoration preserves the recovery copy.
+- Development executables never install over `/Applications/OpenMango.app`. Translocated apps receive instructions to move and reopen the app. Closed windows stop their periodic update checks.
+
+## Validation
+
+Local validation passed on macOS:
+
+- `just fmt-check`
+- `just lint` (all targets)
+- `just check-release` and `just lint-release` (with `mimalloc`)
+- `just check-sidecar`
+- `cargo test -- --test-threads=1` with the active Docker daemon: 657 passed, 0 failed, 1 ignored, including the Docker integration suites.
+
+The focused updater tests passed for independent download-file cleanup, checksum/build identity parsing, nightly ancestry, development-executable detection, and rollback after a failed bundle swap. The GUI and a real signed macOS installation were not exercised; verify that flow manually before release.
+
+Manual scenarios: download/cancel/retry; check while downloading; stable/nightly selection; checksum failure; missing cached file; read-only/translocated installation; unsaved-work cancellation; signature rejection; launch failure and rollback.
+
+See [primary-source research](UPDATER_WORKFLOW_RESEARCH.md) for component APIs and distribution guidance.

--- a/docs/UPDATER_WORKFLOW_RESEARCH.md
+++ b/docs/UPDATER_WORKFLOW_RESEARCH.md
@@ -1,0 +1,146 @@
+# Stable/nightly updater workflow research
+
+Reviewed 2026-09-11 on `fix/updater-workflow`; implementation belongs to the parent task.
+Sources: the local updater/release workflow, published GPUI Kit/Base/Component 0.6.0, GitHub REST documentation, Rust/tempfile documentation, and Apple distribution guidance.
+Local observations describe the baseline inspected before the concurrent updater changes, not a completed diagnosis or runtime verification.
+
+## What the reported timing means
+
+The baseline emits 100% when the response bytes have arrived, then synchronizes the file, checks SHA-256, removes the old cache ZIP, and renames the partial file.
+Therefore **100% downloaded is not the same as a verified package ready to install**.
+An error at that transition can come from cache promotion; it does not by itself implicate `ditto`, a mounted image, or restart.
+The baseline uses shared `.OpenMango-update.download` and `OpenMango-update.zip` names and deletes/replaces them during attempts.
+Another attempt or stale task can therefore interfere with the path still owned by an earlier attempt; this is a concrete mechanism to test, not proof that it caused every reported ENOENT.
+[Baseline updater](../src/state/commands/updater.rs), [updater UI state](../src/state/app_state/updater.rs)
+
+Report operation and path context separately: checking release, downloading, flushing, verifying checksum, promoting package, extracting, validating bundle, swapping, or launching.
+For example: **Could not prepare the downloaded update** with the underlying rename error in expandable details.
+Avoid a single unqualified “Update failed” message that makes all phases look identical.
+
+## GPUI Kit supplies native controls, not an updater service
+
+No updater/auto-update service is exported by the inspected published Kit, Base, or Component crates.
+Release lookup, download lifetime, verification, rollback, channel policy, and relaunch remain application responsibilities.
+Reuse the native controls already in this dependency graph; no UI-library upgrade is needed for the workflow below.
+[Published Kit](https://docs.rs/crate/gpui-kit/0.6.0/source/src/lib.rs), [Component](https://docs.rs/crate/gpui-component/0.6.0/source/src/lib.rs), [Base](https://docs.rs/crate/gpui-base/0.6.0/source/src/lib.rs)
+
+| Need | Verified 0.6.0 API | Limit |
+| --- | --- | --- |
+| Measured download progress | `Progress::new(id).value(percent)` | Percentage is 0–100; input is clamped, not inferred |
+| Accessible progress name | `.accessibility_label(...)` | Application supplies meaningful phase text |
+| Unknown-length download / verification | `Spinner::new()` | Does not measure bytes or completion |
+| Pending action | `Button::loading(bool)` | Request exclusion/cancellation still belongs to application state |
+| Persistent local failure | `Alert::error(id, message)` | Add a retry action appropriate to the failed phase |
+| Background notification | `Notification::error(message).autohide(false)` | Keep the same error accessible in the update surface too |
+| Technical details | Existing `Collapsible` and native text controls | Do not put raw implementation details in the primary action label |
+
+[Progress](https://docs.rs/crate/gpui-component/0.6.0/source/src/progress/progress.rs), [Spinner](https://docs.rs/crate/gpui-component/0.6.0/source/src/spinner.rs), [Button](https://docs.rs/crate/gpui-component/0.6.0/source/src/button/button.rs), [Alert](https://docs.rs/crate/gpui-component/0.6.0/source/src/alert.rs), [Notification](https://docs.rs/crate/gpui-component/0.6.0/source/src/notification.rs)
+
+## A truthful, recoverable update flow
+
+| Phase | User-facing state | Available action |
+| --- | --- | --- |
+| Checking | Checking for updates… | Avoid starting a duplicate check |
+| Available | Version/build, channel, architecture, release notes | Download update |
+| Downloading | Received bytes and percentage when total size is known | Cancel only if implemented correctly |
+| Verifying/preparing | Download complete; verifying update… | Retain the package until verification/promotion completes |
+| Ready | Update downloaded and verified | Install and restart; Later |
+| Installing | Installing update… | Prevent another installation from starting |
+| Restarting | Restarting OpenMango… | Preserve failure details if relaunch fails |
+| Failed | Specific failed phase and readable reason | Retry download, retry install, or open the release page as appropriate |
+
+For missing `Content-Length`, show an indeterminate indicator and received bytes rather than an invented percentage.
+Do not let delayed download-progress messages turn Ready, Failed, or a newer request back into Downloading.
+Use one active operation identity/generation and check it at every progress/completion update; filesystem isolation is still needed across app instances.
+Keep a verified download available after a cancelled restart or an installation failure when retrying it remains valid.
+Resolve unsaved work before replacing the installed bundle, and recheck it at the final destructive transition if preparation was asynchronous.
+
+## Stable and nightly are explicit release identities
+
+GitHub's `/releases/latest` returns the latest published non-draft, non-prerelease release.
+The documented ordering uses `created_at`, meaning the release commit date rather than draft/publication time; do not treat it as a generic “newest uploaded artifact” endpoint.
+Nightly needs `/releases/tags/nightly` or another explicit channel identity.
+The baseline checks both and prefers a newer stable SemVer; otherwise a differing nightly SHA may be offered. That is OpenMango policy, not Kit/GitHub behavior.
+Make the selected channel and target build visible, and do not silently cross channels merely because another SHA differs.
+A different SHA establishes a different build, not by itself that the build is newer than a local development checkout.
+[GitHub: latest release](https://docs.github.com/en/rest/releases/releases#get-the-latest-release), [release by tag](https://docs.github.com/en/rest/releases/releases#get-a-release-by-tag-name)
+
+For nightly ancestry, call `GET /repos/{owner}/{repo}/compare/{LOCAL_SHA}...{REMOTE_SHA}` with the local build as BASE and the candidate as HEAD.
+The documented commit comparison corresponds to `git log BASE..HEAD`; use its comparison status, not SHA inequality or commit-list length.
+`ahead` means the candidate is ahead of the local base; `identical` means no change; `behind` means an older candidate; `diverged` is not a fast-forward update.
+Only `ahead` should produce an automatic newer-nightly offer. An unknown local SHA, unavailable comparison, or divergent history needs an explicit unavailable/manual path, not a silent downgrade or an unsupported “up to date” claim.
+Direction was also verified through read-only GitHub API responses for the known Kit commits: `3a25a73...36b5181` returned ahead by 7; the inverse returned behind by 7.
+[GitHub: compare two commits](https://docs.github.com/en/rest/commits/commits#compare-two-commits)
+
+The repository's nightly workflow deletes and recreates the `nightly` release, with ZIP and matching `.sha256` assets.
+A tag/filename URL can consequently name different bytes later or disappear during replacement.
+Capture the selected release ID, asset ID/name, architecture, size, expected checksum/digest, and build identity together.
+Do not fetch an unpinned old ZIP and a newly replaced checksum under the same mutable tag and call the pair one release.
+If the pinned asset disappears, return to release checking and offer the newly resolved candidate rather than silently substituting it mid-download.
+[Local nightly publication](../.github/workflows/nightly.yml), [GitHub: release asset API](https://docs.github.com/en/rest/releases/assets#get-a-release-asset)
+
+GitHub asset metadata includes ID, state, size, download URL, and a digest when provided; accept a completed uploaded asset of the expected architecture/format.
+The asset-ID endpoint with `Accept: application/octet-stream` may return bytes directly or redirect; clients must handle both 200 and 302.
+GitHub rejects uploading another asset under an existing filename unless the old asset is removed, so filename equality is not immutable identity.
+Validate the bytes received against the selected metadata and the project's checksum requirement; an HTTP success alone does not verify an update.
+[GitHub: download and upload assets](https://docs.github.com/en/rest/releases/assets)
+
+## Isolated staging and safe promotion
+
+Use one owned staging file/directory per attempt, preferably under the destination cache filesystem.
+`tempfile` 3.26 is already a project dependency; `NamedTempFile::new_in(cache_dir)` provides unique file creation without a shared-name delete/create sequence.
+Complete the write, synchronize as needed, verify the digest, then promote the same owned artifact and retain its lifetime through Ready/Install.
+Do not drop a temporary-file owner and keep only its path: automatic cleanup can make that path disappear.
+`persist(...)` can atomically replace an existing file and returns ownership on failure; it does not synchronize file/directory contents and cannot cross filesystems.
+[Existing dependency](../Cargo.toml), [tempfile 3.26: NamedTempFile](https://docs.rs/tempfile/3.26.0/tempfile/struct.NamedTempFile.html)
+
+Prefer an attempt-specific verified ZIP path over a globally shared “latest ZIP” filename; a second app instance must not replace the package another instance is about to install.
+Cleanup should remove only artifacts owned by that attempt, with stale cleanup separate from active work.
+When a fixed destination is necessary, do not delete the existing destination before a same-filesystem file promotion.
+Rust `rename` can fail when the source no longer exists or paths cross mount points; POSIX replacement provides an atomic name transition for the individual rename.
+That guarantee does not make a multi-step `.app → backup → new .app` installation a single atomic transaction.
+[Rust: rename](https://doc.rust-lang.org/std/fs/fn.rename.html), [POSIX: rename](https://pubs.opengroup.org/onlinepubs/9799919799/functions/rename.html)
+
+## macOS paths, bundles, and relaunch
+
+The inspected updater consumes ZIP assets and uses `ditto`; it does not attach a DMG, so an `hdiutil` rewrite is not indicated by this report.
+Apple documents that apps launched directly from ZIP/disk-image distribution locations may have randomized/translocated bundle paths.
+Treat an executable-derived bundle path as runtime location, not proof of a writable installation target.
+Handle mounted/read-only/translocated locations explicitly, and do not silently replace an unrelated `/Applications/OpenMango.app` when running a development binary.
+Apple also recommends testing upgrades, duplicate installations, different locations, and different installing/running user accounts.
+[Apple: Packaging Mac software](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution)
+
+Verify the staged app's signature and expected identity before replacing the installed app; keep a recoverable previous bundle until installation is confirmed.
+ZIP checksums and signed/notarized application contents serve different purposes; retaining both checks is appropriate for direct distribution.
+Apple identifies direct-download software updates as developer-managed, with Developer ID/notarization used for trusted distribution.
+[Apple: Distributing software on macOS](https://developer.apple.com/macos/distribution/)
+
+`codesign --verify` alone does not establish that the candidate is OpenMango from the expected publisher.
+Apple TN3127 documents an explicit `-R` requirement: bind the signing identifier and the expected Team ID, not merely `anchor apple generic` (which accepts identities issued by Apple generally).
+For a Developer ID-only channel, the requirement can also constrain the Developer ID intermediate and Application certificate OIDs.
+The expected identity must come from trusted application/build configuration, never from the downloaded candidate itself.
+Example requirement text, with placeholders replaced by trusted values:
+`anchor apple generic and identifier "EXPECTED_BUNDLE_ID" and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = "EXPECTED_TEAM_ID"`
+Pass it as a test requirement (Apple's command examples use `-R '=...'`) alongside strict verification. Quote the Team ID, including when it starts with a digit.
+[Apple: TN3127 requirements](https://developer.apple.com/documentation/technotes/tn3127-inside-code-signing-requirements), [requirement language](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html), [Apple DTS: quoted Team IDs](https://developer.apple.com/forums/thread/801478)
+
+Use known executable paths such as `/usr/bin/ditto` and `/usr/bin/open`, or a native launch API, and pass paths as separate arguments.
+Rust searches `PATH` for non-absolute program names, so a process-spawn ENOENT can mean a missing executable rather than a missing update archive.
+Capture spawn errors and command exit status/stderr; do not discard relaunch failure and then close all windows as though restart succeeded.
+[Rust: Command](https://doc.rust-lang.org/std/process/struct.Command.html), [Apple: NSWorkspace application launch](https://developer.apple.com/documentation/appkit/nsworkspace/openapplication(at:configuration:completionhandler:))
+
+If a helper performs replacement after the old process exits, transfer ownership of its staging path before quitting and give it absolute validated input/output paths.
+The helper must survive parent exit, retain the verified package, report swap/rollback/launch outcomes, and clean only its own files.
+Do not place it solely inside a temporary owner that the parent will drop or inside the bundle it is about to remove.
+These are lifecycle requirements, not evidence that Kit supplies a helper or that a helper is required to fix the post-download error.
+
+## Focused verification targets for implementation
+
+- Two concurrent attempts/app instances cannot remove or promote each other's partial ZIPs.
+- Missing source at promotion produces phase-specific context, and no failed/stale attempt can publish Ready.
+- Unknown-length and interrupted responses never show invented completion; 100% transitions to verification before Ready.
+- Nightly replacement between check/download produces a controlled refresh/retry, not an unexplained checksum or missing-file loop.
+- Download/install retries, Later, and cancelled dirty-work prompts retain the correct verified artifact.
+- Installer destination, backup restoration, read-only/translocated launch locations, and restart failure are exercised without replacing the development user's installed app.
+
+Research was read-only except for this document; no app launch, build, test, release mutation, or dependency change was performed.

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -415,9 +415,11 @@ impl AppRoot {
             }
             "cmd:check-updates" => {
                 AppCommands::check_for_updates(state.clone(), cx);
+                crate::components::updater::open_updates(state.clone(), window, cx);
             }
             "cmd:download-update" => {
                 AppCommands::download_update(state.clone(), cx);
+                crate::components::updater::open_updates(state.clone(), window, cx);
             }
             "cmd:install-update" => {
                 AppCommands::install_update(state.clone(), cx);

--- a/src/app/root.rs
+++ b/src/app/root.rs
@@ -422,10 +422,17 @@ impl AppRoot {
             let recheck_secs = std::env::var("OPENMANGO_UPDATE_INTERVAL_SECS")
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())
-                .unwrap_or(4 * 60 * 60);
-            async move |_this: WeakEntity<Self>, cx: &mut gpui_kit::AsyncApp| {
+                .unwrap_or(4 * 60 * 60)
+                .max(1);
+            async move |this: WeakEntity<Self>, cx: &mut gpui_kit::AsyncApp| {
                 cx.background_executor().timer(std::time::Duration::from_secs(startup_delay)).await;
-                let should_check = cx.update(|cx| state.read(cx).settings.auto_update);
+                if this.upgrade().is_none() {
+                    return;
+                }
+                let should_check = cx.update(|cx| {
+                    state.read(cx).settings.auto_update
+                        && AppCommands::automatic_updates_supported()
+                });
                 if should_check {
                     cx.update(|cx| {
                         AppCommands::check_for_updates(state.clone(), cx);
@@ -436,9 +443,22 @@ impl AppRoot {
                     cx.background_executor()
                         .timer(std::time::Duration::from_secs(recheck_secs))
                         .await;
+                    if this.upgrade().is_none() {
+                        break;
+                    }
                     let should_check = cx.update(|cx| {
                         let s = state.read(cx);
-                        s.settings.auto_update && matches!(s.update_status, UpdateStatus::Idle)
+                        s.settings.auto_update
+                            && AppCommands::automatic_updates_supported()
+                            && matches!(
+                                s.update_status,
+                                UpdateStatus::Idle
+                                    | UpdateStatus::UpToDate { .. }
+                                    | UpdateStatus::Failed {
+                                        stage: crate::state::app_state::updater::UpdateStage::Check,
+                                        ..
+                                    }
+                            )
                     });
                     if should_check {
                         cx.update(|cx| {
@@ -968,8 +988,9 @@ impl Render for AppRoot {
             .on_action(cx.listener(|this, _: &FocusContent, window, cx| {
                 this.focus_current_content(window, cx);
             }))
-            .on_action(cx.listener(|this, _: &DownloadUpdate, _window, cx| {
+            .on_action(cx.listener(|this, _: &DownloadUpdate, window, cx| {
                 AppCommands::download_update(this.state.clone(), cx);
+                crate::components::updater::open_updates(this.state.clone(), window, cx);
             }))
             .on_action(cx.listener(|this, _: &InstallUpdate, _window, cx| {
                 AppCommands::install_update(this.state.clone(), cx);

--- a/src/bson/formatter.rs
+++ b/src/bson/formatter.rs
@@ -24,19 +24,6 @@ pub fn format_bson_for_clipboard(value: &Bson) -> String {
     }
 }
 
-#[cfg(test)]
-mod json_tests {
-    use super::*;
-    use mongodb::bson::{Decimal128, doc};
-    #[test]
-    fn document_json_preserves_numeric_types_and_string_whitespace() {
-        let document = doc! { "small_long": Bson::Int64(1), "large_long": Bson::Int64(i64::MAX), "decimal": Bson::Decimal128("12.30".parse::<Decimal128>().unwrap()), "text": "  value  " };
-        let text = document_to_json_string(&document);
-        assert!(serde_json::from_str::<serde_json::Value>(&text).is_ok());
-        assert_eq!(crate::bson::parse_document_from_json(&text).unwrap(), document);
-    }
-}
-
 /// Get a human-readable type label for a BSON value.
 pub fn bson_type_label(value: &Bson) -> &'static str {
     match value {
@@ -120,4 +107,17 @@ fn sanitize_for_preview(input: &str) -> String {
         }
     }
     output
+}
+
+#[cfg(test)]
+mod json_tests {
+    use super::*;
+    use mongodb::bson::{Decimal128, doc};
+    #[test]
+    fn document_json_preserves_numeric_types_and_string_whitespace() {
+        let document = doc! { "small_long": Bson::Int64(1), "large_long": Bson::Int64(i64::MAX), "decimal": Bson::Decimal128("12.30".parse::<Decimal128>().unwrap()), "text": "  value  " };
+        let text = document_to_json_string(&document);
+        assert!(serde_json::from_str::<serde_json::Value>(&text).is_ok());
+        assert_eq!(crate::bson::parse_document_from_json(&text).unwrap(), document);
+    }
 }

--- a/src/components/action_bar/providers.rs
+++ b/src/components/action_bar/providers.rs
@@ -358,30 +358,28 @@ pub fn command_actions(state: &AppState, window: &Window) -> Vec<ActionItem> {
             id: SharedString::from("cmd:download-update"),
             label: SharedString::from("Download Update"),
             detail: match &state.update_status {
-                UpdateStatus::Available { version, .. } => {
-                    Some(SharedString::from(format!("v{version}")))
-                }
+                UpdateStatus::Available(release) => Some(SharedString::from(release.label())),
                 _ => None,
             },
             category: ActionCategory::Command,
-            available: matches!(state.update_status, UpdateStatus::Available { .. }),
+            available: matches!(state.update_status, UpdateStatus::Available(_)),
             priority: -10,
-            highlighted: matches!(state.update_status, UpdateStatus::Available { .. }),
+            highlighted: matches!(state.update_status, UpdateStatus::Available(_)),
             ..Default::default()
         },
         ActionItem {
             id: SharedString::from("cmd:install-update"),
             label: SharedString::from("Restart to Update"),
             detail: match &state.update_status {
-                UpdateStatus::ReadyToInstall { version, .. } => {
-                    Some(SharedString::from(format!("v{version}")))
+                UpdateStatus::ReadyToInstall(download) => {
+                    Some(SharedString::from(download.release.label()))
                 }
                 _ => None,
             },
             category: ActionCategory::Command,
-            available: matches!(state.update_status, UpdateStatus::ReadyToInstall { .. }),
+            available: matches!(state.update_status, UpdateStatus::ReadyToInstall(_)),
             priority: -20,
-            highlighted: matches!(state.update_status, UpdateStatus::ReadyToInstall { .. }),
+            highlighted: matches!(state.update_status, UpdateStatus::ReadyToInstall(_)),
             ..Default::default()
         },
         ActionItem {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -38,6 +38,7 @@ pub mod form_field;
 pub mod query_library;
 mod status_bar;
 mod unsaved_guard;
+pub mod updater;
 pub(crate) use confirm::with_scoped_production_authorizations;
 pub use confirm::{WriteConfirmation, WriteRequest, open_confirm_dialog, request_connection_write};
 pub use connection_dialog::ConnectionDialog;

--- a/src/components/status_bar/right.rs
+++ b/src/components/status_bar/right.rs
@@ -1,11 +1,12 @@
 use gpui_kit::component::ActiveTheme as _;
+use gpui_kit::component::button::ButtonVariants as _;
 use gpui_kit::component::tooltip::Tooltip;
 use gpui_kit::component::{Icon, IconName, Sizable as _};
 use gpui_kit::prelude::FluentBuilder as _;
 use gpui_kit::*;
 
 use crate::state::app_state::updater::UpdateStatus;
-use crate::state::{AppCommands, AppState, StatusLevel, StatusMessage};
+use crate::state::{AppState, StatusLevel, StatusMessage};
 
 pub(crate) fn render_status_right(
     status_message: Option<StatusMessage>,
@@ -17,67 +18,25 @@ pub(crate) fn render_status_right(
 ) -> AnyElement {
     let state_for_ai = state.clone();
     let inner = match &update_status {
-        UpdateStatus::Available { version, .. } => div()
-            .id("update-available")
-            .cursor_pointer()
-            .text_xs()
-            .text_color(cx.theme().primary)
-            .child(format!("v{version} available \u{2193}"))
-            .on_click(move |_, _window, cx| {
-                AppCommands::download_update(state.clone(), cx);
+        UpdateStatus::Idle | UpdateStatus::UpToDate { .. } | UpdateStatus::Unavailable(_) => {
+            let label = status_message
+                .filter(|message| matches!(message.level, StatusLevel::Info))
+                .map(|message| message.text)
+                .unwrap_or_else(|| format!("v{}", env!("CARGO_PKG_VERSION")));
+            div().text_xs().text_color(cx.theme().muted_foreground).child(label).into_any_element()
+        }
+        _ => crate::components::Button::new("software-update-status")
+            .ghost()
+            .xsmall()
+            .label(crate::components::updater::status_label(&update_status))
+            .tooltip("View software update details")
+            .when(matches!(update_status, UpdateStatus::Failed { .. }), |button| {
+                button.text_color(cx.theme().danger)
+            })
+            .on_click(move |_, window, cx| {
+                crate::components::updater::open_updates(state.clone(), window, cx)
             })
             .into_any_element(),
-        UpdateStatus::Downloading { progress_pct, .. } => div()
-            .text_xs()
-            .text_color(cx.theme().secondary_foreground)
-            .child(format!("Updating\u{2026} {progress_pct}%"))
-            .into_any_element(),
-        UpdateStatus::ReadyToInstall { .. } => div()
-            .id("update-restart")
-            .cursor_pointer()
-            .text_xs()
-            .text_color(cx.theme().primary)
-            .child("Restart to update \u{21BB}")
-            .on_click(move |_, _window, cx| {
-                AppCommands::install_update(state.clone(), cx);
-            })
-            .into_any_element(),
-        UpdateStatus::Failed(error) => {
-            let details = error.clone();
-            div()
-                .id("update-check-retry")
-                .cursor_pointer()
-                .text_xs()
-                .text_color(cx.theme().danger)
-                .child("Update check failed · Retry")
-                .tooltip(move |window, cx| Tooltip::new(details.clone()).build(window, cx))
-                .on_click(move |_, _window, cx| {
-                    AppCommands::check_for_updates(state.clone(), cx);
-                })
-                .into_any_element()
-        }
-        _ => {
-            // Idle or Checking — show status message or version
-            match status_message {
-                Some(message) => match message.level {
-                    StatusLevel::Info => div()
-                        .text_xs()
-                        .text_color(cx.theme().secondary_foreground)
-                        .child(message.text)
-                        .into_any_element(),
-                    StatusLevel::Error => div()
-                        .text_xs()
-                        .text_color(cx.theme().muted_foreground)
-                        .child(format!("v{}", env!("CARGO_PKG_VERSION")))
-                        .into_any_element(),
-                },
-                None => div()
-                    .text_xs()
-                    .text_color(cx.theme().muted_foreground)
-                    .child(format!("v{}", env!("CARGO_PKG_VERSION")))
-                    .into_any_element(),
-            }
-        }
     };
 
     let ai_icon_color =

--- a/src/components/updater.rs
+++ b/src/components/updater.rs
@@ -1,0 +1,255 @@
+use gpui_kit::component::alert::Alert;
+use gpui_kit::component::button::ButtonVariants as _;
+use gpui_kit::component::dialog::Dialog;
+use gpui_kit::component::menu::{DropdownMenu as _, PopupMenuItem};
+use gpui_kit::component::progress::Progress;
+use gpui_kit::component::spinner::Spinner;
+use gpui_kit::component::{ActiveTheme as _, Disableable as _, Sizable as _, WindowExt as _};
+use gpui_kit::prelude::FluentBuilder as _;
+use gpui_kit::*;
+
+use crate::state::app_state::updater::{RELEASES_URL, UpdateChannel, UpdateStage, UpdateStatus};
+use crate::state::{AppCommands, AppState};
+use crate::theme::spacing;
+
+use super::Button;
+
+pub fn status_label(status: &UpdateStatus) -> String {
+    match status {
+        UpdateStatus::Idle => "Software Update".into(),
+        UpdateStatus::Checking => "Checking for updates…".into(),
+        UpdateStatus::UpToDate { channel } => {
+            format!("No {} update available", channel.label().to_lowercase())
+        }
+        UpdateStatus::Unavailable(_) => "Manual update available".into(),
+        UpdateStatus::Available(release) => format!("{} available", release.label()),
+        UpdateStatus::Downloading { .. } => status
+            .progress_pct()
+            .map(|pct| format!("Downloading update · {pct:.0}%"))
+            .unwrap_or_else(|| "Downloading update…".into()),
+        UpdateStatus::Verifying(_) => "Verifying update…".into(),
+        UpdateStatus::ReadyToInstall(_) => "Update verified · Restart".into(),
+        UpdateStatus::Installing(_) => "Preparing installation…".into(),
+        UpdateStatus::Failed { .. } => "Update failed · Details".into(),
+    }
+}
+
+pub fn channel_picker(
+    id: impl Into<ElementId>,
+    state: Entity<AppState>,
+    cx: &App,
+) -> impl IntoElement {
+    let channel = state.read(cx).settings.update_channel;
+    let disabled =
+        state.read(cx).update_status.is_busy() || state.read(cx).unsaved_guard_is_active();
+    Button::new(id)
+        .small()
+        .label(channel.label())
+        .dropdown_caret(true)
+        .disabled(disabled)
+        .dropdown_menu(move |mut menu, _, _| {
+            for option in [UpdateChannel::Stable, UpdateChannel::Nightly] {
+                let state = state.clone();
+                menu = menu.item(
+                    PopupMenuItem::new(option.label()).checked(option == channel).on_click(
+                        move |_, _, cx| AppCommands::set_update_channel(state.clone(), option, cx),
+                    ),
+                );
+            }
+            menu
+        })
+}
+
+pub fn open_updates(state: Entity<AppState>, window: &mut Window, cx: &mut App) {
+    let panel = cx.new(|cx| UpdatePanel::new(state, cx));
+    window.open_dialog(cx, move |dialog: Dialog, _, _| {
+        dialog.title("Software Update").w(px(500.0)).child(panel.clone())
+    });
+}
+
+struct UpdatePanel {
+    state: Entity<AppState>,
+    _subscription: Subscription,
+}
+
+impl UpdatePanel {
+    fn new(state: Entity<AppState>, cx: &mut Context<Self>) -> Self {
+        let subscription = cx.observe(&state, |_, _, cx| cx.notify());
+        Self { state, _subscription: subscription }
+    }
+}
+
+impl Render for UpdatePanel {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let state = self.state.clone();
+        let status = state.read(cx).update_status.clone();
+        let channel = state.read(cx).settings.update_channel;
+        let release = status.release();
+        let notes_url = release
+            .as_ref()
+            .map(|release| release.release_url.clone())
+            .unwrap_or_else(|| RELEASES_URL.into());
+        let mut body = div()
+            .flex()
+            .flex_col()
+            .gap(spacing::md())
+            .min_w(px(0.0))
+            .child(div().text_sm().text_color(cx.theme().muted_foreground).child(format!(
+                "Installed: {} v{} · {}",
+                UpdateChannel::default().label(),
+                env!("CARGO_PKG_VERSION"),
+                env!("OPENMANGO_GIT_SHA").get(..7).unwrap_or("development"),
+            )))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .child("Update channel")
+                    .child(channel_picker("update-dialog-channel", state.clone(), cx)),
+            )
+            .when(channel == UpdateChannel::Nightly, |view| {
+                view.child(
+                    div()
+                        .text_xs()
+                        .text_color(cx.theme().muted_foreground)
+                        .child("Nightly includes unreleased changes and may be less stable."),
+                )
+            });
+
+        let title = match &status {
+            UpdateStatus::Failed { stage, .. } => match stage {
+                UpdateStage::Check => "Could not check for updates".into(),
+                UpdateStage::Download => "Download did not finish".into(),
+                UpdateStage::Verify => "Update could not be verified".into(),
+                UpdateStage::Install => "Update could not be installed".into(),
+            },
+            _ => status_label(&status),
+        };
+        body = body.child(
+            div()
+                .flex()
+                .items_center()
+                .gap(spacing::sm())
+                .when(status.is_busy(), |row| row.child(Spinner::new().small()))
+                .child(div().text_sm().font_weight(FontWeight::MEDIUM).child(title)),
+        );
+        if let Some(release) = &release {
+            body = body.child(
+                div().text_xs().text_color(cx.theme().muted_foreground).child(release.label()),
+            );
+        }
+        match &status {
+            UpdateStatus::Downloading { received, total, .. } => {
+                body = body
+                    .child(
+                        Progress::new("update-download-progress")
+                            .accessibility_label("Update download progress")
+                            .loading(*total == 0)
+                            .value(status.progress_pct().unwrap_or(0.)),
+                    )
+                    .child(div().text_xs().text_color(cx.theme().muted_foreground).child(format!(
+                        "{:.1} MB of {:.1} MB",
+                        *received as f64 / 1_048_576.,
+                        *total as f64 / 1_048_576.
+                    )));
+            }
+            UpdateStatus::Verifying(_) => {
+                body = body.child(div().text_sm().child(
+                    "The download is complete. Checking its size and SHA-256 before installation.",
+                ));
+            }
+            UpdateStatus::ReadyToInstall(_) => {
+                body = body.child(div().text_sm().child("The download is verified. You can finish your work now and restart when ready."));
+            }
+            UpdateStatus::Installing(_) => {
+                body = body.child(div().text_sm().child("Extracting and checking the app signature. Your installed application has not been replaced."));
+            }
+            UpdateStatus::Failed { message, .. } => {
+                body = body.child(Alert::error("update-error", message.clone()));
+            }
+            UpdateStatus::Unavailable(message) => {
+                body = body.child(div().text_sm().child(message.clone()))
+            }
+            _ => {}
+        }
+        let mut actions = div().flex().items_center().justify_end().gap(spacing::sm());
+        match &status {
+            UpdateStatus::Idle | UpdateStatus::UpToDate { .. } => {
+                let state = state.clone();
+                actions = actions.child(
+                    Button::new("update-check").primary().label("Check again").on_click(
+                        move |_, _, cx| AppCommands::check_for_updates(state.clone(), cx),
+                    ),
+                );
+            }
+            UpdateStatus::Available(_) => {
+                let state = state.clone();
+                actions = actions.child(
+                    Button::new("update-download")
+                        .primary()
+                        .label("Download update")
+                        .on_click(move |_, _, cx| AppCommands::download_update(state.clone(), cx)),
+                );
+            }
+            UpdateStatus::ReadyToInstall(_) => {
+                let state = state.clone();
+                actions = actions.child(
+                    Button::new("update-install")
+                        .primary()
+                        .label("Restart and install")
+                        .on_click(move |_, _, cx| AppCommands::install_update(state.clone(), cx)),
+                );
+            }
+            UpdateStatus::Failed { stage, downloaded, .. } => {
+                let label = if *stage == UpdateStage::Install
+                    && downloaded.as_ref().is_some_and(|download| download.archive.is_file())
+                {
+                    "Retry installation"
+                } else {
+                    "Check and retry"
+                };
+                let state = state.clone();
+                actions = actions.child(
+                    Button::new("update-retry")
+                        .primary()
+                        .label(label)
+                        .on_click(move |_, _, cx| AppCommands::retry_update(state.clone(), cx)),
+                );
+            }
+            UpdateStatus::Checking
+            | UpdateStatus::Downloading { .. }
+            | UpdateStatus::Verifying(_) => {
+                let state = state.clone();
+                actions = actions.child(
+                    Button::new("update-cancel")
+                        .label("Cancel")
+                        .on_click(move |_, _, cx| AppCommands::cancel_update(state.clone(), cx)),
+                );
+            }
+            _ => {}
+        }
+        body.child(
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap(spacing::sm())
+                .child(
+                    Button::new("update-notes")
+                        .ghost()
+                        .label("Release notes")
+                        .on_click(move |_, _, cx| cx.open_url(&notes_url)),
+                )
+                .child(actions),
+        )
+        .child(
+            div().flex().justify_end().child(
+                Button::new("close-updates")
+                    .ghost()
+                    .label("Close")
+                    .on_click(|_, window, cx| window.close_dialog(cx)),
+            ),
+        )
+    }
+}

--- a/src/helpers/support.rs
+++ b/src/helpers/support.rs
@@ -62,6 +62,7 @@ pub fn export_support_bundle(state: &AppState, destination: &Path) -> anyhow::Re
     writeln!(contents, "Architecture: {}", std::env::consts::ARCH)?;
     writeln!(contents, "Log location: {}", app_log_path().display())?;
     writeln!(contents, "Auto update: {}", state.settings.auto_update)?;
+    writeln!(contents, "Update channel: {}", state.settings.update_channel.label())?;
     writeln!(contents, "AI enabled: {}", state.settings.ai.enabled)?;
     writeln!(contents, "AI provider: {}", state.settings.ai.provider.label())?;
     writeln!(contents, "AI model: {}", state.settings.ai.model)?;

--- a/src/state/app_state/mod.rs
+++ b/src/state/app_state/mod.rs
@@ -140,6 +140,8 @@ pub struct AppState {
 
     // Auto-update
     pub update_status: UpdateStatus,
+    pub(crate) update_request_id: u64,
+    pub(crate) update_task: Option<tokio::task::AbortHandle>,
 
     // Lightweight file export progress (Save As)
     export_progress: Option<crate::state::commands::ExportProgress>,
@@ -259,6 +261,8 @@ impl AppState {
             changelog_pending: false,
             aggregation_workspace_save_gen,
             update_status: UpdateStatus::Idle,
+            update_request_id: 0,
+            update_task: None,
             export_progress: None,
             editor_sessions: EditorSessionStore::default(),
         }

--- a/src/state/app_state/updater.rs
+++ b/src/state/app_state/updater.rs
@@ -1,12 +1,125 @@
-use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+pub const RELEASES_URL: &str = "https://github.com/ggagosh/openmango/releases";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateChannel {
+    Stable,
+    Nightly,
+}
+
+impl Default for UpdateChannel {
+    fn default() -> Self {
+        if option_env!("OPENMANGO_RELEASE_CHANNEL").is_some_and(|channel| channel == "nightly") {
+            Self::Nightly
+        } else {
+            Self::Stable
+        }
+    }
+}
+
+impl UpdateChannel {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Stable => "Stable",
+            Self::Nightly => "Nightly",
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
+pub struct UpdateRelease {
+    pub channel: UpdateChannel,
+    pub version: String,
+    pub release_url: String,
+    pub download_url: String,
+    pub checksum_url: Option<String>,
+    pub sha256: Option<String>,
+    pub size: u64,
+}
+
+impl UpdateRelease {
+    pub fn label(&self) -> String {
+        match self.channel {
+            UpdateChannel::Stable => format!("Stable v{}", self.version),
+            UpdateChannel::Nightly => format!("Nightly {}", self.version),
+        }
+    }
+}
+
+/// The verified file remains owned until installation or cancellation finishes.
+#[derive(Debug)]
+pub struct DownloadedUpdate {
+    pub release: Arc<UpdateRelease>,
+    pub archive: tempfile::TempPath,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateStage {
+    Check,
+    Download,
+    Verify,
+    Install,
+}
+
+#[derive(Debug, Clone)]
 pub enum UpdateStatus {
     Idle,
     Checking,
-    Available { version: String, download_url: String, checksum_url: String },
-    Downloading { version: String, progress_pct: u8 },
-    ReadyToInstall { version: String, zip_path: PathBuf },
-    Failed(String),
+    UpToDate {
+        channel: UpdateChannel,
+    },
+    Unavailable(String),
+    Available(Arc<UpdateRelease>),
+    Downloading {
+        release: Arc<UpdateRelease>,
+        received: u64,
+        total: u64,
+    },
+    Verifying(Arc<UpdateRelease>),
+    ReadyToInstall(Arc<DownloadedUpdate>),
+    Installing(Arc<UpdateRelease>),
+    Failed {
+        stage: UpdateStage,
+        message: String,
+        release: Option<Arc<UpdateRelease>>,
+        downloaded: Option<Arc<DownloadedUpdate>>,
+    },
+}
+
+impl UpdateStatus {
+    pub fn is_busy(&self) -> bool {
+        matches!(
+            self,
+            Self::Checking | Self::Downloading { .. } | Self::Verifying(_) | Self::Installing(_)
+        )
+    }
+
+    pub fn can_check(&self) -> bool {
+        !self.is_busy() && !matches!(self, Self::ReadyToInstall(_) | Self::Unavailable(_))
+    }
+
+    pub fn release(&self) -> Option<Arc<UpdateRelease>> {
+        match self {
+            Self::Available(release)
+            | Self::Verifying(release)
+            | Self::Installing(release)
+            | Self::Downloading { release, .. } => Some(release.clone()),
+            Self::ReadyToInstall(download) => Some(download.release.clone()),
+            Self::Failed { release, .. } => release.clone(),
+            _ => None,
+        }
+    }
+
+    pub fn progress_pct(&self) -> Option<f32> {
+        match self {
+            Self::Downloading { received, total, .. } if *total > 0 => {
+                Some(((*received as f64 / *total as f64) * 100.).min(99.) as f32)
+            }
+            _ => None,
+        }
+    }
 }

--- a/src/state/commands/updater.rs
+++ b/src/state/commands/updater.rs
@@ -1,635 +1,321 @@
-use std::path::PathBuf;
-use std::process::Command;
+mod download;
+mod install;
+mod release;
 
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use futures::StreamExt as _;
 use gpui_kit::{App, AppContext as _, Entity};
 
 use crate::components::request_unsaved_action;
-use crate::state::app_state::updater::UpdateStatus;
-use crate::state::events::AppEvent;
-use crate::state::{AppState, UnsavedScope};
+use crate::state::app_state::updater::{UpdateChannel, UpdateStage, UpdateStatus};
+use crate::state::{AppEvent, AppState, UnsavedScope};
 
 use super::AppCommands;
 
-#[cfg(target_arch = "aarch64")]
-const ARCH_SUFFIX: &str = "macos-arm64";
-#[cfg(target_arch = "x86_64")]
-const ARCH_SUFFIX: &str = "macos-x86_64";
-
-const GITHUB_API: &str = "https://api.github.com/repos/ggagosh/openmango/releases";
-
-/// Result of checking a single release channel.
-struct ReleaseCandidate {
-    version: String,
-    download_url: String,
-    checksum_url: String,
-}
-
-/// Find the arch-matching zip asset from a release JSON.
-fn find_release_candidate(
-    release: &serde_json::Value,
-    version: String,
-) -> Option<ReleaseCandidate> {
-    let assets = release["assets"].as_array()?;
-    let zip = assets.iter().find(|asset| {
-        asset["name"]
-            .as_str()
-            .is_some_and(|name| name.contains(ARCH_SUFFIX) && name.ends_with(".zip"))
-    })?;
-    let zip_name = zip["name"].as_str()?;
-    let checksum_name = format!("{zip_name}.sha256");
-    let checksum = assets.iter().find(|asset| asset["name"].as_str() == Some(&checksum_name))?;
-    Some(ReleaseCandidate {
-        version,
-        download_url: zip["browser_download_url"].as_str()?.to_string(),
-        checksum_url: checksum["browser_download_url"].as_str()?.to_string(),
+fn begin(state: &Entity<AppState>, status: UpdateStatus, cx: &mut App) -> u64 {
+    state.update(cx, |state, cx| {
+        if let Some(task) = state.update_task.take() {
+            task.abort();
+        }
+        state.update_request_id = state.update_request_id.wrapping_add(1);
+        state.update_status = status;
+        cx.notify();
+        state.update_request_id
     })
 }
 
-/// Extract the commit SHA from a nightly release body.
-/// Body format: "...**Commit:** abc123def..."
-fn parse_sha256_checksum(body: &str) -> Result<String, anyhow::Error> {
-    let checksum =
-        body.split_whitespace().next().ok_or_else(|| anyhow::anyhow!("Checksum asset is empty"))?;
-    if checksum.len() != 64 || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        anyhow::bail!("Checksum asset does not contain a valid SHA-256 digest");
-    }
-    Ok(checksum.to_ascii_lowercase())
-}
-
-fn parse_nightly_sha(body: &str) -> Option<&str> {
-    let marker = "**Commit:** ";
-    let start = body.find(marker)? + marker.len();
-    let rest = &body[start..];
-    // SHA is the next word (up to whitespace or end)
-    let end = rest.find(|c: char| c.is_whitespace()).unwrap_or(rest.len());
-    let sha = &rest[..end];
-    if sha.len() >= 7 { Some(sha) } else { None }
-}
-
 impl AppCommands {
-    /// Check GitHub for a newer release (stable or nightly). Runs silently on startup.
+    pub fn automatic_updates_supported() -> bool {
+        install::running_bundle().is_ok()
+    }
+
     pub fn check_for_updates(state: Entity<AppState>, cx: &mut App) {
+        Self::check_updates(state, false, cx);
+    }
+
+    fn check_updates(state: Entity<AppState>, download_after_check: bool, cx: &mut App) {
+        if !state.read(cx).update_status.can_check() {
+            return;
+        }
+        if let Err(error) = install::running_bundle() {
+            state.update(cx, |state, cx| {
+                state.update_status = UpdateStatus::Unavailable(error.to_string());
+                cx.notify();
+            });
+            return;
+        }
+        let channel = state.read(cx).settings.update_channel;
+        let request = begin(&state, UpdateStatus::Checking, cx);
+        let runtime = state.read(cx).connection_manager().runtime_handle();
+        let sha = std::env::var("OPENMANGO_TEST_SHA")
+            .unwrap_or_else(|_| env!("OPENMANGO_GIT_SHA").to_string());
+        let task = runtime.spawn(async move {
+            release::check(channel, UpdateChannel::default(), env!("CARGO_PKG_VERSION"), &sha).await
+        });
+        state.update(cx, |state, _| state.update_task = Some(task.abort_handle()));
+        cx.spawn(async move |cx: &mut gpui_kit::AsyncApp| {
+            let result = task
+                .await
+                .context("The update check stopped unexpectedly")
+                .and_then(|result| result);
+            cx.update(|cx| {
+                if state.read(cx).update_request_id != request {
+                    return;
+                }
+                let mut should_download = false;
+                state.update(cx, |state, cx| {
+                    state.update_task = None;
+                    match result {
+                        Ok(Some(release)) => {
+                            let label = release.label();
+                            state.update_status = UpdateStatus::Available(release);
+                            should_download = state.settings.auto_update || download_after_check;
+                            let event = AppEvent::UpdateAvailable { version: label };
+                            cx.emit(event);
+                        }
+                        Ok(None) => state.update_status = UpdateStatus::UpToDate { channel },
+                        Err(error) => {
+                            log::warn!("Update check failed: {error:#}");
+                            state.update_status = UpdateStatus::Failed {
+                                stage: UpdateStage::Check,
+                                message: format!("{error:#}"),
+                                release: None,
+                                downloaded: None,
+                            };
+                        }
+                    }
+                    cx.notify();
+                });
+                if should_download {
+                    Self::download_update(state.clone(), cx);
+                }
+            });
+        })
+        .detach();
+    }
+
+    pub fn set_update_channel(state: Entity<AppState>, channel: UpdateChannel, cx: &mut App) {
+        if state.read(cx).update_status.is_busy() || state.read(cx).unsaved_guard_is_active() {
+            return;
+        }
+        if state.read(cx).settings.update_channel == channel {
+            return;
+        }
         state.update(cx, |state, cx| {
-            state.update_status = UpdateStatus::Checking;
+            state.settings.update_channel = channel;
+            state.save_settings();
+            state.update_request_id = state.update_request_id.wrapping_add(1);
+            state.update_status = UpdateStatus::Idle;
             cx.notify();
         });
+        Self::check_for_updates(state, cx);
+    }
 
-        let current_version = env!("CARGO_PKG_VERSION").to_string();
-        // Allow runtime override for testing: OPENMANGO_TEST_SHA=fake just dev
-        let current_sha = std::env::var("OPENMANGO_TEST_SHA")
-            .unwrap_or_else(|_| env!("OPENMANGO_GIT_SHA").to_string());
+    pub fn cancel_update(state: Entity<AppState>, cx: &mut App) {
+        if matches!(state.read(cx).update_status, UpdateStatus::Installing(_)) {
+            return;
+        }
+        let release = state.read(cx).update_status.release();
+        begin(&state, release.map(UpdateStatus::Available).unwrap_or(UpdateStatus::Idle), cx);
+    }
 
-        log::info!(
-            "Update check: version={current_version}, sha={}, arch={ARCH_SUFFIX}",
-            &current_sha[..7.min(current_sha.len())]
+    pub fn retry_update(state: Entity<AppState>, cx: &mut App) {
+        let status = state.read(cx).update_status.clone();
+        match status {
+            UpdateStatus::Failed { downloaded: Some(download), .. }
+                if download.archive.is_file() =>
+            {
+                state.update(cx, |state, cx| {
+                    state.update_status = UpdateStatus::ReadyToInstall(download);
+                    cx.notify();
+                });
+                Self::install_update(state, cx);
+            }
+            // Refresh release metadata: a nightly may have been replaced since the failure.
+            UpdateStatus::Failed { stage, .. } => {
+                state.update(cx, |state, _| state.update_status = UpdateStatus::Idle);
+                Self::check_updates(state, stage != UpdateStage::Check, cx);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn download_update(state: Entity<AppState>, cx: &mut App) {
+        let UpdateStatus::Available(release) = state.read(cx).update_status.clone() else {
+            return;
+        };
+        let request = begin(
+            &state,
+            UpdateStatus::Downloading {
+                release: release.clone(),
+                received: 0,
+                total: release.size,
+            },
+            cx,
         );
-
-        // GPUI uses smol, but reqwest/hyper needs Tokio — spin up a one-shot runtime
-        let task = cx.background_spawn(async move {
-            tokio::runtime::Builder::new_current_thread().enable_all().build()?.block_on(async {
-                let client = reqwest::Client::builder()
-                    .user_agent(format!("OpenMango/{current_version}"))
-                    .build()?;
-
-                // Check both channels in parallel
-                let (stable_resp, nightly_resp) = futures::join!(
-                    client.get(format!("{GITHUB_API}/latest")).send(),
-                    client.get(format!("{GITHUB_API}/tags/nightly")).send(),
-                );
-
-                // --- Stable channel ---
-                let stable_response = stable_resp?.error_for_status()?;
-                let stable_json: serde_json::Value = stable_response.json().await?;
-                let tag = stable_json["tag_name"].as_str().unwrap_or_default();
-                let version_str = tag.strip_prefix('v').unwrap_or(tag);
-                let remote: semver::Version =
-                    version_str.parse().ok().unwrap_or(semver::Version::new(0, 0, 0));
-                let local: semver::Version = current_version.parse()?;
-                let stable = if remote > local {
-                    Some(find_release_candidate(&stable_json, version_str.to_string()).ok_or_else(
-                        || anyhow::anyhow!("Release is missing its SHA-256 checksum asset"),
-                    )?)
-                } else {
-                    None
-                };
-
-                // If there's a newer stable release, always prefer it
-                if let Some(stable) = stable {
-                    log::info!("Update found: stable v{}", stable.version);
-                    return Ok::<Option<(String, String, String)>, anyhow::Error>(Some((
-                        stable.version,
-                        stable.download_url,
-                        stable.checksum_url,
-                    )));
-                }
-
-                // --- Nightly channel ---
-                // Only check nightly if we have a build SHA.
-                if !current_sha.is_empty() {
-                    let response = nightly_resp?.error_for_status()?;
-                    let json: serde_json::Value = response.json().await?;
-                    let body = json["body"].as_str().unwrap_or_default();
-                    if let Some(remote_sha) = parse_nightly_sha(body) {
-                        log::info!(
-                            "Nightly check: local={}, remote={}",
-                            &current_sha[..7.min(current_sha.len())],
-                            &remote_sha[..7.min(remote_sha.len())]
-                        );
-                        if remote_sha != current_sha {
-                            let short_sha = &remote_sha[..7.min(remote_sha.len())];
-                            let candidate =
-                                find_release_candidate(&json, format!("nightly ({short_sha})"))
-                                    .ok_or_else(|| {
-                                        anyhow::anyhow!(
-                                            "Nightly release is missing its SHA-256 checksum asset"
-                                        )
-                                    })?;
-                            log::info!("Update found: nightly ({short_sha})");
-                            return Ok(Some((
-                                candidate.version,
-                                candidate.download_url,
-                                candidate.checksum_url,
-                            )));
-                        }
-                    }
-                }
-
-                Ok(None)
-            })
+        let (sender, mut receiver) = futures::channel::mpsc::unbounded();
+        let runtime = state.read(cx).connection_manager().runtime_handle();
+        let release_for_task = release.clone();
+        let task = runtime.spawn(async move {
+            let result = download::download(release_for_task, sender.clone()).await;
+            let _ = sender.unbounded_send(download::Progress::Finished(result));
         });
+        state.update(cx, |state, _| state.update_task = Some(task.abort_handle()));
+        cx.spawn(async move |cx: &mut gpui_kit::AsyncApp| {
+            let mut finished = false;
+            // Progress and completion share one ordered stream; late progress cannot undo Ready.
+            while let Some(progress) = receiver.next().await {
+                if matches!(&progress, download::Progress::Finished(_)) {
+                    finished = true;
+                }
+                cx.update(|cx| {
+                    if state.read(cx).update_request_id != request {
+                        return;
+                    }
+                    state.update(cx, |state, cx| {
+                        match progress {
+                            download::Progress::Downloading { received, total } => {
+                                state.update_status = UpdateStatus::Downloading {
+                                    release: release.clone(),
+                                    received,
+                                    total,
+                                };
+                            }
+                            download::Progress::Verifying => {
+                                state.update_status = UpdateStatus::Verifying(release.clone())
+                            }
+                            download::Progress::Finished(result) => {
+                                state.update_task = None;
+                                let stage =
+                                    if matches!(state.update_status, UpdateStatus::Verifying(_)) {
+                                        UpdateStage::Verify
+                                    } else {
+                                        UpdateStage::Download
+                                    };
+                                state.update_status = match result {
+                                    Ok(download) => {
+                                        UpdateStatus::ReadyToInstall(Arc::new(download))
+                                    }
+                                    Err(error) => {
+                                        log::error!("Update {stage:?} failed: {error:#}");
+                                        UpdateStatus::Failed {
+                                            stage,
+                                            message: format!("{error:#}"),
+                                            release: Some(release.clone()),
+                                            downloaded: None,
+                                        }
+                                    }
+                                };
+                            }
+                        }
+                        cx.notify();
+                    });
+                });
+            }
+            let result = task.await;
+            if !finished {
+                cx.update(|cx| {
+                    if state.read(cx).update_request_id != request {
+                        return;
+                    }
+                    state.update(cx, |state, cx| {
+                        state.update_task = None;
+                        state.update_status = UpdateStatus::Failed {
+                            stage: UpdateStage::Download,
+                            message: result
+                                .err()
+                                .map(|error| format!("The update download stopped: {error}"))
+                                .unwrap_or_else(|| {
+                                    "The update download ended without a verified file.".into()
+                                }),
+                            release: Some(release),
+                            downloaded: None,
+                        };
+                        cx.notify();
+                    });
+                });
+            }
+        })
+        .detach();
+    }
 
-        cx.spawn({
-            let state = state.clone();
-            async move |cx: &mut gpui_kit::AsyncApp| {
-                let result: Result<Option<(String, String, String)>, anyhow::Error> = task.await;
-                cx.update(|cx| match result {
-                    Ok(Some((version, download_url, checksum_url))) => {
+    pub fn install_update(state: Entity<AppState>, cx: &mut App) {
+        if state.read(cx).unsaved_guard_is_active() {
+            return;
+        }
+        let UpdateStatus::ReadyToInstall(download) = state.read(cx).update_status.clone() else {
+            return;
+        };
+        let request = begin(&state, UpdateStatus::Installing(download.release.clone()), cx);
+        let download_for_task = download.clone();
+        let task = cx.background_spawn(async move { install::prepare(&download_for_task.archive) });
+        cx.spawn(async move |cx: &mut gpui_kit::AsyncApp| {
+            let result = task.await;
+            cx.update(|cx| {
+                if state.read(cx).update_request_id != request {
+                    return;
+                }
+                match result {
+                    Ok(prepared) => {
+                        // Preparation has not touched the installed bundle. Cancel leaves it intact.
                         state.update(cx, |state, cx| {
-                            state.update_status = UpdateStatus::Available {
-                                version: version.clone(),
-                                download_url,
-                                checksum_url,
-                            };
-                            let event = AppEvent::UpdateAvailable { version };
-                            state.update_status_from_event(&event);
-                            cx.emit(event);
+                            state.update_status = UpdateStatus::ReadyToInstall(download.clone());
                             cx.notify();
                         });
-                        // Auto-download if enabled
-                        if state.read(cx).settings.auto_update {
-                            AppCommands::download_update(state.clone(), cx);
-                        }
-                    }
-                    Ok(None) => {
-                        state.update(cx, |state, cx| {
-                            state.update_status = UpdateStatus::Idle;
-                            cx.notify();
+                        let Some(handle) = cx.windows().into_iter().next() else {
+                            return;
+                        };
+                        let state_for_install = state.clone();
+                        let _ = handle.update(cx, move |_, window, cx| {
+                            request_unsaved_action(
+                                state.clone(),
+                                UnsavedScope::App,
+                                window,
+                                cx,
+                                move |_, cx| {
+                                    if state_for_install.read(cx).update_request_id != request {
+                                        return;
+                                    }
+                                    state_for_install.update(cx, |state, _| {
+                                        state.update_workspace_from_state();
+                                        state.flush_workspace_now();
+                                    });
+                                    match install::activate_and_restart(prepared) {
+                                        Ok(()) => cx.quit(),
+                                        Err(error) => {
+                                            log::error!("Update installation failed: {error:#}");
+                                            state_for_install.update(cx, |state, cx| {
+                                                state.update_status = UpdateStatus::Failed {
+                                                    stage: UpdateStage::Install,
+                                                    message: format!("{error:#}"),
+                                                    release: Some(download.release.clone()),
+                                                    downloaded: Some(download),
+                                                };
+                                                cx.notify();
+                                            });
+                                        }
+                                    }
+                                },
+                            );
                         });
                     }
                     Err(error) => {
-                        log::warn!("Update check failed: {error}");
+                        log::error!("Update preparation failed: {error:#}");
                         state.update(cx, |state, cx| {
-                            let message = error.to_string();
-                            state.update_status = UpdateStatus::Failed(message.clone());
-                            state.set_status_message(Some(crate::state::StatusMessage::error(
-                                format!("Update check failed: {message}"),
-                            )));
-                            cx.notify();
-                        });
-                    }
-                });
-            }
-        })
-        .detach();
-    }
-
-    /// Download the update zip with progress tracking.
-    pub fn download_update(state: Entity<AppState>, cx: &mut App) {
-        use futures::StreamExt as _;
-
-        let (version, download_url, checksum_url) = {
-            let s = state.read(cx);
-            match &s.update_status {
-                UpdateStatus::Available { version, download_url, checksum_url } => {
-                    (version.clone(), download_url.clone(), checksum_url.clone())
-                }
-                _ => return,
-            }
-        };
-
-        state.update(cx, |state, cx| {
-            state.update_status =
-                UpdateStatus::Downloading { version: version.clone(), progress_pct: 0 };
-            cx.notify();
-        });
-
-        let (progress_tx, mut progress_rx) = futures::channel::mpsc::unbounded::<u8>();
-
-        let download_url_clone = download_url.clone();
-        let checksum_url_clone = checksum_url.clone();
-        let task = cx.background_spawn({
-            let version = version.clone();
-            async move {
-                tokio::runtime::Builder::new_current_thread().enable_all().build()?.block_on(
-                    async {
-                        let client = reqwest::Client::builder()
-                            .user_agent(format!("OpenMango/{}", env!("CARGO_PKG_VERSION")))
-                            .build()?;
-
-                        let checksum_text = client
-                            .get(&checksum_url_clone)
-                            .send()
-                            .await?
-                            .error_for_status()?
-                            .text()
-                            .await?;
-                        let expected_checksum = parse_sha256_checksum(&checksum_text)?;
-                        let resp =
-                            client.get(&download_url_clone).send().await?.error_for_status()?;
-                        let total = resp.content_length().unwrap_or(0);
-
-                        // Download separately and promote only after checksum verification.
-                        let cache_dir = dirs::cache_dir()
-                            .unwrap_or_else(|| PathBuf::from("/tmp"))
-                            .join("com.openmango.app");
-                        std::fs::create_dir_all(&cache_dir)?;
-                        let zip_path = cache_dir.join("OpenMango-update.zip");
-                        let partial_path = cache_dir.join(".OpenMango-update.download");
-                        let _ = std::fs::remove_file(&partial_path);
-
-                        let mut stream = resp.bytes_stream();
-                        let mut file = std::fs::File::create(&partial_path)?;
-                        let mut hasher = sha2::Sha256::new();
-                        let mut downloaded: u64 = 0;
-                        let mut last_pct: u8 = 0;
-
-                        use sha2::Digest as _;
-                        use std::io::Write;
-                        while let Some(chunk) = stream.next().await {
-                            let chunk = chunk?;
-                            file.write_all(&chunk)?;
-                            hasher.update(&chunk);
-                            downloaded += chunk.len() as u64;
-                            let pct = match total {
-                                0 => {
-                                    // No Content-Length: estimate indeterminate progress
-                                    // Cap at 99 until we know it's truly done
-                                    99u8.min((downloaded / (1024 * 100)) as u8)
-                                }
-                                total => downloaded
-                                    .saturating_mul(100)
-                                    .checked_div(total)
-                                    .unwrap_or(100)
-                                    .min(100) as u8,
+                            state.update_status = UpdateStatus::Failed {
+                                stage: UpdateStage::Install,
+                                message: format!("{error:#}"),
+                                release: Some(download.release.clone()),
+                                downloaded: Some(download),
                             };
-                            if pct != last_pct {
-                                last_pct = pct;
-                                let _ = progress_tx.unbounded_send(pct);
-                            }
-                        }
-                        file.sync_all()?;
-                        let actual_checksum = format!("{:x}", hasher.finalize());
-                        if actual_checksum != expected_checksum {
-                            drop(file);
-                            let _ = std::fs::remove_file(&partial_path);
-                            anyhow::bail!(
-                                "Update checksum mismatch (expected {expected_checksum}, got {actual_checksum})"
-                            );
-                        }
-                        drop(file);
-                        let _ = std::fs::remove_file(&zip_path);
-                        std::fs::rename(&partial_path, &zip_path)?;
-
-                        Ok::<(PathBuf, String), anyhow::Error>((zip_path, version))
-                    },
-                )
-            }
-        });
-
-        // Forward progress updates to UI
-        cx.spawn({
-            let state = state.clone();
-            let version = version.clone();
-            async move |cx: &mut gpui_kit::AsyncApp| {
-                while let Some(pct) = progress_rx.next().await {
-                    let version = version.clone();
-                    cx.update(|cx| {
-                        state.update(cx, |state, cx| {
-                            state.update_status =
-                                UpdateStatus::Downloading { version, progress_pct: pct };
-                            cx.notify();
-                        });
-                    });
-                }
-            }
-        })
-        .detach();
-
-        cx.spawn({
-            let state = state.clone();
-            let version_for_err = version.clone();
-
-            async move |cx: &mut gpui_kit::AsyncApp| {
-                let result: Result<(PathBuf, String), anyhow::Error> = task.await;
-                cx.update(|cx| match result {
-                    Ok((zip_path, version)) => {
-                        state.update(cx, |state, cx| {
-                            state.update_status =
-                                UpdateStatus::ReadyToInstall { version, zip_path };
                             cx.notify();
                         });
                     }
-                    Err(e) => {
-                        log::error!("Update download failed: {e}");
-                        // Clean up partial download
-                        let cache_dir = dirs::cache_dir()
-                            .unwrap_or_else(|| PathBuf::from("/tmp"))
-                            .join("com.openmango.app");
-                        let _ = std::fs::remove_file(cache_dir.join(".OpenMango-update.download"));
-
-                        let version = version_for_err.clone();
-                        let url = download_url.clone();
-                        let checksum_url = checksum_url.clone();
-                        state.update(cx, |state, cx| {
-                            // Set back to Available so user can retry.
-                            state.update_status = UpdateStatus::Available {
-                                version,
-                                download_url: url,
-                                checksum_url,
-                            };
-                            state.set_status_message(Some(crate::state::StatusMessage::error(
-                                format!("Update failed: {e}"),
-                            )));
-                            cx.notify();
-                        });
-                    }
-                });
-            }
+                }
+            });
         })
         .detach();
-    }
-
-    /// Replace the running app bundle with the downloaded update and relaunch.
-    pub fn install_update(state: Entity<AppState>, cx: &mut App) {
-        let zip_path = {
-            let s = state.read(cx);
-            match &s.update_status {
-                UpdateStatus::ReadyToInstall { zip_path, .. } => zip_path.clone(),
-                _ => return,
-            }
-        };
-
-        // Determine target .app path:
-        // If running from .app bundle → replace in-place
-        // If running from cargo run → install to /Applications/
-        let app_bundle = match std::env::current_exe() {
-            Ok(exe) => match exe.parent().and_then(|p| p.parent()).and_then(|p| p.parent()) {
-                Some(bundle) if bundle.extension().is_some_and(|e| e == "app") => {
-                    bundle.to_path_buf()
-                }
-                _ => {
-                    log::info!("Not running from .app bundle, will install to /Applications/");
-                    PathBuf::from("/Applications/OpenMango.app")
-                }
-            },
-            Err(e) => {
-                log::error!("Cannot get current exe: {e}");
-                PathBuf::from("/Applications/OpenMango.app")
-            }
-        };
-
-        // Run extract + swap on a background thread to avoid blocking the UI
-        let task = cx.background_spawn({
-            let app_bundle = app_bundle.clone();
-            let zip_path = zip_path.clone();
-            async move { Self::do_install(&app_bundle, &zip_path) }
-        });
-
-        cx.spawn({
-            let state = state.clone();
-            let app_bundle = app_bundle.clone();
-            async move |cx: &mut gpui_kit::AsyncApp| {
-                let result: Result<(), anyhow::Error> = task.await;
-                match result {
-                    Ok(()) => {
-                        cx.update(|cx| {
-                            let Some(handle) = cx.windows().into_iter().next() else {
-                                return;
-                            };
-                            let state_for_quit = state.clone();
-                            let bundle = app_bundle.clone();
-                            let _ = handle.update(cx, |_root, window, cx| {
-                                request_unsaved_action(
-                                    state.clone(),
-                                    UnsavedScope::App,
-                                    window,
-                                    cx,
-                                    move |window, cx| {
-                                        state_for_quit.update(cx, |state, _| {
-                                            state.update_workspace_from_state();
-                                            state.flush_workspace_now();
-                                        });
-                                        let _ = Command::new("open").arg("-n").arg(&bundle).spawn();
-                                        let this_window = window.window_handle();
-                                        for handle in cx.windows() {
-                                            if handle != this_window {
-                                                let _ = handle.update(cx, |_, window, _cx| {
-                                                    window.remove_window();
-                                                });
-                                            }
-                                        }
-                                        cx.quit();
-                                    },
-                                );
-                            });
-                        });
-                    }
-                    Err(e) => {
-                        log::error!("Install failed: {e}");
-                        cx.update(|cx| {
-                            state.update(cx, |state, cx| {
-                                state.set_status_message(Some(crate::state::StatusMessage::error(
-                                    format!("Install failed: {e}"),
-                                )));
-                                cx.notify();
-                            });
-                        });
-                    }
-                }
-            }
-        })
-        .detach();
-    }
-
-    /// Extract zip, swap .app bundle, clean up. Runs on a background thread.
-    fn do_install(
-        app_bundle: &std::path::Path,
-        zip_path: &std::path::Path,
-    ) -> Result<(), anyhow::Error> {
-        let parent = app_bundle.parent().unwrap_or_else(|| std::path::Path::new("/tmp"));
-        let temp_dir = parent.join(".openmango-update-tmp");
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        std::fs::create_dir_all(&temp_dir)?;
-
-        // Extract the zip
-        let extract =
-            Command::new("ditto").args(["-x", "-k"]).arg(zip_path).arg(&temp_dir).output()?;
-
-        if !extract.status.success() {
-            let _ = std::fs::remove_dir_all(&temp_dir);
-            anyhow::bail!("ditto extraction failed: {}", String::from_utf8_lossy(&extract.stderr));
-        }
-
-        // Find the .app in the extracted directory
-        let extracted_app = std::fs::read_dir(&temp_dir)?.find_map(|e| {
-            let path = e.ok()?.path();
-            if path.extension().is_some_and(|ext| ext == "app") { Some(path) } else { None }
-        });
-
-        let Some(extracted_app) = extracted_app else {
-            let _ = std::fs::remove_dir_all(&temp_dir);
-            anyhow::bail!("No .app found in extracted update");
-        };
-        verify_app_code_signature(&extracted_app)?;
-
-        // If existing .app exists, back it up first
-        if app_bundle.exists() {
-            let backup = app_bundle.with_extension("app.bak");
-            let _ = std::fs::remove_dir_all(&backup);
-
-            let mv_backup = Command::new("mv").arg(app_bundle).arg(&backup).output()?;
-            if !mv_backup.status.success() {
-                let _ = std::fs::remove_dir_all(&temp_dir);
-                anyhow::bail!("Failed to move current app to backup");
-            }
-
-            let mv_new = Command::new("mv").arg(&extracted_app).arg(app_bundle).output()?;
-            if !mv_new.status.success() {
-                // Restore backup
-                let _ = Command::new("mv").arg(&backup).arg(app_bundle).output();
-                let _ = std::fs::remove_dir_all(&temp_dir);
-                anyhow::bail!("Failed to move extracted app into place");
-            }
-            if let Err(error) = verify_app_code_signature(app_bundle) {
-                let _ = std::fs::remove_dir_all(app_bundle);
-                let restore = Command::new("mv").arg(&backup).arg(app_bundle).output();
-                let _ = std::fs::remove_dir_all(&temp_dir);
-                match restore {
-                    Ok(output) if output.status.success() => {
-                        anyhow::bail!(
-                            "Installed app signature verification failed; the previous app was restored: {error}"
-                        )
-                    }
-                    Ok(output) => anyhow::bail!(
-                        "Installed app signature verification failed and restoration failed: {error}; {}",
-                        String::from_utf8_lossy(&output.stderr)
-                    ),
-                    Err(restore_error) => anyhow::bail!(
-                        "Installed app signature verification failed and restoration could not start: {error}; {restore_error}"
-                    ),
-                }
-            }
-
-            let _ = std::fs::remove_dir_all(&backup);
-        } else {
-            // Fresh install (e.g. first time from cargo run → /Applications/)
-            let mv_new = Command::new("mv").arg(&extracted_app).arg(app_bundle).output()?;
-            if !mv_new.status.success() {
-                let _ = std::fs::remove_dir_all(&temp_dir);
-                anyhow::bail!("Failed to move app to {}", app_bundle.display());
-            }
-            if let Err(error) = verify_app_code_signature(app_bundle) {
-                let _ = std::fs::remove_dir_all(app_bundle);
-                let _ = std::fs::remove_dir_all(&temp_dir);
-                anyhow::bail!("Installed app signature verification failed: {error}");
-            }
-        }
-
-        // Clean up
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        let _ = std::fs::remove_file(zip_path);
-
-        Ok(())
-    }
-}
-
-fn verify_app_code_signature(app_bundle: &std::path::Path) -> Result<(), anyhow::Error> {
-    #[cfg(target_os = "macos")]
-    {
-        let output = Command::new("/usr/bin/codesign")
-            .args(["--verify", "--deep", "--strict", "--verbose=2"])
-            .arg(app_bundle)
-            .output()?;
-        if !output.status.success() {
-            anyhow::bail!(
-                "Code signature verification failed for {}: {}",
-                app_bundle.display(),
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = app_bundle;
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_sha256_checksum_assets() {
-        let digest = "A".repeat(64);
-        assert_eq!(
-            parse_sha256_checksum(&format!("{digest}  OpenMango.zip\n")).unwrap(),
-            digest.to_ascii_lowercase()
-        );
-        assert!(parse_sha256_checksum("not-a-checksum").is_err());
-        assert!(parse_sha256_checksum(&"g".repeat(64)).is_err());
-    }
-
-    #[test]
-    fn release_candidate_requires_matching_checksum_asset() {
-        let release = serde_json::json!({
-            "assets": [
-                {
-                    "name": format!("OpenMango-1.2.3-{ARCH_SUFFIX}.zip"),
-                    "browser_download_url": "https://example.test/update.zip"
-                },
-                {
-                    "name": format!("OpenMango-1.2.3-{ARCH_SUFFIX}.zip.sha256"),
-                    "browser_download_url": "https://example.test/update.zip.sha256"
-                }
-            ]
-        });
-        let candidate = find_release_candidate(&release, "1.2.3".to_string()).unwrap();
-        assert_eq!(candidate.checksum_url, "https://example.test/update.zip.sha256");
-
-        let missing_checksum = serde_json::json!({
-            "assets": [{
-                "name": format!("OpenMango-1.2.3-{ARCH_SUFFIX}.zip"),
-                "browser_download_url": "https://example.test/update.zip"
-            }]
-        });
-        assert!(find_release_candidate(&missing_checksum, "1.2.3".to_string()).is_none());
-    }
-
-    #[test]
-    fn parse_nightly_sha_from_body() {
-        let body = "Automated nightly build from main branch.\n\n**Commit:** abc1234def5678\n\n> This is a development build.";
-        assert_eq!(parse_nightly_sha(body), Some("abc1234def5678"));
-    }
-
-    #[test]
-    fn parse_nightly_sha_missing() {
-        assert_eq!(parse_nightly_sha("no commit here"), None);
-    }
-
-    #[test]
-    fn parse_nightly_sha_too_short() {
-        let body = "**Commit:** abc";
-        assert_eq!(parse_nightly_sha(body), None);
     }
 }

--- a/src/state/commands/updater/download.rs
+++ b/src/state/commands/updater/download.rs
@@ -1,0 +1,123 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context as _, Result, ensure};
+use futures::{StreamExt as _, channel::mpsc::UnboundedSender};
+use sha2::{Digest as _, Sha256};
+use tokio::io::AsyncWriteExt as _;
+
+use crate::state::app_state::updater::{DownloadedUpdate, UpdateRelease};
+
+pub(super) enum Progress {
+    Downloading { received: u64, total: u64 },
+    Verifying,
+    Finished(Result<DownloadedUpdate>),
+}
+
+fn staging_file(cache: &Path) -> Result<tempfile::NamedTempFile> {
+    std::fs::create_dir_all(cache).context("Could not create the update download folder")?;
+    tempfile::Builder::new()
+        .prefix("OpenMango-update-")
+        .suffix(".zip")
+        .tempfile_in(cache)
+        .context("Could not create a temporary update file")
+}
+
+pub(super) async fn download(
+    release: Arc<UpdateRelease>,
+    progress: UnboundedSender<Progress>,
+) -> Result<DownloadedUpdate> {
+    let client = super::release::client(Duration::from_secs(15 * 60))?;
+    let expected_checksum = if let Some(digest) = &release.sha256 {
+        digest.clone()
+    } else {
+        let url = release.checksum_url.as_ref().context("The update has no checksum")?;
+        let text = client
+            .get(url)
+            .header(reqwest::header::ACCEPT, "application/octet-stream")
+            .send()
+            .await
+            .context("Could not download the update checksum")?
+            .error_for_status()
+            .context("The checksum is no longer available; check for updates again")?
+            .text()
+            .await
+            .context("Could not read the update checksum")?;
+        super::release::parse_checksum(&text)?
+    };
+    let response = client
+        .get(&release.download_url)
+        .header(reqwest::header::ACCEPT, "application/octet-stream")
+        .send()
+        .await
+        .context("Could not start the update download")?
+        .error_for_status()
+        .context("The update file is no longer available; check for updates again")?;
+    let cache = dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("com.openmango.app")
+        .join("updates");
+    let staged = staging_file(&cache)?;
+    let mut file = tokio::fs::File::from_std(
+        staged.reopen().context("Could not open the temporary update file")?,
+    );
+    let mut stream = response.bytes_stream();
+    let mut hasher = Sha256::new();
+    let mut received = 0_u64;
+    let mut last_percent = 0_u64;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("The update download was interrupted")?;
+        received = received.saturating_add(chunk.len() as u64);
+        ensure!(
+            received <= release.size,
+            "The update file is larger than its published size. Check for updates again."
+        );
+        file.write_all(&chunk)
+            .await
+            .context("Could not write the downloaded update; check free disk space")?;
+        hasher.update(&chunk);
+        let percent = received.saturating_mul(100).checked_div(release.size).unwrap_or(0).min(99);
+        if percent != last_percent {
+            last_percent = percent;
+            let _ =
+                progress.unbounded_send(Progress::Downloading { received, total: release.size });
+        }
+    }
+    let _ = progress.unbounded_send(Progress::Verifying);
+    ensure!(received == release.size, "The update download is incomplete. Download it again.");
+    file.flush().await.context("Could not finish writing the update")?;
+    file.sync_all().await.context("Could not save the update to disk")?;
+    drop(file);
+    ensure!(
+        format!("{:x}", hasher.finalize()) == expected_checksum,
+        "The update checksum did not match. Check for updates and download again."
+    );
+    ensure!(
+        staged.path().is_file(),
+        "The download folder was cleared before verification finished. Download the update again."
+    );
+    // No shared filename, destructive cleanup, or final rename: ownership promotes the verified file.
+    Ok(DownloadedUpdate { release, archive: staged.into_temp_path() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::staging_file;
+    use std::io::Write as _;
+
+    #[test]
+    fn failed_download_cleanup_cannot_remove_another_download() {
+        let cache = tempfile::tempdir().unwrap();
+        let mut first = staging_file(cache.path()).unwrap();
+        let second = staging_file(cache.path()).unwrap();
+        assert_ne!(first.path(), second.path());
+        first.write_all(b"completed download").unwrap();
+        drop(second);
+        let verified = first.into_temp_path();
+        assert_eq!(std::fs::read(&verified).unwrap(), b"completed download");
+        let path = verified.to_path_buf();
+        drop(verified);
+        assert!(!path.exists());
+    }
+}

--- a/src/state/commands/updater/install.rs
+++ b/src/state/commands/updater/install.rs
@@ -1,0 +1,224 @@
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::SystemTime;
+
+use anyhow::{Context as _, Result, bail, ensure};
+
+pub(super) struct PreparedInstall {
+    staging: tempfile::TempDir,
+    target: PathBuf,
+    extracted: PathBuf,
+    original_modified: SystemTime,
+    _lock: File,
+}
+
+pub(super) fn running_bundle() -> Result<PathBuf> {
+    ensure!(
+        cfg!(target_os = "macos"),
+        "Automatic installation is currently available on macOS only"
+    );
+    let executable = std::env::current_exe().context("Could not locate the running application")?;
+    let bundle = bundle_for_executable(&executable)
+        .context("This is a development executable. Install OpenMango.app to use in-app updates")?;
+    ensure!(
+        !bundle.components().any(|part| part.as_os_str() == "AppTranslocation"),
+        "Move OpenMango to Applications and reopen it before updating."
+    );
+    Ok(bundle)
+}
+
+fn bundle_for_executable(executable: &Path) -> Option<PathBuf> {
+    let macos = executable.parent()?;
+    let contents = macos.parent()?;
+    let bundle = contents.parent()?;
+    (macos.file_name()? == "MacOS"
+        && contents.file_name()? == "Contents"
+        && bundle.extension().is_some_and(|extension| extension == "app"))
+    .then(|| bundle.to_path_buf())
+}
+
+fn designated_requirement(bundle: &Path) -> Result<String> {
+    let output = Command::new("/usr/bin/codesign")
+        .args(["-d", "-r-"])
+        .arg(bundle)
+        .output()
+        .context("Could not read the installed app's signing identity")?;
+    ensure!(output.status.success(), "Could not verify the installed app's signing identity");
+    let text = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let requirement = text
+        .lines()
+        .find_map(|line| line.strip_prefix("designated => "))
+        .context("The installed app has no signing requirement")?
+        .to_string();
+    ensure!(
+        requirement.contains("identifier")
+            && requirement.contains("anchor apple generic")
+            && requirement.contains("subject.OU"),
+        "The installed app has no trusted Developer ID identity. Install a signed release first."
+    );
+    Ok(requirement)
+}
+
+fn verify_signature(bundle: &Path, requirement: &str) -> Result<()> {
+    let output = Command::new("/usr/bin/codesign")
+        .args(["--verify", "--deep", "--strict", "--verbose=2"])
+        .arg(bundle)
+        .output()
+        .context("Could not start macOS signature verification")?;
+    ensure!(
+        output.status.success(),
+        "The app signature is invalid: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    let identity = Command::new("/usr/bin/codesign")
+        .args(["--verify", "--strict", "-R", requirement])
+        .arg(bundle)
+        .output()
+        .context("Could not verify the app's signing identity")?;
+    ensure!(
+        identity.status.success(),
+        "The update's signing identity does not match this application: {}",
+        String::from_utf8_lossy(&identity.stderr).trim()
+    );
+    Ok(())
+}
+
+/// Extraction and signature checks do not modify the installed application.
+pub(super) fn prepare(archive: &Path) -> Result<PreparedInstall> {
+    ensure!(archive.is_file(), "The downloaded update is no longer available. Download it again.");
+    let target = running_bundle()?;
+    let parent = target.parent().context("The application has no installation folder")?;
+    let lock = OpenOptions::new().create(true).truncate(false).write(true)
+        .open(parent.join(".openmango-update.lock"))
+        .context("The application folder is not writable. Move OpenMango to a writable Applications folder.")?;
+    lock.try_lock().context(
+        "Another OpenMango instance is preparing an update. Try again after it finishes.",
+    )?;
+    let original_modified = fs::metadata(&target)
+        .context("Could not find the installed app. Reopen OpenMango if it was moved")?
+        .modified()
+        .context("Could not inspect the installed app's modification time")?;
+    let requirement = designated_requirement(&target)?;
+    verify_signature(&target, &requirement)?;
+    let staging = tempfile::Builder::new()
+        .prefix(".openmango-update-")
+        .tempdir_in(parent)
+        .context("Could not create the installation staging folder")?;
+    let payload = staging.path().join("payload");
+    fs::create_dir(&payload).context("Could not create the update extraction folder")?;
+    let extraction = Command::new("/usr/bin/ditto")
+        .args(["-x", "-k"])
+        .arg(archive)
+        .arg(&payload)
+        .output()
+        .context("Could not start the macOS update extractor")?;
+    ensure!(
+        extraction.status.success(),
+        "Could not extract the update: {}",
+        String::from_utf8_lossy(&extraction.stderr).trim()
+    );
+    let extracted = payload.join("OpenMango.app");
+    ensure!(extracted.is_dir(), "The downloaded update does not contain OpenMango.app");
+    verify_signature(&extracted, &requirement)?;
+    Ok(PreparedInstall { staging, target, extracted, original_modified, _lock: lock })
+}
+
+fn replace_bundle(target: &Path, extracted: &Path, backup: &Path) -> Result<()> {
+    fs::rename(target, backup).context("Could not back up the current application")?;
+    if let Err(error) = fs::rename(extracted, target) {
+        restore_bundle(target, extracted, backup)
+            .with_context(|| format!("Could not install the update ({error}) and could not restore the previous application"))?;
+        bail!("Could not install the update; the previous application was restored: {error}");
+    }
+    Ok(())
+}
+
+fn restore_bundle(target: &Path, extracted: &Path, backup: &Path) -> Result<()> {
+    if target.exists() {
+        fs::rename(target, extracted)
+            .context("Could not move the failed update out of the installation folder")?;
+    }
+    fs::rename(backup, target).context("Could not restore the previous application")
+}
+
+/// Called only after the unsaved-work guard approves restart. The final swap and
+/// launch stay in one callback so no new edits can appear between approval and quit.
+pub(super) fn activate_and_restart(prepared: PreparedInstall) -> Result<()> {
+    let current_modified = fs::metadata(&prepared.target)
+        .context("The installed app is no longer available. Reopen OpenMango and try again")?
+        .modified()
+        .context("Could not recheck the installed application")?;
+    ensure!(
+        current_modified == prepared.original_modified,
+        "The installed application changed while preparing this update. Reopen OpenMango and check again."
+    );
+    let backup = prepared.staging.path().join("previous.app");
+    if let Err(error) = replace_bundle(&prepared.target, &prepared.extracted, &backup) {
+        if backup.exists() {
+            let recovery = prepared.staging.keep();
+            bail!("{error:#}. The previous application is preserved in {}", recovery.display());
+        }
+        return Err(error);
+    }
+    let launch = Command::new("/usr/bin/open").arg("-n").arg(&prepared.target).output();
+    let error = match launch {
+        Ok(output) if output.status.success() => None,
+        Ok(output) => Some(String::from_utf8_lossy(&output.stderr).trim().to_string()),
+        Err(error) => Some(error.to_string()),
+    };
+    if let Some(error) = error {
+        if let Err(restore) = restore_bundle(&prepared.target, &prepared.extracted, &backup) {
+            let recovery = prepared.staging.keep();
+            bail!(
+                "The update could not be opened ({error}) or restored ({restore:#}). The previous application is preserved in {}",
+                recovery.display()
+            );
+        }
+        bail!("The new app could not be opened. The previous app was restored: {error}");
+    }
+    // Only this operation's staging area and backup are removed.
+    if let Err(error) = prepared.staging.close() {
+        log::warn!("Update installed, but its backup could not be cleaned up: {error}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bundle_for_executable, replace_bundle};
+    use std::path::Path;
+
+    #[test]
+    fn development_executables_never_target_applications() {
+        assert!(bundle_for_executable(Path::new("/work/target/debug/openmango")).is_none());
+        assert_eq!(
+            bundle_for_executable(Path::new(
+                "/Applications/OpenMango.app/Contents/MacOS/OpenMango"
+            ))
+            .unwrap(),
+            Path::new("/Applications/OpenMango.app")
+        );
+    }
+
+    #[test]
+    fn failed_swap_preserves_the_installed_application() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("OpenMango.app");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("original"), "keep").unwrap();
+        assert!(
+            replace_bundle(
+                &target,
+                &root.path().join("missing.app"),
+                &root.path().join("backup.app")
+            )
+            .is_err()
+        );
+        assert_eq!(std::fs::read_to_string(target.join("original")).unwrap(), "keep");
+    }
+}

--- a/src/state/commands/updater/release.rs
+++ b/src/state/commands/updater/release.rs
@@ -1,0 +1,196 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context as _, Result, bail};
+use serde_json::Value;
+
+use crate::state::app_state::updater::{RELEASES_URL, UpdateChannel, UpdateRelease};
+
+pub(super) const REPOSITORY_API: &str = "https://api.github.com/repos/ggagosh/openmango";
+
+pub(super) fn client(timeout: Duration) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(format!("OpenMango/{}", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(timeout)
+        .build()
+        .context("Could not initialize the update connection")
+}
+
+pub(super) async fn check(
+    channel: UpdateChannel,
+    installed_channel: UpdateChannel,
+    current_version: &str,
+    current_sha: &str,
+) -> Result<Option<Arc<UpdateRelease>>> {
+    let client = client(Duration::from_secs(30))?;
+    let endpoint = match channel {
+        UpdateChannel::Stable => "latest",
+        UpdateChannel::Nightly => "tags/nightly",
+    };
+    let response = client
+        .get(format!("{REPOSITORY_API}/releases/{endpoint}"))
+        .send()
+        .await
+        .context("Could not contact GitHub for update information")?;
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    let release: Value = response
+        .error_for_status()
+        .context("GitHub could not provide update information")?
+        .json()
+        .await
+        .context("GitHub returned invalid release information")?;
+    let version = match channel {
+        UpdateChannel::Stable => {
+            let tag =
+                release["tag_name"].as_str().context("The stable release has no version tag")?;
+            let version = tag.strip_prefix('v').unwrap_or(tag);
+            let remote: semver::Version =
+                version.parse().context("The stable release version is invalid")?;
+            let local: semver::Version = current_version.parse()?;
+            if installed_channel == channel && remote <= local {
+                return Ok(None);
+            }
+            version.to_string()
+        }
+        UpdateChannel::Nightly => {
+            let sha = nightly_sha(release["body"].as_str().unwrap_or_default())
+                .context("The nightly release has no valid build identifier")?;
+            if same_commit(current_sha, sha) {
+                return Ok(None);
+            }
+            if installed_channel == channel {
+                if !valid_sha(current_sha) {
+                    bail!(
+                        "This build cannot be compared with the nightly release. Open Releases to choose a build."
+                    );
+                }
+                let comparison: Value = client
+                    .get(format!("{REPOSITORY_API}/compare/{current_sha}...{sha}"))
+                    .send()
+                    .await
+                    .context("Could not compare nightly builds")?
+                    .error_for_status()
+                    .context(
+                        "The installed nightly could not be compared with the published build",
+                    )?
+                    .json()
+                    .await
+                    .context("GitHub returned an invalid build comparison")?;
+                if !nightly_is_newer(&comparison)? {
+                    return Ok(None);
+                }
+            }
+            sha[..7].to_string()
+        }
+    };
+    Ok(Some(Arc::new(candidate(&release, channel, version)?)))
+}
+
+fn valid_sha(sha: &str) -> bool {
+    (7..=64).contains(&sha.len()) && sha.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn same_commit(local: &str, remote: &str) -> bool {
+    valid_sha(local)
+        && valid_sha(remote)
+        && (local.starts_with(remote) || remote.starts_with(local))
+}
+
+fn nightly_sha(body: &str) -> Option<&str> {
+    let sha = body.split_once("**Commit:**")?.1.split_whitespace().next()?;
+    valid_sha(sha).then_some(sha)
+}
+
+fn nightly_is_newer(comparison: &Value) -> Result<bool> {
+    match comparison["status"].as_str() {
+        Some("ahead") => Ok(true),
+        Some("behind" | "identical") => Ok(false),
+        _ => bail!(
+            "The nightly build is from a different history. Open Releases to choose a build; automatic downgrade was stopped."
+        ),
+    }
+}
+
+fn candidate(release: &Value, channel: UpdateChannel, version: String) -> Result<UpdateRelease> {
+    let suffix = match std::env::consts::ARCH {
+        "aarch64" => "macos-arm64.zip",
+        "x86_64" => "macos-x86_64.zip",
+        _ => bail!("Automatic updates are not available for this architecture"),
+    };
+    let assets = release["assets"].as_array().context("This release has no downloadable files")?;
+    let asset = assets
+        .iter()
+        .find(|asset| {
+            asset["name"]
+                .as_str()
+                .is_some_and(|name| name.starts_with("OpenMango-") && name.ends_with(suffix))
+        })
+        .context("The release does not contain an update for this Mac")?;
+    let name = asset["name"].as_str().context("The update file has no name")?;
+    let asset_id = asset["id"].as_u64().context("The update file has no asset identifier")?;
+    let size = asset["size"]
+        .as_u64()
+        .filter(|size| *size > 0)
+        .context("The update file is empty or still being published")?;
+    let sha256 = asset["digest"]
+        .as_str()
+        .and_then(|digest| digest.strip_prefix("sha256:"))
+        .map(parse_checksum)
+        .transpose()?;
+    let checksum_name = format!("{name}.sha256");
+    let checksum_url = assets
+        .iter()
+        .find(|asset| asset["name"].as_str() == Some(&checksum_name))
+        .and_then(|asset| asset["id"].as_u64())
+        .map(|id| format!("{REPOSITORY_API}/releases/assets/{id}"));
+    if sha256.is_none() && checksum_url.is_none() {
+        bail!("The release is missing its SHA-256 checksum");
+    }
+    Ok(UpdateRelease {
+        channel,
+        version,
+        release_url: match channel {
+            UpdateChannel::Stable => format!("{RELEASES_URL}/latest"),
+            UpdateChannel::Nightly => format!("{RELEASES_URL}/tag/nightly"),
+        },
+        // Asset IDs remain tied to the selected release, even when nightly is republished.
+        download_url: format!("{REPOSITORY_API}/releases/assets/{asset_id}"),
+        checksum_url,
+        sha256,
+        size,
+    })
+}
+
+pub(super) fn parse_checksum(text: &str) -> Result<String> {
+    let digest = text.split_whitespace().next().context("The checksum file is empty")?;
+    if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("The release has an invalid SHA-256 checksum");
+    }
+    Ok(digest.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{nightly_is_newer, nightly_sha, parse_checksum, same_commit};
+    use serde_json::json;
+
+    #[test]
+    fn nightly_updates_require_forward_history_and_valid_identity() {
+        assert!(nightly_is_newer(&json!({"status":"ahead"})).unwrap());
+        for status in ["behind", "identical"] {
+            assert!(!nightly_is_newer(&json!({"status":status})).unwrap());
+        }
+        assert!(nightly_is_newer(&json!({"status":"diverged"})).is_err());
+        assert!(same_commit("abc1234", "abc1234def5678"));
+        assert_eq!(nightly_sha("**Commit:** abc1234def5678\n"), Some("abc1234def5678"));
+        assert_eq!(nightly_sha("**Commit:** not-a-sha"), None);
+        assert_eq!(
+            parse_checksum(&format!("{} file.zip", "A".repeat(64))).unwrap(),
+            "a".repeat(64)
+        );
+        assert!(parse_checksum("invalid").is_err());
+    }
+}

--- a/src/state/settings.rs
+++ b/src/state/settings.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::app_state::updater::UpdateChannel;
 use super::app_state::{InsertMode, TransferFormat};
 use crate::ai::settings::AiSettings;
 
@@ -29,6 +30,8 @@ pub struct AppSettings {
     #[serde(default = "default_true")]
     pub auto_update: bool,
     #[serde(default)]
+    pub update_channel: UpdateChannel,
+    #[serde(default)]
     pub collection_double_click_action: CollectionDoubleClickAction,
 }
 
@@ -43,6 +46,7 @@ impl Default for AppSettings {
             interactive_query_timeout_ms: default_interactive_query_timeout_ms(),
             last_seen_version: default_current_version(),
             auto_update: true,
+            update_channel: UpdateChannel::default(),
             collection_double_click_action: CollectionDoubleClickAction::default(),
         }
     }

--- a/src/views/settings.rs
+++ b/src/views/settings.rs
@@ -703,9 +703,9 @@ fn render_updates_section(
     let auto_update_checkbox = {
         let state = state.clone();
         gpui_kit::component::checkbox::Checkbox::new("auto-update").checked(auto_update).on_click(
-            move |_, _, cx| {
+            move |checked, _, cx| {
                 state.update(cx, |state, cx| {
-                    state.settings.auto_update = !auto_update;
+                    state.settings.auto_update = *checked;
                     state.save_settings();
                     cx.notify();
                 });
@@ -715,12 +715,37 @@ fn render_updates_section(
 
     section(
         "Updates",
-        div().flex().flex_col().gap(spacing::md()).child(setting_row_with_description(
-            "Automatic updates",
-            "Automatically check for and download updates; restart to install",
-            auto_update_checkbox,
-            cx,
-        )),
+        div()
+            .flex()
+            .flex_col()
+            .gap(spacing::md())
+            .child(setting_row_with_description(
+                "Automatic updates",
+                "Check and download in the background; installation always waits for your approval",
+                auto_update_checkbox,
+                cx,
+            ))
+            .child(setting_row_with_description(
+                "Update channel",
+                "Stable releases by default; nightly builds include unreleased changes",
+                crate::components::updater::channel_picker(
+                    "settings-update-channel",
+                    state.clone(),
+                    cx,
+                ),
+                cx,
+            ))
+            .child(setting_row_with_description(
+                "Software Update",
+                "Review available versions, download progress, and installation errors",
+                Button::new("settings-check-updates").small().label("Check for updates…").on_click(
+                    move |_, window, cx| {
+                        AppCommands::check_for_updates(state.clone(), cx);
+                        crate::components::updater::open_updates(state.clone(), window, cx);
+                    },
+                ),
+                cx,
+            )),
         cx,
     )
 }


### PR DESCRIPTION
Downloads could fail at completion because update attempts shared temporary filenames and cleanup. Each attempt now owns its archive through verification and installation, and ordered progress plus request IDs prevent stale tasks from replacing newer state.

The updater now checks the selected Stable or Nightly channel, rejects backward nightly updates, pins release assets, and verifies size and SHA-256. A GPUI Kit dialog shows download, verification, installation, and retry states. Installation checks the existing signing identity, asks about unsaved work before replacing the app, and restores the previous bundle after a failed swap or launch. Development builds cannot overwrite the installed application.

Includes updater research and manual verification scenarios. Also moves an existing BSON test module to the end of its file to satisfy all-target Clippy.

Validation:

- `just fmt-check`
- `just lint`
- `just check-release` and `just lint-release`
- `just check-sidecar`
- `cargo test -- --test-threads=1` with Docker: 657 passed, 0 failed, 1 ignored.

The GUI and a real signed macOS installation were not exercised locally; no new UI screenshot was captured. The manual scenarios in `docs/UPDATER_WORKFLOW.md` remain necessary before release.
