### PR TITLE
Group only minor and patch cargo bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    # Every Cargo.lock change is a cold CI build, so batch bumps into two PRs:
-    # GPUI on its own (0.x minors break the build), everything else together.
+    # Every Cargo.lock change is a cold CI build, so batch the safe bumps.
+    # GPUI gets its own PR (0.x minors break the build). Semver-major bumps of
+    # anything else fall outside both groups and arrive as individual PRs.
     groups:
       gpui:
         patterns: ["gpui*"]
       cargo:
         patterns: ["*"]
         exclude-patterns: ["gpui*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
The first cargo-group PR (#21) bundled 34 updates including nine semver-major bumps (`rig-core` 0.31→0.42 renames its crate; `dirs`, `aes-gcm`, `argon2`, `base64`, `sha2`, `rusqlite`, `tower-http`, `rust_xlsxwriter`), so it could never go green and hid the safe patch bumps behind them.

Restrict the `cargo` group to `minor` + `patch`. Majors now arrive as individual PRs that can be tackled or closed one at a time. The `gpui` group is unchanged.