### PR TITLE
Streamline CI and release pipeline

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/sh
-# Run CI checks before commit
-just ci
+# Keep this fast; CI runs clippy and the tests.
+cargo fmt --all -- --check

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    # Every Cargo.lock change is a cold CI build, so batch bumps into two PRs:
+    # GPUI on its own (0.x minors break the build), everything else together.
+    groups:
+      gpui:
+        patterns: ["gpui*"]
+      cargo:
+        patterns: ["*"]
+        exclude-patterns: ["gpui*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,39 +23,30 @@ env:
 jobs:
   quality:
     runs-on: macos-latest
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.4.2"
-
-      - uses: Swatinem/rust-cache@v2
-
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-on-failure: true
       - name: Disable lld linker flags for CI
         run: rm -f .cargo/config.toml
-
       - name: Format check
         run: cargo fmt --check
-
       - name: Compile macOS app icon
         run: bash ./scripts/build_app_icon.sh
-
-      - name: Check
-        run: cargo check --release --features mimalloc
-
       - name: Clippy
-        run: cargo clippy --release --features mimalloc -- -D warnings
-
+        run: cargo clippy --locked --release --all-targets -- -D warnings
       - name: Verify Forge sidecar bundle
         run: ./scripts/check_mongosh_sidecar.sh
-
       - name: Run unit tests
-        run: cargo test --lib -- --test-threads=1
+        run: cargo test --locked --lib -- --test-threads=1
 
   linux:
     name: Linux (${{ matrix.arch }})
@@ -71,23 +62,28 @@ jobs:
           - runner: ubuntu-24.04-arm
             arch: arm64
             target: aarch64-unknown-linux-gnu
-    env:
-      CARGO_BUILD_JOBS: 2
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.4.2"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          # Same key as linux-release.yml so nightly and stable builds start warm after a merge.
+          shared-key: linux-release-${{ matrix.arch }}
+          cache-on-failure: true
       - name: Install Linux dependencies
         run: bash scripts/bootstrap_linux.sh --desktop-tests
       - name: Format check
         run: cargo fmt --check
       - name: Clippy
-        run: cargo clippy --locked --all-targets -- -D warnings
+        run: cargo clippy --locked --release --all-targets -- -D warnings
       - name: Run unit tests
-        run: cargo test --locked --lib -- --test-threads=1
+        # Release profile so this build and the package step below share one compile.
+        run: cargo test --locked --release --lib -- --test-threads=1
       - name: Verify bundled helper scripts
         run: bash scripts/check_linux_tools.sh
       - name: Verify Forge sidecar bundle
@@ -102,7 +98,7 @@ jobs:
         env:
           OPENMANGO_GUI_WINDOW_MANAGER: xfwm4
         run: python3 scripts/check_linux_gui.py 'dist/OpenMango-'*'-linux-${{ matrix.arch }}.AppImage' target/linux-gui-xfce.png
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Linux-preview-${{ matrix.arch }}
           path: |
@@ -118,24 +114,19 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Linux system deps for GPUI linking
         run: |
           bash scripts/bootstrap_linux.sh
           pkg-config --modversion fontconfig
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Disable lld linker flags for CI
-        run: rm -f .cargo/config.toml
-
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-on-failure: true
       - name: Verify Docker availability
         run: docker version
-
       - name: Pull integration test images
         run: |
           for test_image in mongo:7.0 testcontainers/sshd:1.3.0; do
@@ -149,14 +140,15 @@ jobs:
               sleep 5
             done
           done
-
       - name: Download MongoDB Database Tools
         run: ./scripts/download_tools.sh
-
+      - name: Build integration tests
+        # One invocation links all suites in parallel; the loop below then only runs them.
+        run: cargo test --locked --no-run --tests
       - name: Run integration tests
         run: |
           for test_file in tests/*_tests.rs; do
             test_name="$(basename "${test_file}" .rs)"
             echo "Running ${test_name}"
-            cargo test --test "${test_name}" -- --test-threads=1
+            cargo test --locked --test "${test_name}" -- --test-threads=1
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Compile macOS app icon
         run: bash ./scripts/build_app_icon.sh
       - name: Clippy
-        run: cargo clippy --locked --release --all-targets -- -D warnings
+        run: cargo clippy --locked --release -- -D warnings
       - name: Verify Forge sidecar bundle
         run: ./scripts/check_mongosh_sidecar.sh
       - name: Run unit tests
@@ -72,18 +72,16 @@ jobs:
           bun-version: "1.4.2"
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          # Same key as linux-release.yml so nightly and stable builds start warm after a merge.
-          shared-key: linux-release-${{ matrix.arch }}
           cache-on-failure: true
       - name: Install Linux dependencies
         run: bash scripts/bootstrap_linux.sh --desktop-tests
       - name: Format check
         run: cargo fmt --check
       - name: Clippy
-        run: cargo clippy --locked --release --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
       - name: Run unit tests
-        # Release profile so this build and the package step below share one compile.
-        run: cargo test --locked --release --lib -- --test-threads=1
+        # Debug profile: the integration-test seams in src/ are gated on cfg(debug_assertions).
+        run: cargo test --locked --lib -- --test-threads=1
       - name: Verify bundled helper scripts
         run: bash scripts/check_linux_tools.sh
       - name: Verify Forge sidecar bundle

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -37,18 +37,20 @@ jobs:
     env:
       OPENMANGO_RELEASE_CHANNEL: ${{ inputs.channel }}
       OPENMANGO_LINUX_UPDATE_PUBLIC_KEY: ${{ vars.LINUX_UPDATE_PUBLIC_KEY }}
-      CARGO_BUILD_JOBS: 2
       CARGO_INCREMENTAL: 0
       CARGO_HUSKY_DONT_INSTALL_HOOKS: "true"
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.4.2"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: linux-release-${{ matrix.arch }}
+          cache-on-failure: true
       - name: Install Linux dependencies
         run: bash scripts/bootstrap_linux.sh --desktop-tests
       - name: Load Linux signing key
@@ -75,7 +77,7 @@ jobs:
       - name: Remove signing key
         if: always()
         run: rm -f "$RUNNER_TEMP/linux-signing.key"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: OpenMango-linux-${{ matrix.arch }}
           if-no-files-found: error

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -1,0 +1,101 @@
+name: macOS Apps
+
+# Signing and notarization use the repository secrets MACOS_CERTIFICATE,
+# MACOS_CERTIFICATE_PASSWORD, MACOS_SIGNING_IDENTITY, APPLE_API_KEY_ID,
+# APPLE_API_ISSUER_ID, and APPLE_API_KEY; callers pass them with `secrets: inherit`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        type: choice
+        options: [nightly, stable]
+        default: nightly
+        required: true
+  workflow_call:
+    inputs:
+      channel:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            suffix: macos-arm64
+          - target: x86_64-apple-darwin
+            suffix: macos-x86_64
+    env:
+      OPENMANGO_RELEASE_CHANNEL: ${{ inputs.channel }}
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_RETRY: 10
+      RUST_BACKTRACE: short
+      CARGO_HUSKY_DONT_INSTALL_HOOKS: "true"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.4.2"
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: release-${{ matrix.target }}
+          cache-on-failure: true
+      - name: Disable lld linker flags for CI
+        run: rm -f .cargo/config.toml
+      - name: Build Forge mongosh sidecar
+        run: bash scripts/build_mongosh_sidecar.sh ${{ matrix.target }}
+      - name: Download MongoDB Database Tools
+        run: bash scripts/download_tools.sh ${{ matrix.target }}
+      - name: Import signing certificate
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          if [[ -z "${MACOS_CERTIFICATE:-}" ]]; then
+            echo "No signing certificate provided, skipping codesign import."
+            exit 0
+          fi
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+          echo "$MACOS_CERTIFICATE" | base64 -D > "$CERT_PATH"
+          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT_PATH" -k "$KEYCHAIN" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychain -d user -s "$KEYCHAIN"
+      - name: Build and package
+        env:
+          MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS: ""
+          CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: ""
+          REQUIRE_BUNDLED_TOOLS: "1"
+        run: bash scripts/release_macos.sh ${{ matrix.target }}
+      - name: Generate SHA-256 checksum
+        run: |
+          for file in dist/OpenMango-*-${{ matrix.suffix }}.zip; do
+            shasum -a 256 "$file" | awk '{print $1}' > "$file.sha256"
+          done
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: OpenMango-${{ matrix.suffix }}
+          if-no-files-found: error
+          path: |
+            dist/OpenMango-*-${{ matrix.suffix }}.zip
+            dist/OpenMango-*-${{ matrix.suffix }}.zip.sha256

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,13 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-
-env:
-  CARGO_INCREMENTAL: 0
-  CARGO_NET_RETRY: 10
-  RUST_BACKTRACE: short
-  OPENMANGO_RELEASE_CHANNEL: nightly
+  contents: read
 
 jobs:
   linux:
@@ -24,123 +18,41 @@ jobs:
     uses: ./.github/workflows/linux-release.yml
     with:
       channel: nightly
-    secrets:
-      LINUX_SIGNING_KEY: ${{ secrets.LINUX_SIGNING_KEY }}
+    secrets: inherit
 
   macos:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            suffix: macos-arm64
-          - target: x86_64-apple-darwin
-            suffix: macos-x86_64
-    steps:
-      - uses: actions/checkout@v4
+    uses: ./.github/workflows/macos-release.yml
+    with:
+      channel: nightly
+    secrets: inherit
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.4.2"
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "release-${{ matrix.target }}"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Ensure scripts executable
-        run: chmod +x scripts/release_macos.sh scripts/build_mongosh_sidecar.sh scripts/check_mongosh_sidecar.sh
-
-      - name: Disable lld linker flags for CI
-        run: rm -f .cargo/config.toml
-
-      - name: Build Forge mongosh sidecar
-        run: ./scripts/build_mongosh_sidecar.sh ${{ matrix.target }}
-
-      - name: Download MongoDB Database Tools
-        run: bash scripts/download_tools.sh ${{ matrix.target }}
-
-      - name: Import signing certificate
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-        run: |
-          if [[ -z "${MACOS_CERTIFICATE:-}" ]]; then
-            echo "No signing certificate provided, skipping codesign import."
-            exit 0
-          fi
-          CERT_PATH="$RUNNER_TEMP/cert.p12"
-          if base64 --help 2>&1 | grep -q -- "-d"; then
-            echo "$MACOS_CERTIFICATE" | base64 -d > "$CERT_PATH"
-          else
-            echo "$MACOS_CERTIFICATE" | base64 -D > "$CERT_PATH"
-          fi
-          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
-          echo "::add-mask::$KEYCHAIN_PASSWORD"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security import "$CERT_PATH" -k "$KEYCHAIN" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security list-keychain -d user -s "$KEYCHAIN"
-
-      - name: Build and package
-        env:
-          MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS: ""
-          CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: ""
-          REQUIRE_BUNDLED_TOOLS: "1"
-        run: scripts/release_macos.sh ${{ matrix.target }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: OpenMango-nightly-${{ matrix.suffix }}
-          path: dist/OpenMango-*-${{ matrix.suffix }}.zip
-
-  release:
+  publish:
     needs: [macos, linux]
     if: always() && needs.macos.result == 'success' && (needs.linux.result == 'success' || needs.linux.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: artifacts
-
-      - name: Prepare release files and checksums
-        run: |
-          mkdir -p release
-          find artifacts -type f \( -name "*.zip" -o -name "*.AppImage*" \) -exec cp {} release/ \;
-          for file in release/*.zip; do
-            sha256sum "$file" | awk '{print $1}' > "$file.sha256"
-          done
-          ls -la release/
-
-      - name: Delete existing nightly release
+          pattern: OpenMango-*
+          merge-multiple: true
+          path: release
+      - run: ls -la release/
+      - name: Replace previous nightly release and tag
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release delete nightly --repo ${{ github.repository }} --yes || true
-
-      - name: Create nightly release
-        uses: softprops/action-gh-release@v2
+        run: gh release delete nightly --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+      - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: nightly
           name: Nightly Build
           prerelease: true
-          files: |
-            release/*.zip
-            release/*.zip.sha256
-            release/*.AppImage*
+          target_commitish: ${{ github.sha }}
+          fail_on_unmatched_files: true
+          files: release/OpenMango-*
+          # The in-app updater reads the commit from the "**Commit:**" line; keep that format.
           body: |
             Automated nightly build from main branch.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,117 +10,63 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-
-env:
-  CARGO_INCREMENTAL: 0
-  CARGO_NET_RETRY: 10
-  RUST_BACKTRACE: short
-  OPENMANGO_RELEASE_CHANNEL: stable
+  contents: read
 
 jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Tag matches Cargo.toml version
+        run: |
+          version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)"
+          if [[ "v$version" != "$GITHUB_REF_NAME" ]]; then
+            echo "Tag $GITHUB_REF_NAME does not match Cargo.toml version $version" >&2
+            exit 1
+          fi
+      - name: CHANGELOG has a section for this version
+        run: grep -q "^## \[${GITHUB_REF_NAME#v}\]" CHANGELOG.md
+
   linux:
+    needs: verify
     if: vars.LINUX_RELEASES_ENABLED == 'true'
     uses: ./.github/workflows/linux-release.yml
     with:
       channel: stable
-    secrets:
-      LINUX_SIGNING_KEY: ${{ secrets.LINUX_SIGNING_KEY }}
-
-  publish-linux:
-    needs: linux
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: OpenMango-linux-*
-          merge-multiple: true
-          path: linux-release
-      - uses: softprops/action-gh-release@v2
-        with:
-          files: linux-release/*.AppImage*
+    secrets: inherit
 
   macos:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            suffix: macos-arm64
-          - target: x86_64-apple-darwin
-            suffix: macos-x86_64
+    needs: verify
+    uses: ./.github/workflows/macos-release.yml
+    with:
+      channel: stable
+    secrets: inherit
+
+  publish:
+    needs: [verify, macos, linux]
+    if: always() && needs.verify.result == 'success' && needs.macos.result == 'success' && (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          bun-version: "1.4.2"
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "release-${{ matrix.target }}"
-
-      - name: Ensure scripts executable
-        run: chmod +x scripts/release_macos.sh scripts/build_mongosh_sidecar.sh scripts/check_mongosh_sidecar.sh
-
-      - name: Disable lld linker flags for CI
-        run: rm -f .cargo/config.toml
-
-      - name: Build Forge mongosh sidecar
-        run: ./scripts/build_mongosh_sidecar.sh ${{ matrix.target }}
-
-      - name: Download MongoDB Database Tools
-        run: bash scripts/download_tools.sh ${{ matrix.target }}
-
-      - name: Import signing certificate
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          pattern: OpenMango-*
+          merge-multiple: true
+          path: release
+      - run: ls -la release/
+      - name: Release notes from CHANGELOG
         run: |
-          if [[ -z "${MACOS_CERTIFICATE:-}" ]]; then
-            echo "No signing certificate provided, skipping codesign import."
-            exit 0
-          fi
-          CERT_PATH="$RUNNER_TEMP/cert.p12"
-          if base64 --help 2>&1 | grep -q -- "-d"; then
-            echo "$MACOS_CERTIFICATE" | base64 -d > "$CERT_PATH"
-          else
-            echo "$MACOS_CERTIFICATE" | base64 -D > "$CERT_PATH"
-          fi
-          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
-          echo "::add-mask::$KEYCHAIN_PASSWORD"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security import "$CERT_PATH" -k "$KEYCHAIN" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security list-keychain -d user -s "$KEYCHAIN"
-
-      - name: Build and package
-        env:
-          MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS: ""
-          CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: ""
-          REQUIRE_BUNDLED_TOOLS: "1"
-        run: scripts/release_macos.sh ${{ matrix.target }}
-
-      - name: Generate SHA-256 checksum
-        run: |
-          for file in dist/OpenMango-*-${{ matrix.suffix }}.zip; do
-            shasum -a 256 "$file" | awk '{print $1}' > "$file.sha256"
-          done
-
-      - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+          awk -v v="${GITHUB_REF_NAME#v}" \
+            '/^## \[/ { p = ($0 ~ "^## \\[" v "\\]") } p && !/^## \[/' CHANGELOG.md > release-notes.md
+          test -s release-notes.md
+          cat release-notes.md
+      - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
-          files: |
-            dist/OpenMango-*-${{ matrix.suffix }}.zip
-            dist/OpenMango-*-${{ matrix.suffix }}.zip.sha256
+          body_path: release-notes.md
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: release/OpenMango-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Applied fast filters now keep the text you typed instead of rewriting it into MongoDB JSON
 
 ### Changed
+- Stable releases publish every platform from one job with notes taken from this changelog, and the `nightly` tag now points at the commit that was built
 - Migrated the desktop UI to published GPUI Kit 0.6 components and removed the vendored toolkit patches
 - Forge retains editor and result-view state across tabs and uses fuzzy completions with consistent native editing shortcuts
 - Filter Builder now uses consistent native controls, collapsible borderless groups, and scoped keyboard handling with validation before execution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,15 @@ Add or extend tests whenever you change behavior. PRs without relevant test cove
 
 3. **Commit style:** short imperative subjects (e.g., `fix srv error`, `add changelog`)
 
+## Releasing
+
+Releases are cut from `main` in two steps:
+
+1. `just prepare-release 0.2.2` bumps `Cargo.toml` and `Cargo.lock`, moves the CHANGELOG `[Unreleased]` entries under `[0.2.2]`, and opens a `release 0.2.2` pull request.
+2. After that pull request merges, `just tag-release 0.2.2` tags `main` and pushes `v0.2.2`.
+
+The tag starts the Release workflow: it checks that the tag matches `Cargo.toml`, builds and signs the macOS and Linux packages, and publishes one GitHub release with the CHANGELOG section as its notes. Nightly builds publish automatically from every push to `main`.
+
 ## Reporting Issues
 
 Found a bug or have a feature idea? [Open an issue](https://github.com/ggagosh/openmango/issues/new/choose) using one of the templates.

--- a/Justfile
+++ b/Justfile
@@ -15,7 +15,7 @@ lint:
     cargo clippy --all-targets -- -D warnings
 
 lint-release:
-    cargo clippy --release --all-targets -- -D warnings
+    cargo clippy --release -- -D warnings
 
 fmt:
     cargo fmt

--- a/Justfile
+++ b/Justfile
@@ -15,7 +15,7 @@ lint:
     cargo clippy --all-targets -- -D warnings
 
 lint-release:
-    cargo clippy --release --features mimalloc -- -D warnings
+    cargo clippy --release --all-targets -- -D warnings
 
 fmt:
     cargo fmt
@@ -27,17 +27,17 @@ check:
     cargo check
 
 check-release:
-    cargo check --release --features mimalloc
+    cargo check --release
 
 # Build
 build:
     cargo build
 
 release:
-    cargo build --release --features mimalloc
+    cargo build --release
 
 bundle:
-    cargo bundle --release --features mimalloc
+    cargo bundle --release
 
 # Compile the macOS app icon (requires Xcode 26 or newer)
 app-icon:
@@ -64,7 +64,7 @@ clean:
     cargo clean
 
 # CI checks (matches GitHub Actions quality job; integration-tests still require Docker)
-ci: fmt-check check-release lint-release check-sidecar unit-test
+ci: fmt-check lint-release check-sidecar unit-test
 
 # macOS additionally validates the platform-specific app icon.
 ci-macos: ci app-icon
@@ -75,6 +75,14 @@ bootstrap-linux:
 
 package-linux:
     bash ./scripts/release_linux.sh
+
+# Cut a release: bump version, rotate CHANGELOG, open the release PR
+prepare-release VERSION:
+    bash ./scripts/prepare_release.sh {{VERSION}}
+
+# After the release PR merges: tag main and push the tag (starts the Release workflow)
+tag-release VERSION:
+    bash ./scripts/prepare_release.sh {{VERSION}} --tag
 
 # All checks before commit
 precommit: ci test

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Cut a release in two steps:
+#   scripts/prepare_release.sh 0.2.2        bump the version, rotate CHANGELOG, open the release PR
+#   scripts/prepare_release.sh 0.2.2 --tag  after that PR merges: tag main and push the tag
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+version="${1:?Usage: $0 <version> [--tag]}"
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Version must be MAJOR.MINOR.PATCH" >&2; exit 1; }
+[[ -z "$(git status --porcelain)" ]] || { echo "Working tree must be clean." >&2; exit 1; }
+git fetch -q origin main
+if git ls-remote --exit-code --tags origin "v$version" >/dev/null; then
+    echo "Tag v$version already exists." >&2; exit 1
+fi
+changelog_section() {
+    awk -v v="$1" '/^## \[/ { p = ($0 ~ "^## \\[" v "\\]") } p && !/^## \[/' CHANGELOG.md
+}
+
+if [[ "${2:-}" == --tag ]]; then
+    [[ "$(git branch --show-current)" == main ]] || { echo "Tag from main." >&2; exit 1; }
+    [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || { echo "main differs from origin/main; pull first." >&2; exit 1; }
+    grep -q "^version = \"$version\"" Cargo.toml || { echo "Cargo.toml is not at $version; merge the release PR first." >&2; exit 1; }
+    [[ -n "$(changelog_section "$version")" ]] || { echo "CHANGELOG.md has no [$version] section." >&2; exit 1; }
+    git tag -a "v$version" -m "OpenMango $version"
+    git push origin "v$version"
+    echo "Pushed v$version. The Release workflow publishes it: https://github.com/ggagosh/openmango/actions/workflows/release.yml"
+    exit 0
+fi
+
+grep -q '^## \[Unreleased\]' CHANGELOG.md || { echo "CHANGELOG.md has no [Unreleased] section." >&2; exit 1; }
+git checkout -q -b "release/$version" origin/main
+perl -0pi -e 's/^version = "[^"]*"/version = "'"$version"'"/m' Cargo.toml
+perl -pi -e 's/^## \[Unreleased\]$/## [Unreleased]\n\n## ['"$version"'] - '"$(date +%F)"'/' CHANGELOG.md
+cargo update --workspace
+git add Cargo.toml Cargo.lock CHANGELOG.md
+git commit -q -m "release $version"
+git push -q -u origin "release/$version"
+# shellcheck disable=SC2016  # backticks are literal markdown
+gh pr create --title "release $version" \
+    --body "$(printf '%s\n\nAfter merging: `just tag-release %s`\n' "$(changelog_section "$version")" "$version")"

--- a/scripts/release_macos.sh
+++ b/scripts/release_macos.sh
@@ -141,7 +141,7 @@ if [[ -n "${APPLE_API_KEY_ID:-}" && -n "${APPLE_API_ISSUER_ID:-}" ]]; then
         --key "$NOTARY_KEY_PATH" \
         --key-id "$APPLE_API_KEY_ID" \
         --issuer "$APPLE_API_ISSUER_ID" \
-        --wait
+        --wait --timeout 30m
     echo "Stapling notarization ticket..."
     xcrun stapler staple "$APP_DIR"
     # Re-create zip with stapled app


### PR DESCRIPTION
## Purpose

Faster CI, a safer release path, and current actions. Follow-up to the Linux support PR (#18), where the 43-minute cold run exposed most of this.

## CI

- Drop `CARGO_BUILD_JOBS: 2` from both Linux workflows — leftover from the 3 GB OrbStack VM; hosted runners have 4 vCPU.
- `cache-on-failure: true` everywhere — a failed cold run no longer guarantees a second cold run.
- `cargo test --no-run --tests` before the integration loop links all 17 suites in parallel.
- `cargo clippy` replaces the redundant `cargo check` step in `quality` (clippy is a superset).
- `--locked` on every cargo invocation.
- `timeout-minutes` on every job.

Tried and reverted in the second commit: running the Linux unit tests in `--release` so they share a build with packaging. `McpBridge::fixed_with_clients*` (`src/mcp/bridge.rs:86`) are integration-test seams gated on `cfg(debug_assertions)`, so any release-profile compile of the test targets fails. Linux keeps debug tests; the job still drops from ~43 to ~26 min cold and stays fast warm.

## Release

- `macos-release.yml` — macOS build/sign/notarize extracted to a reusable workflow, mirroring the existing `linux-release.yml`. Was ~60 lines duplicated verbatim across `nightly.yml` and `release.yml`.
- `release.yml` now builds → artifacts → **one** `publish` job, same shape as nightly. Previously three jobs called `action-gh-release` on the same tag concurrently, and `releases/latest` (which the in-app updater polls) was visible with partial assets for ~7 minutes.
- Release notes come from the matching `CHANGELOG.md` section (`generate_release_notes` appended as a fallback). v0.2.1 shipped with an empty body.
- `verify` job: the tag must match `Cargo.toml` and have a CHANGELOG section. A mismatch would ship assets named for the old version and leave the updater offering the "update" forever.
- Nightly now deletes its tag (`--cleanup-tag`); it had been stuck at `7204785` since January while the release body said otherwise.
- `notarytool --wait --timeout 30m` — Apple's service occasionally stalls.
- `scripts/prepare_release.sh` + `just prepare-release X` / `just tag-release X`. Documented in CONTRIBUTING.

## Housekeeping

- All actions bumped to current majors (clears the Node 20 deprecation warnings) and pinned to SHAs with version comments.
- `.github/dependabot.yml`: weekly `github-actions`; weekly `cargo` in two groups (GPUI alone, everything else together) since every lockfile change is a cold build.
- `permissions: contents: write` scoped to the publish jobs only.
- Pre-commit hook is now `cargo fmt --check` only; it was `just ci` — two full compiles per commit.
- `--features mimalloc` removed where it appeared; it's the default feature.

## Verification

- `actionlint` clean on all five workflows.
- `shellcheck` clean on `prepare_release.sh`; bump and CHANGELOG rotation exercised on copies.
- CHANGELOG extraction tested against the real `[0.2.0]` section.
- CI on this PR exercises the new `ci.yml`. Nightly on merge exercises `macos-release.yml`, `linux-release.yml`, and the new publish job.